### PR TITLE
Localize mandarin example

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.6.5'
 
 gem 'aws-sdk-rails'
-gem 'aws-partitions'
 gem 'caracal'
 gem 'carrierwave'
 gem 'deep_cloneable'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.6.5'
 
 gem 'aws-sdk-rails'
+gem 'aws-partitions'
 gem 'caracal'
 gem 'carrierwave'
 gem 'deep_cloneable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     aws-partitions (1.235.0)
     aws-sdk-core (3.75.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.228.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
     aws-sdk-rails (3.0.5)
@@ -327,7 +328,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-partitions
   aws-sdk-rails
   byebug
   capybara

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,10 +59,9 @@ GEM
     aes_key_wrap (1.0.1)
     arel (9.0.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.234.0)
+    aws-partitions (1.235.0)
     aws-sdk-core (3.75.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.228.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
     aws-sdk-rails (3.0.5)
@@ -328,6 +327,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-partitions
   aws-sdk-rails
   byebug
   capybara

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,12 @@
 class ApplicationController < ActionController::Base
+  
+  around_action :switch_locale
 
+  def switch_locale(&action)
+    locale = params[:locale] || I18n.default_locale
+    I18n.with_locale(locale, &action)
+  end
+  
   def after_sign_in_path_for(resource)
     admin_root_path
   end

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -1,18 +1,17 @@
 <h1>
-  Welcome to Touchpoints
+  <%= t('site.header',touchpoints: (t 'touchpoints')) %>
 </h1>
 <p>
-  A <strong>Touchpoint</strong>
-  is the interaction point between a Customer and Service Provider.
+  <%= t('site.definition_html',touchpoint: (t 'touchpoint')) %>
 </p>
 <p>
-  Touchpoints exists to help Federal Agencies:
+  <%= t('site.list_header',touchpoints:(t 'touchpoints')) %>
 </p>
 <ul class="usa-list">
-  <li>Administer the A-11 Form</li>
-  <li>Streamline CX CAP Goal reporting</li>
-  <li>Solicit open-ended Feedback</li>
-  <li>Recruit users to talk to during product and service development</li>
+  <li><%= t 'site.list_item_1' %></li>
+  <li><%= t 'site.list_item_2' %></li>
+  <li><%= t 'site.list_item_3' %></li>
+  <li><%= t 'site.list_item_4' %></li>    
 </ul>
 <% unless current_user %>
 <br>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,54 @@ module Touchpoints
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # When I18n.config.enforce_available_locales is true we'll raise an I18n::InvalidLocale
+    # exception if the passed locale is unavailable. See http://stackoverflow.com/a/20381730
+    config.i18n.enforce_available_locales = false
+
+    # The default locale is :en-US and all translations from config/locales/*.rb,yml are auto loaded.
+    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+    config.i18n.default_locale = :'en-US'
+
+    # Set list here instead of relying on backend reading translation files in case any file is incomplete
+    # and we don't want to include it.
+    config.i18n.available_locales = ['en-US', 'zh-CN']
+
+    # Configure where to look for yml-based i18n files
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+
+    # Fallback language if translation missing in selected culture
+    config.i18n.fallbacks = [:'en-US']
+
+    # Database file for country lookup by IP. From https://github.com/yhirose/maxminddb
+    #config.locale_by_country_db = 'lib/GeoLite2-Country.mmdb'
+
+    # Default locales for countries for use with IP look up
+    # To add additional refer to https://en.wikipedia.org/wiki/ISO_3166-1 for codes
+    config.locale_by_country = {
+       # Base for supported cultures (note fr-CA missing because CA defaults to en-CA)
+       'DE' => 'de-DE', # Germany
+       'AU' => 'en-AU', # Australia
+       'CA' => 'en-CA', # Canada
+       'GB' => 'en-GB', # United Kingdon
+       'IN' => 'en-IN', # India
+       'SG' => 'en-SG', # Singapore
+       'ID' => 'en-SG', # Indonesia
+       'MY' => 'en-SG', # Malaysia
+       'US' => 'en-US', # US
+       'CO' => 'es-CO', # Colombia
+       'MX' => 'es-MX', # Mexico
+       'FR' => 'fr-FR', # France
+       'JP' => 'ja-JP', # Japan
+       'KR' => 'ko-KR', # Korea
+       'BR' => 'pt-BR', # Brazil
+       'CN' => 'zh-CN', # China
+       # Additional countries
+       'IE' => 'en-GB' # Ireland
+    }
+
+    # Configure the default encoding used in templates for Ruby 1.9.
+    config.encoding = 'utf-8'
+    
     config.generators do |g|
       g.test_framework :rspec
     end

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -29,5 +29,14 @@
 # To learn more, please read the Rails Internationalization guide
 # available at http://guides.rubyonrails.org/i18n.html.
 
-en:
-  hello: "Hello world"
+en-US:
+  touchpoint: "Touchpoint"
+  touchpoints: "Touchpoints"
+  site:
+    header: "Welcome to %{touchpoints}"
+    definition_html: "A <strong>%{touchpoint}</strong> is the interaction point between a Customer and Service Provider."
+    list_header: "%{touchpoints} exists to help Federal Agencies:"
+    list_item_1: "Administer the A-11 Form"
+    list_item_2: "Streamline CX CAP Goal reporting"
+    list_item_3: "Solicit open-ended Feedback"
+    list_item_4: "Recruit users to talk to during product and service development"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,0 +1,190 @@
+zh-CN:
+  touchpoint: "接触点"
+  touchpoints: "接触点"
+  site:
+    header: "欢迎来到%{touchpoints}"
+    definition_html: "一种<strong>%{touchpoint}</strong>是客户和服务提供商之间的交互点。"
+    list_header: "%{touchpoints}存在以帮助联邦机构："
+    list_item_1: "管理A-11表格"
+    list_item_2: "简化CX CAP目标报告"
+    list_item_3: "征集开放式反馈"
+    list_item_4: "招募用户在产品和服务开发过程中进行交谈"    
+  activerecord:
+    errors:
+      messages:
+        record_invalid: '验证失败: %{errors}'
+        restrict_dependent_destroy:
+          has_one: 由于 %{record} 需要此记录，所以无法移除记录
+          has_many: 由于 %{record} 需要此记录，所以无法移除记录
+  date:
+    abbr_day_names:
+    - 周日
+    - 周一
+    - 周二
+    - 周三
+    - 周四
+    - 周五
+    - 周六
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 星期日
+    - 星期一
+    - 星期二
+    - 星期三
+    - 星期四
+    - 星期五
+    - 星期六
+    formats:
+      default: "%Y-%m-%d"
+      long: "%Y年%m月%d日"
+      short: "%m月%d日"
+    month_names:
+    - 
+    - 一月
+    - 二月
+    - 三月
+    - 四月
+    - 五月
+    - 六月
+    - 七月
+    - 八月
+    - 九月
+    - 十月
+    - 十一月
+    - 十二月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 大约 %{count} 小时
+      about_x_months: 大约 %{count} 个月
+      about_x_years: 大约 %{count} 年
+      almost_x_years: 接近 %{count} 年
+      half_a_minute: 半分钟
+      less_than_x_seconds: 不到 %{count} 秒
+      less_than_x_minutes: 不到 %{count} 分钟
+      over_x_years: "%{count} 年多"
+      x_seconds: "%{count} 秒"
+      x_minutes: "%{count} 分钟"
+      x_days: "%{count} 天"
+      x_months: "%{count} 个月"
+      x_years: "%{count} 年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 时
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: 必须是可被接受的
+      blank: 不能为空字符
+      confirmation: 与 %{attribute} 不匹配
+      empty: 不能留空
+      equal_to: 必须等于 %{count}
+      even: 必须为双数
+      exclusion: 是保留关键字
+      greater_than: 必须大于 %{count}
+      greater_than_or_equal_to: 必须大于或等于 %{count}
+      inclusion: 不包含于列表中
+      invalid: 是无效的
+      less_than: 必须小于 %{count}
+      less_than_or_equal_to: 必须小于或等于 %{count}
+      model_invalid: '验证失败: %{errors}'
+      not_a_number: 不是数字
+      not_an_integer: 必须是整数
+      odd: 必须为单数
+      other_than: 长度非法（不可为 %{count} 个字符
+      present: 必须是空白
+      required: 必须存在
+      taken: 已经被使用
+      too_long: 过长（最长为 %{count} 个字符）
+      too_short: 过短（最短为 %{count} 个字符）
+      wrong_length: 长度非法（必须为 %{count} 个字符）
+    template:
+      body: 如下字段出现错误：
+      header: 有 %{count} 个错误发生导致“%{model}”无法被保存。
+  helpers:
+    select:
+      prompt: 请选择
+    submit:
+      create: 新增%{model}
+      submit: 储存%{model}
+      update: 更新%{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CN¥
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十亿
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte: 字节
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " 以及 "
+      two_words_connector: " 和 "
+      words_connector: "、"
+  time:
+    am: 上午
+    formats:
+      default: "%Y年%m月%d日 %A %H:%M:%S %Z"
+      long: "%Y年%m月%d日 %H:%M"
+      short: "%m月%d日 %H:%M"
+    pm: 下午

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - '.:/app'
+      - '.:/touchpoints'
     env_file:
       - '.env'
 


### PR DESCRIPTION
I've created the groundwork for mandarin localization and have translated the site/index page as an example.

The example includes variable substitution in translations, html_safe translations and all the default date/time/active record/etc mandarin translations.

The locale is currently simply passed on the url, see below example for the site index page in mandarin:
http://localhost:3000/?locale=zh-CN

We can also use the geographic location of the user, the HTTP_ACCEPT_LANG header, user settings or url parameters as hints to set a local.   

I also tweaked the docker-compose file to mount the local project directory within the docker image.  Now any change you make to your project on the local filesystem will be immediately available on browser refresh ( without having to do the docker down/up sequence ).

I'm traveling to Greensboro today for my finger printing but let's chat more about how dynamic translation might work and what the specific requirements for translation are moving forward.