### PR TITLE
Touchpoints-445es

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,11 @@ AWS_REGION=
 # For Docker
 COMPOSE_PROJECT_NAME=touchpoints
 
+# GitHub email address for Developer.
+# Creates a user when seeding the database.
+# Assumes GitHub OAuth is configured to login.
+DEVELOPER_EMAIL_ADDRESS=your-github-email@domain.com
+
 # For GitHub OAuth
 GITHUB_CLIENT_ID=
 GITHUB_SECRET=

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -10,7 +10,7 @@ class Form < ApplicationRecord
   after_create :create_first_form_section
 
   def create_first_form_section
-    self.form_sections.create(title: (I18n.t 'page_1'), position: 1)
+    self.form_sections.create(title: (I18n.t 'form.page_1'), position: 1)
   end
 
   def success_text

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Touchpoints
 
     # Set list here instead of relying on backend reading translation files in case any file is incomplete
     # and we don't want to include it.
-    config.i18n.available_locales = ['en-US', 'zh-CN']
+    config.i18n.available_locales = ['en-US', 'zh-CN', 'es']
 
     # Configure where to look for yml-based i18n files
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -50,6 +50,8 @@ en-US:
     next: "Next →"
     back: "← Back"
     select_one: "Select one"
+    page_1: "Page 1"
+    page_2: "Page 2"
   header:
     official: "An official website of the United States government"
     heres_how_you_know: "Here’s how you know"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,256 @@
+es:
+  touchpoint: "Punto de contacto"
+  touchpoints: "Puntos de contacto"
+  beta: "beta"
+  report_an_issue: "Reportar un problema"
+  contact: "contacto"
+  please: "Por favor"
+  or: "o"
+  success: "Éxito"
+  error: "Error"
+  the_feedback_and_analytics_team: " el equipo de retroalimentación y análisis"
+  form:   
+    submit: "Enviar"
+    submit_thankyou: "Gracias. Su comentario ha sido recibido."
+    help_improve: "Ayuda a mejorar este sitio"
+    answer_more_questions: "¿Le gustaría tomar dos minutos más para responder más preguntas y ayudarnos a mejorar nuestros servicios?"
+    yes_keep_going: "Sí, sigue adelante →"
+    no_submit: "No, solo envíe estas respuestas"
+    next: "Siguiente →"
+    back: "← Volver"
+    select_one: "Seleccione uno"
+    page_1: "Página 1"
+    page_2: "Página 2"    
+  header:
+    official: "Un sitio web oficial del gobierno de los Estados Unidos"
+    heres_how_you_know: "Así es como sabes"
+    dot_gov_means_official: "El .gov significa que es oficial."
+    dot_gov_websites: "Los sitios web del gobierno federal a menudo terminan en .gov o .mil. Antes de compartir información confidencial, asegúrese de estar en un sitio del gobierno federal."
+    this_site_is_secure: "Este sitio es seguro."
+    https_notes_html: "El <strong>https://</strong> asegura que se está conectando al sitio web oficial y que toda la información que proporciona está encriptada y transmitida de forma segura."
+    disclaimer_1: "Este sitio web está actualmente en"  
+  site:
+    header: "Bienvenido a %{touchpoints}"
+    definition_html: "Un <strong>%{touchpoint}</strong> es el punto de interacción entre un Cliente y un Proveedor de servicios."
+    list_header: "%{touchpoints} existe para ayudar a las agencias federales:"
+    list_item_1: "Administrar el formulario A-11"
+    list_item_2: "Agilice los informes de objetivos de CX CAP"
+    list_item_3: "Solicitar comentarios abiertos"
+    list_item_4: "Reclutar usuarios para hablar durante el desarrollo de productos y servicios"  
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'La validación falló: %{errors}'
+        restrict_dependent_destroy:
+          has_one: No se puede eliminar el registro porque existe un %{record} dependiente
+          has_many: No se puede eliminar el registro porque existen %{record} dependientes
+  date:
+    abbr_day_names:
+    - dom
+    - lun
+    - mar
+    - mié
+    - jue
+    - vie
+    - sáb
+    abbr_month_names:
+    - 
+    - ene
+    - feb
+    - mar
+    - abr
+    - may
+    - jun
+    - jul
+    - ago
+    - sep
+    - oct
+    - nov
+    - dic
+    day_names:
+    - domingo
+    - lunes
+    - martes
+    - miércoles
+    - jueves
+    - viernes
+    - sábado
+    formats:
+      default: "%-d/%-m/%Y"
+      long: "%-d de %B de %Y"
+      short: "%-d de %b"
+    month_names:
+    - 
+    - enero
+    - febrero
+    - marzo
+    - abril
+    - mayo
+    - junio
+    - julio
+    - agosto
+    - septiembre
+    - octubre
+    - noviembre
+    - diciembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: alrededor de 1 hora
+        other: alrededor de %{count} horas
+      about_x_months:
+        one: alrededor de 1 mes
+        other: alrededor de %{count} meses
+      about_x_years:
+        one: alrededor de 1 año
+        other: alrededor de %{count} años
+      almost_x_years:
+        one: casi 1 año
+        other: casi %{count} años
+      half_a_minute: medio minuto
+      less_than_x_seconds:
+        one: menos de 1 segundo
+        other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
+      over_x_years:
+        one: más de 1 año
+        other: más de %{count} años
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
+      x_months:
+        one: 1 mes
+        other: "%{count} meses"
+      x_years:
+        one: 1 año
+        other: "%{count} años"
+    prompts:
+      second: Segundo
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
+      year: Año
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: debe ser aceptado
+      blank: no puede estar en blanco
+      confirmation: no coincide
+      empty: no puede estar vacío
+      equal_to: debe ser igual a %{count}
+      even: debe ser par
+      exclusion: está reservado
+      greater_than: debe ser mayor que %{count}
+      greater_than_or_equal_to: debe ser mayor que o igual a %{count}
+      inclusion: no está incluido en la lista
+      invalid: no es válido
+      less_than: debe ser menor que %{count}
+      less_than_or_equal_to: debe ser menor que o igual a %{count}
+      model_invalid: 'La validación falló: %{errors}'
+      not_a_number: no es un número
+      not_an_integer: debe ser un entero
+      odd: debe ser impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
+      required: debe existir
+      taken: ya está en uso
+      too_long:
+        one: es demasiado largo (1 carácter máximo)
+        other: es demasiado largo (%{count} caracteres máximo)
+      too_short:
+        one: es demasiado corto (1 carácter mínimo)
+        other: es demasiado corto (%{count} caracteres mínimo)
+      wrong_length:
+        one: no tiene la longitud correcta (1 carácter exactos)
+        other: no tiene la longitud correcta (%{count} caracteres exactos)
+    template:
+      body: 'Se encontraron problemas con los siguientes campos:'
+      header:
+        one: No se pudo guardar este/a %{model} porque se encontró 1 error
+        other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
+  helpers:
+    select:
+      prompt: Por favor seleccione
+    submit:
+      create: Crear %{model}
+      submit: Guardar %{model}
+      update: Actualizar %{model}
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%A, %-d de %B de %Y %H:%M:%S %z"
+      long: "%-d de %B de %Y %H:%M"
+      short: "%-d de %b %H:%M"
+    pm: pm

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -39,6 +39,8 @@ zh-CN:
     next: "下一个→"    
     back: "←返回"   
     select_one: "选择一个" 
+    page_1: "第一頁"
+    page_2: "第二頁"    
   header:
     official: "美国政府的官方网站"
     heres_how_you_know: "这就是你所知道的"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,23 +17,26 @@ return false if Rails.env.production?
 require_relative 'seeds/forms/a11'
 require_relative 'seeds/forms/kitchen_sink'
 
-frikshun = Organization.create!({
-  name: "FrikShun",
-  domain: "frikshun.com",
-  url: "https://www.frikshun.com",
-  abbreviation: "FS"
-})
-puts "Created Default Organization: #{frikshun.name}"
-
 # Create Seeds
-admin_user = User.new({
-  organization: frikshun,
-  email: "akt@frikshun.com",
-  password: "password",
-  admin: true
-})
-admin_user.save!
-puts "Created Admin User: #{admin_user.email}"
+
+if ENV["DEVELOPER_EMAIL_ADDRESS"].present?
+  developer_organization = Organization.create!({
+    name: "Development Org",
+    domain: "lvh.me",
+    url: "https://lvh.me",
+    abbreviation: "DEV"
+  })
+  puts "Created Default Organization: #{developer_organization.name}"
+
+  developer_user = User.new({
+    organization: developer_organization,
+    email: ENV["DEVELOPER_EMAIL_ADDRESS"],
+    password: "password",
+    admin: true
+  })
+  developer_user.save!
+  puts "Created Developer User: #{developer_user.email}"
+end
 
 example_gov = Organization.create!({
   name: "Example.gov",
@@ -43,7 +46,6 @@ example_gov = Organization.create!({
 })
 puts "Created Default Organization: #{example_gov.name}"
 
-# Create Seeds
 admin_user = User.new({
   organization: example_gov,
   email: "admin@example.gov",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,24 @@ return false if Rails.env.production?
 require_relative 'seeds/forms/a11'
 require_relative 'seeds/forms/kitchen_sink'
 
+frikshun = Organization.create!({
+  name: "FrikShun",
+  domain: "frikshun.com",
+  url: "https://www.frikshun.com",
+  abbreviation: "FS"
+})
+puts "Created Default Organization: #{frikshun.name}"
+
+# Create Seeds
+admin_user = User.new({
+  organization: frikshun,
+  email: "akt@frikshun.com",
+  password: "password",
+  admin: true
+})
+admin_user.save!
+puts "Created Admin User: #{admin_user.email}"
+
 example_gov = Organization.create!({
   name: "Example.gov",
   domain: "example.gov",


### PR DESCRIPTION
Add support for Spanish with form translations.   Tweak seed data for local developer.

To view Spanish translations append locale=es as a url argument.

We should discuss how locale will actually be fed into international Touchpoints.  Could possibly be a hidden form variable generated based on a language selector within the Touchpoint admin.