### PR TITLE
TP-708 client side character limit enforcement

### DIFF
--- a/app/assets/stylesheets/widget.scss
+++ b/app/assets/stylesheets/widget.scss
@@ -71,3 +71,8 @@
 .hide {
   display: none;
 }
+
+.counter-msg {
+  font-size: 0.8em;
+  color: #BBBBBB;
+}

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,11 +3,18 @@ class Question < ApplicationRecord
   belongs_to :form_section, required: true
   has_many :question_options, dependent: :destroy
 
+  MAX_CHARACTERS = 100000
+
   validates :answer_field, presence: true
-  validates :character_limit, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100000, allow_nil: true }
+  validates :character_limit, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: MAX_CHARACTERS, allow_nil: true }
 
   after_save do | question |
     TouchpointCache.invalidate(question.form.touchpoint.id) if question.form.touchpoint.present?
+  end
+
+  def max_length
+  	return character_limit if character_limit.present?
+  	MAX_CHARACTERS
   end
 
   default_scope { order(position: :asc) }

--- a/app/views/components/forms/question_types/_text_area.html.erb
+++ b/app/views/components/forms/question_types/_text_area.html.erb
@@ -3,5 +3,6 @@
     <%= t question_number.to_s %>.
     <%= question.text %>
   </label>
-  <%= text_area_tag question.answer_field.to_sym, nil, class: "usa-textarea", required: question.is_required  %>
+  <%= text_area_tag question.answer_field.to_sym, nil, class: "usa-textarea", required: question.is_required, maxlength: question.max_length, onkeyup: "fba.textCounter(this,#{question.max_length});" %>
+  <em class="counter-msg"><%= t 'form.chars_remaining' %> <span class="counter"><%= question.max_length %></span></em>
 </div>

--- a/app/views/components/forms/question_types/_text_field.html.erb
+++ b/app/views/components/forms/question_types/_text_field.html.erb
@@ -3,5 +3,6 @@
     <%= t question_number.to_s %>.
     <%= question.text %>
   </label>
-  <%= text_field_tag question.answer_field.to_sym, nil, class: "usa-input", required: question.is_required  %>
+  <%= text_field_tag question.answer_field.to_sym, nil, class: "usa-input", required: question.is_required,  maxlength: question.max_length, onkeyup: "N.fba.textCounter(this,#{question.max_length});" %>
+  <em class="counter-msg"><%= t 'form.chars_remaining' %> <span class="counter"><%= question.max_length %></span></em>
 </div>

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -187,6 +187,17 @@ N.fba = {
 			elem = form.querySelector('#input-error');
 			if (elem != null) elem.parentNode.removeChild(elem);
 		},
+		textCounter: function(field,maxlimit)
+			{
+			 var countfield = field.parentNode.querySelector(".counter");
+			 if ( field.value.length > maxlimit ) {
+			  field.value = field.value.substring( 0, maxlimit );
+			  countfield.innerText = '0';
+			  return false;
+			 } else {
+			  countfield.innerText = "" + (maxlimit - field.value.length);
+			 }
+		},
 		loadButton: function()
 		{
 			this.buttonEl = document.createElement('a');

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -53,6 +53,7 @@ en-US:
     page_1: "Page 1"
     page_2: "Page 2"
     field_is_required: "You must respond to question: "
+    chars_remaining: "Chars remaining: "
   header:
     official: "An official website of the United States government"
     heres_how_you_know: "Here’s how you know"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -22,6 +22,7 @@ es:
     page_1: "Página 1"
     page_2: "Página 2"
     field_is_required: "Debes responder a la pregunta: "
+    chars_remaining: "Caracteres restantes: "
   header:
     official: "Un sitio web oficial del gobierno de los Estados Unidos"
     heres_how_you_know: "Así es como sabes"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -42,6 +42,7 @@ zh-CN:
     page_1: "第一頁"
     page_2: "第二頁"
     field_is_required: 您必須回答以下問題
+    chars_remaining: "剩餘字符: "
   header:
     official: "美国政府的官方网站"
     heres_how_you_know: "这就是你所知道的"

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -65,18 +65,19 @@ feature "Touchpoints", js: true do
 
     describe "character_limit" do
       before do
+        question = touchpoint.form.questions.first
+        question.update_attribute(:character_limit, 150)
         visit touchpoint_path(touchpoint)
         expect(page.current_path).to eq("/touchpoints/#{touchpoint.id}/submit")
         expect(page).to have_content("OMB Approval ##{touchpoint.omb_approval_number}")
         expect(page).to have_content("Exp. Date #{touchpoint.expiration_date.strftime("%m/%d/%Y")}")
-        fill_in("answer_01", with: "T" * 100 * ((touchpoint.form.character_limit.to_i / 100) + 10))
+        fill_in("answer_01", with: "T" * 145)
         click_button "Submit"
       end
 
-      describe "display flash error on submission" do
-        xit "renders body character_limit flash message" do
-          expect(page).to have_content("body is limited to #{touchpoint.form.character_limit} characters")
-          expect(page.current_path).to eq("/touchpoints/#{touchpoint.id}/submit")
+      describe "character counter" do
+        it "updates character count" do
+          expect(page).to have_content("Chars remaining: 5")
         end
       end
     end


### PR DESCRIPTION
TP-708 client side character limit enforcement

Added helper method to compute question max length to be character limit or default if character limit not set.

Added maxlength attributes on textfield and textarea responses to ensure invalid text length can not be entered.

Added counter label to let users know what the max length is and how many characters are left available.

Added translations for remaining characters msg.