### PR TITLE
TP-788 Hide character counters if no character limit has been set by …

### DIFF
--- a/app/views/components/forms/question_types/_text_area.html.erb
+++ b/app/views/components/forms/question_types/_text_area.html.erb
@@ -4,5 +4,5 @@
     <%= question.text %>
   </label>
   <%= text_area_tag question.answer_field.to_sym, nil, class: "usa-textarea", required: question.is_required, maxlength: question.max_length, onkeyup: "fba.textCounter(this,#{question.max_length});" %>
-  <em class="counter-msg"><%= t 'form.chars_remaining' %> <span class="counter"><%= question.max_length %></span></em>
+  <em class="counter-msg" style="display:<%= (question.character_limit.present? ? 'block' : 'none') %>" ><%= t 'form.chars_remaining' %> <span class="counter"><%= question.max_length %></span></em>
 </div>

--- a/app/views/components/forms/question_types/_text_field.html.erb
+++ b/app/views/components/forms/question_types/_text_field.html.erb
@@ -4,5 +4,5 @@
     <%= question.text %>
   </label>
   <%= text_field_tag question.answer_field.to_sym, nil, class: "usa-input", required: question.is_required,  maxlength: question.max_length, onkeyup: "N.fba.textCounter(this,#{question.max_length});" %>
-  <em class="counter-msg"><%= t 'form.chars_remaining' %> <span class="counter"><%= question.max_length %></span></em>
+  <em class="counter-msg" style="display:<%= (question.character_limit.present? ? 'block' : 'none') %>" ><%= t 'form.chars_remaining' %> <span class="counter"><%= question.max_length %></span></em>
 </div>


### PR DESCRIPTION
TP-788 Hide character counters if no character limit has been set by admin.

This simply hides the counter fields if the admin as not set a limit.  The client side javascript to enforce limits is still in place as is the max limits set in HTML on the text fields.