### PR TITLE
Updated all actions of question to stay on edit form

### DIFF
--- a/app/controllers/admin/question_options_controller.rb
+++ b/app/controllers/admin/question_options_controller.rb
@@ -15,6 +15,7 @@ class Admin::QuestionOptionsController < AdminController
   end
 
   def edit
+    render layout: false
   end
 
   def create

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -15,6 +15,7 @@ class Admin::QuestionsController < AdminController
   end
 
   def edit
+    render layout: false
   end
 
   def create
@@ -22,7 +23,7 @@ class Admin::QuestionsController < AdminController
 
     respond_to do |format|
       if @question.save
-        format.html { redirect_to admin_form_path(@form), notice: 'Question was successfully created.' }
+        format.html { redirect_to edit_admin_form_path(@form), notice: 'Question was successfully created.' }
         format.json { render :show, status: :created, location: @question }
       else
         format.html { render :new }
@@ -35,7 +36,9 @@ class Admin::QuestionsController < AdminController
     respond_to do |format|
       if @question.update(question_params)
         format.html { redirect_to edit_admin_form_path(@form), notice: 'Question was successfully updated.' }
-        format.json { render :show, status: :ok, location: @question }
+        format.json {
+          render :show, status: :ok, location: @question
+        }
       else
         format.html { render :edit }
         format.json { render json: @question.errors, status: :unprocessable_entity }

--- a/app/views/admin/question_options/new.html.erb
+++ b/app/views/admin/question_options/new.html.erb
@@ -9,4 +9,5 @@
   </p>
 
   <%= render 'form', form: @question.form, question: @question, question_option: @question_option %>
+  <%= link_to 'Cancel', edit_admin_form_path(@question.form) %>
 </div>

--- a/app/views/admin/questions/edit.html.erb
+++ b/app/views/admin/questions/edit.html.erb
@@ -1,5 +1,4 @@
 <h1>Editing Question</h1>
-
 <%= render 'form', question: @question, form: @form %>
 
-<%= link_to 'View Form', admin_form_path(@form) %>
+<%= link_to 'Cancel', edit_admin_form_path(@form) %>

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -1,6 +1,5 @@
 <div>
   <%= hidden_field_tag :fba_location_code, params[:location_code] %>
-
   <% multi_section_question_number = 0 %>
   <% form.form_sections.each do |section| %>
     <div class="form-section-div">
@@ -36,7 +35,7 @@
           <%= render 'components/forms/question_types/text_display', form: form, question: question, question_number: multi_section_question_number %>
         <% end %>
 
-        <%= link_to "Edit Question", edit_admin_form_question_path(@form, question), class: "usa-button" %>
+        <%= link_to "Edit Question", edit_admin_form_question_path(@form, question), class: "usa-button form-edit-question" %>
 
         <% if form_permissions?(form: @form) %>
         <%= link_to 'Delete Question', admin_form_question_path(@form, question), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary float-right" %>
@@ -96,4 +95,41 @@
         }
      });
   });
+
+  $('.form-edit-question').click(function(event) {
+     event.preventDefault();
+     var contentDiv =  $(this).closest('div.question');
+     $.ajax({
+        type: "GET",
+        url: $(this).attr("href"),
+        success: function (data) {
+          contentDiv.html(data);
+        }
+     });
+  });
+
+  $('.form-edit-question-option-checkbox').click(function(event) {
+    event.preventDefault();
+    var contentDiv =  $(this).closest('div.radio-button');
+    $.ajax({
+      type: "GET",
+      url: $(this).attr("href"),
+      success: function (data) {
+        contentDiv.html(data);
+      }
+    });
+ });
+
+ $('.form-edit-question-option-radio-button').click(function(event) {
+  event.preventDefault();
+  var contentDiv =  $(this).closest('div.usa-checkbox');
+  $.ajax({
+    type: "GET",
+    url: $(this).attr("href"),
+    success: function (data) {
+      contentDiv.html(data);
+    }
+  });
+});
+
 </script>

--- a/app/views/components/forms/edit/question_types/_checkbox.html.erb
+++ b/app/views/components/forms/edit/question_types/_checkbox.html.erb
@@ -19,7 +19,7 @@
     <%= check_box_tag("#{question.answer_field}_#{(index + 1).to_s}", index + 1, nil, { value: option.text , class: "usa-checkbox__input" }) %>
     <%= label_tag(nil, for: "#{question.answer_field}_#{(index + 1).to_s}", class: "usa-checkbox__label") do %>
       <%= option.text %>
-      <%= link_to "Edit", edit_admin_form_question_question_option_path(option.question.form, option.question, option) %>
+      <%= link_to "Edit", edit_admin_form_question_question_option_path(option.question.form, option.question, option), class: "form-edit-question-option-checkbox" %>
     <% end %>
   </div>
   <% end %>

--- a/app/views/components/forms/edit/question_types/_radio_buttons.html.erb
+++ b/app/views/components/forms/edit/question_types/_radio_buttons.html.erb
@@ -20,7 +20,7 @@
     <%= radio_button_tag(question.answer_field.to_sym, index + 1, nil, { value: option.value, class: "usa-radio__input", required: question.is_required  }) %>
     <%= label_tag nil, for: "#{question.answer_field.to_sym}_#{option.position}", class: "usa-radio__label" do %>
       <%= option.text %>
-      <%= link_to "Edit", edit_admin_form_question_question_option_path(option.question.form, option.question, option) %>
+      <%= link_to "Edit", edit_admin_form_question_question_option_path(option.question.form, option.question, option), class: "form-edit-question-option-radio-button" %>
     <% end %>
   </div>
   <% end %>

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -400,7 +400,8 @@ feature "Forms", js: true do
 
           it "can add a Text Field Question" do
             expect(page).to have_content("Question was successfully created.")
-            within ".form-preview .question" do
+            expect(page.current_path).to eq(edit_admin_form_path(form))
+            within ".form-builder .question" do
               expect(page).to have_content("New Test Question")
               expect(page).to have_css("input[type='text']")
             end
@@ -422,7 +423,8 @@ feature "Forms", js: true do
 
           it "can add a Text Area question" do
             expect(page).to have_content("Question was successfully created.")
-            within ".form-preview .question" do
+            expect(page.current_path).to eq(edit_admin_form_path(form))
+            within ".form-builder .question" do
               expect(page).to have_content("New Text Area")
               expect(page).to have_css("textarea")
             end
@@ -445,7 +447,8 @@ feature "Forms", js: true do
 
           it "can add a Text Field Question" do
             expect(page).to have_content("Question was successfully created.")
-            within ".form-preview .question" do
+            expect(page.current_path).to eq(edit_admin_form_path(form))
+            within ".form-builder .question" do
               expect(page).to have_content("New Test Question Radio Buttons")
               # Radio buttons won't be showing yet. Because they need to be added.
             end
@@ -492,7 +495,8 @@ feature "Forms", js: true do
 
             it "can add a dropdown Question" do
               expect(page).to have_content("Question was successfully created.")
-              within ".form-preview" do
+              expect(page.current_path).to eq(edit_admin_form_path(form))
+              within ".form-builder" do
                 expect(page).to have_content("New dropdown field")
                 # Radio buttons won't be showing yet. Because they need to be added.
               end
@@ -502,7 +506,7 @@ feature "Forms", js: true do
               before do
                 visit edit_admin_form_path(form)
                 click_on "Edit Question"
-                expect(page.current_path).to eq(edit_admin_form_question_path(form, form.questions.first))
+                expect(page.current_path).to eq(edit_admin_form_path(form))
                 expect(page).to have_content("Editing Question")
                 expect(find_field('question_text').value).to eq 'New dropdown field'
               end
@@ -559,7 +563,7 @@ feature "Forms", js: true do
 
           it "display text display element with html" do
             expect(page).to have_content("Question was successfully created.")
-            within ".form-preview .question" do
+            within ".form-builder .question" do
               expect(page).to have_content("Some custom")
               expect(page).to have_link("html")
             end


### PR DESCRIPTION
* Updated all edit sections to show inline without refresh
* Added cancel link to new question option inline view to have the ability to cancel operation