### PR TITLE
update form builder buttons

### DIFF
--- a/app/controllers/admin/form_sections_controller.rb
+++ b/app/controllers/admin/form_sections_controller.rb
@@ -38,9 +38,9 @@ class Admin::FormSectionsController < AdminController
   def destroy
     if @form.form_sections.count > 1
       @form_section.destroy
-      redirect_to edit_admin_form_url(@form), notice: 'Form section was successfully destroyed.'
+      redirect_to questions_admin_form_url(@form), notice: 'Form section was successfully destroyed.'
     else
-      redirect_to edit_admin_form_url(@form), alert: 'Cannot delete only remaining Form section'
+      redirect_to questions_admin_form_url(@form), alert: 'Cannot delete only remaining Form section'
     end
   end
 

--- a/app/views/admin/form_sections/_form.html.erb
+++ b/app/views/admin/form_sections/_form.html.erb
@@ -29,6 +29,6 @@
   </div>
 
   <p>
-    <%= html_form.submit class: "usa-button" %>
+    <%= html_form.submit (form_section.persisted? ? "Update Section" : "Create Section"), class: "usa-button" %>
   </p>
 <% end %>

--- a/app/views/admin/form_sections/edit.html.erb
+++ b/app/views/admin/form_sections/edit.html.erb
@@ -1,8 +1,3 @@
 <h1>Editing Form Section</h1>
 
 <%= render 'form', { form: @form, form_section: @form_section } %>
-
-<p>
-  <%= link_to 'Show', admin_form_form_section_path(@form, @form_section), class: "usa-button" %>
-  <%= link_to 'View All Form Sections', admin_form_form_sections_path(@form), class: "usa-button usa-button-gray"  %>
-</p>

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -4,11 +4,16 @@
   <% form.form_sections.each do |section| %>
     <div class="form-section-div">
       <div class="section pad well2">
-        <%= link_to 'Edit Form Section', edit_admin_form_form_section_path(form, section), class: "usa-button form-section-edit float-right" %>
-        <h3>
-          <%= section.title %>
-        </h3>
-        <br>
+        <div>
+          <%= link_to edit_admin_form_form_section_path(form, section), class: "usa-button form-section-edit float-right" do %>
+            <span class="fa fa-pencil-alt"></span>
+            Edit Section
+          <% end %>
+          <h3>
+            <%= section.title %>
+          </h3>
+          <div style="clear: both;"></div>
+        </div>
 
         <% section.questions.each_with_index do |question, index| %>
         <% multi_section_question_number += 1 %>
@@ -39,18 +44,24 @@
             <%= render 'components/forms/question_types/text_display', form: form, question: question, question_number: multi_section_question_number %>
           <% end %>
 
-          <%= link_to "Edit Question", edit_admin_form_question_path(@form, question), class: "usa-button form-edit-question" %>
+          <%= link_to edit_admin_form_question_path(@form, question), class: "usa-button form-edit-question" do %>
+            <span class="fa fa-pencil-alt"></span>
+            Edit Question
+           <% end %>
 
           <% if form_permissions?(form: @form) %>
             <%= link_to admin_form_question_path(@form, question), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary float-right" do %>
-              <i class="fas fa-trash"></i>
+              <span class="fas fa-trash"></span>
               Delete Question
             <% end %>
           <% end %>
         </div>
         <% end %>
         <% unless section.questions.present? || form.form_sections.count == 1  %>
-        <%= link_to 'Delete Form Section', admin_form_form_section_path(form, section), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary" %>
+        <%= link_to admin_form_form_section_path(form, section), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary" do %>
+          <span class="fas fa-trash"></span>
+          Delete Section
+        <% end %>
         <% end %>
       </div>
   </div>
@@ -59,10 +70,16 @@
 </div>
 <div class="new-question-div"></div>
 <p>
-  <%= link_to "Add Question", new_admin_form_question_path(form), class: "usa-button form-add-question" %>
+  <%= link_to new_admin_form_question_path(form), class: "usa-button form-add-question" do %>
+    <span class="fa fa-plus"></span>
+    Add Question
+  <% end %>
 </p>
 <p>
-  <%= link_to "Add Form Section", new_admin_form_form_section_path(form), class: "usa-button" %>
+  <%= link_to new_admin_form_form_section_path(form), class: "usa-button" do %>
+    <span class="fa fa-plus"></span>
+    Add Section
+  <% end %>
 </p>
 
 <script>

--- a/app/views/components/forms/edit/question_types/_matrix_checkboxes.html.erb
+++ b/app/views/components/forms/edit/question_types/_matrix_checkboxes.html.erb
@@ -34,7 +34,10 @@
   <% end %>
   <br>
   <div class="new-question-options-div">
-    <%= link_to "Add Matrix Checkbox Question Option", new_admin_form_question_question_option_path(question.form, question), class: "usa-button usa-button--outline form-add-question-option" %>
+    <%= link_to new_admin_form_question_question_option_path(question.form, question), class: "usa-button usa-button--outline form-add-question-option" do %>
+      <span class="fa fa-plus"></span>
+      Add Matrix Checkbox Question Option
+    <% end %>
   </div>
 </div>
 <br>

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -4,16 +4,16 @@ feature "Forms", js: true do
   let(:future_date) {
     Time.now + 3.days
   }
-  let!(:organization) { FactoryBot.create(:organization) }
+  let(:organization) { FactoryBot.create(:organization) }
   let(:admin) { FactoryBot.create(:user, :admin, organization: organization) }
   let(:user) { FactoryBot.create(:user, organization: organization) }
 
   context "as Admin" do
-    describe "/admin/forms" do
-      before do
-        login_as(admin)
-      end
+    before do
+      login_as(admin)
+    end
 
+    describe "/admin/forms" do
       context "with multiple (3) forms" do
         let!(:form) { FactoryBot.create(:form, organization: organization, user: admin)}
         let!(:form2) { FactoryBot.create(:form, organization: organization, user: admin)}
@@ -82,10 +82,6 @@ feature "Forms", js: true do
     end
 
     describe "/admin/forms/new" do
-      before do
-        login_as(admin)
-      end
-
       let(:new_form) { FactoryBot.create(:form, :custom, organization: organization, user: admin) }
 
       describe "new touchpoint hosted form" do
@@ -156,564 +152,531 @@ feature "Forms", js: true do
       end
     end
 
-    # as a Form Manager
-    describe "/admin/forms/:uuid" do
-      let(:user) { FactoryBot.create(:user, organization: organization) }
-      let(:form) { FactoryBot.create(:form, :open_ended_form, organization: organization, user: user)}
-      let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: user, form: form) }
+    context "as a Form Manager" do
+      describe "/admin/forms/:uuid" do
+        let(:form_manager) { FactoryBot.create(:user, organization: organization) }
+        let(:form) { FactoryBot.create(:form, :open_ended_form, organization: organization, user: user)}
+        let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: form_manager, form: form) }
 
-      before do
-        login_as(user)
-        visit admin_form_path(form)
-      end
-
-      context "for :in_development touchpoint" do
-        describe "Publishing" do
-          before do
-            form.update_attribute(:aasm_state, :in_development)
-            visit admin_form_path(form)
-            click_on "Publish"
-            page.driver.browser.switch_to.alert.accept
-          end
-
-          it "display 'Published' flash message" do
-            expect(page).to have_content("Published")
-            expect(page).to have_content("Viewing Survey: #{form.name}")
-            expect(page).to have_content("General Information")
-          end
-        end
-      end
-
-      describe "Submission Export button" do
-        context "when no Submissions exist" do
-          before do
-            visit responses_admin_form_path(form)
-          end
-
-          it "display text conveying there are no responses yet" do
-            expect(page).to have_content("0 Responses")
-            expect(page).to have_content("Export is not available.")
-            expect(page).to have_content("This Form has yet to receive any Responses.")
-            expect(page).to_not have_link("Export Responses to CSV")
-          end
+        before do
+          login_as(form_manager)
+          visit admin_form_path(form)
         end
 
-        context "when Submissions exist" do
-          let!(:submission) { FactoryBot.create(:submission, form: form)}
-
-          before do
-            visit responses_admin_form_path(form)
-          end
-
-          it "display table list of Responses and Export CSV button link" do
-            within("table.submissions") do
-              expect(page).to have_content(submission.answer_01)
+        context "for :in_development touchpoint" do
+          describe "Publishing" do
+            before do
+              form.update_attribute(:aasm_state, :in_development)
+              visit admin_form_path(form)
+              click_on "Publish"
+              page.driver.browser.switch_to.alert.accept
             end
-            expect(page).to have_link("Export All Responses to CSV")
-          end
-        end
-      end
 
-      describe "/admin/forms/:uuid/example" do
-        describe "Form with `inline` delivery_method" do
-          let(:form2) { FactoryBot.create(:form, :open_ended_form, :inline, organization: organization, user: user)}
-
-          before "/admin/forms/:uuid/example" do
-            visit example_admin_form_path(form2)
-          end
-
-          it "can complete then submit the inline Form and see a Success message" do
-            fill_in "answer_01", with: "We the People of the United States, in Order to form a more perfect Union..."
-            click_on "Submit"
-
-            expect(page).to have_content("Success")
-            expect(page).to have_content("Thank you. Your feedback has been received.")
-          end
-        end
-
-        context "With load_css" do
-          let(:form3) { FactoryBot.create(:form, :open_ended_form, :inline, organization: organization, user: user, load_css: true)}
-
-          before "/admin/forms/:uuid/example" do
-            visit example_admin_form_path(form3)
-          end
-
-          it "can complete then submit the inline Form and see a Success message" do
-            fill_in "answer_01", with: "We the People of the United States, in Order to form a more perfect Union..."
-            click_on "Submit"
-
-            expect(page).to have_content("Success")
-            expect(page).to have_content("Thank you. Your feedback has been received.")
-          end
-        end
-      end
-    end
-
-    describe "/admin/forms/:uuid/notifications" do
-      let(:form) { FactoryBot.create(:form, :open_ended_form, organization: organization, user: admin)}
-      let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: admin, form: form) }
-
-      before do
-        login_as(admin)
-        visit notifications_admin_form_path(form)
-        expect(find_field('form_notification_emails').value).to eq(form.notification_emails)
-        fill_in("form_notification_emails", with: "new@email.gov")
-        click_on "Update Survey"
-      end
-
-      it "updates successfully" do
-        expect(page).to have_content("Survey was successfully updated.")
-        expect(page).to have_content("new@email.gov")
-      end
-    end
-
-    # as a Response Viewer
-    describe "/admin/forms/:uuid" do
-      let(:response_viewer) { FactoryBot.create(:user, organization: organization) }
-      let(:form) { FactoryBot.create(:form, :open_ended_form, organization: organization, user: response_viewer)}
-      let!(:user_role) { FactoryBot.create(:user_role, :response_viewer, user: response_viewer, form: form) }
-
-      before do
-        login_as(response_viewer)
-        visit admin_form_path(form)
-      end
-
-      describe "unavailable UI features" do
-        it "does not display 'Publish' component" do
-          expect(page).not_to have_content("Publish your form")
-        end
-
-        it "does not display 'Roles and Permissions' component" do
-          expect(page).not_to have_content("Roles & Permissions")
-        end
-      end
-
-      describe "insufficient privileges to /permissions" do
-        before do
-          login_as(user)
-          visit permissions_admin_form_path(form)
-        end
-
-        it "is redirected away and shown a message" do
-          expect(page).to have_content("Authorization is Required")
-          expect(page.current_path).to eq admin_root_path
-        end
-      end
-
-      describe "insufficient privileges to /questions" do
-        before do
-          login_as(user)
-          visit questions_admin_form_path(form)
-        end
-
-        it "is redirected away and shown a message" do
-          expect(page).to have_content("Authorization is Required")
-          expect(page.current_path).to eq admin_root_path
-        end
-      end
-
-      describe "Submission Export button" do
-        context "when no Submissions exist" do
-        end
-
-        context "when Submissions exist" do
-          let!(:submission) { FactoryBot.create(:submission, form: form)}
-
-          before do
-            visit responses_admin_form_path(form)
-          end
-
-          it "display table list of Responses and Export CSV button link" do
-            within("table.submissions") do
-              expect(page).to have_content(submission.answer_01)
+            it "display 'Published' flash message" do
+              expect(page).to have_content("Published")
+              expect(page).to have_content("Viewing Survey: #{form.name}")
+              expect(page).to have_content("General Information")
             end
-            expect(page).to have_link("Export All Responses to CSV")
+          end
+        end
+
+        describe "Submission Export button" do
+          context "when no Submissions exist" do
+            before do
+              visit responses_admin_form_path(form)
+            end
+
+            it "display text conveying there are no responses yet" do
+              expect(page).to have_content("0 Responses")
+              expect(page).to have_content("Export is not available.")
+              expect(page).to have_content("This Form has yet to receive any Responses.")
+              expect(page).to_not have_link("Export Responses to CSV")
+            end
+          end
+
+          context "when Submissions exist" do
+            let!(:submission) { FactoryBot.create(:submission, form: form)}
+
+            before do
+              visit responses_admin_form_path(form)
+            end
+
+            it "display table list of Responses and Export CSV button link" do
+              within("table.submissions") do
+                expect(page).to have_content(submission.answer_01)
+              end
+              expect(page).to have_link("Export All Responses to CSV")
+            end
+          end
+        end
+
+        describe "/admin/forms/:uuid/example" do
+          describe "Form with `inline` delivery_method" do
+            let(:form2) { FactoryBot.create(:form, :open_ended_form, :inline, organization: organization, user: user)}
+
+            before "/admin/forms/:uuid/example" do
+              visit example_admin_form_path(form2)
+            end
+
+            it "can complete then submit the inline Form and see a Success message" do
+              fill_in "answer_01", with: "We the People of the United States, in Order to form a more perfect Union..."
+              click_on "Submit"
+
+              expect(page).to have_content("Success")
+              expect(page).to have_content("Thank you. Your feedback has been received.")
+            end
+          end
+
+          context "With load_css" do
+            let(:form3) { FactoryBot.create(:form, :open_ended_form, :inline, organization: organization, user: user, load_css: true)}
+
+            before "/admin/forms/:uuid/example" do
+              visit example_admin_form_path(form3)
+            end
+
+            it "can complete then submit the inline Form and see a Success message" do
+              fill_in "answer_01", with: "We the People of the United States, in Order to form a more perfect Union..."
+              click_on "Submit"
+
+              expect(page).to have_content("Success")
+              expect(page).to have_content("Thank you. Your feedback has been received.")
+            end
           end
         end
       end
 
-      describe "/admin/forms/:uuid/example" do
-        describe "Form with `inline` delivery_method" do
-          let(:form2) { FactoryBot.create(:form, :open_ended_form, :inline, organization: organization, user: admin)}
+      describe "/admin/forms/:uuid/notifications" do
+        let(:form) { FactoryBot.create(:form, :open_ended_form, organization: organization, user: admin)}
+        let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: admin, form: form) }
 
-          before "/admin/forms/:uiid/example" do
-            visit example_admin_form_path(form2)
-          end
-
-          it "can complete then submit the inline Form and see a Success message" do
-            fill_in "answer_01", with: "We the People of the United States, in Order to form a more perfect Union..."
-            click_on "Submit"
-            expect(page).to have_content("Success")
-            expect(page).to have_content("Thank you. Your feedback has been received.")
-          end
-        end
-      end
-    end
-
-    context "Edit Form page" do
-      let!(:form) { FactoryBot.create(:form, :custom, organization: organization, user: admin) }
-
-      before do
-        login_as(admin)
-        visit edit_admin_form_path(form)
-      end
-
-      describe "editing a Form definition" do
         before do
-          fill_in "form_name", with: "Updated Form Name"
-          fill_in "form_title", with: "Updated Title"
+          # login_as(admin)
+          visit notifications_admin_form_path(form)
+          expect(find_field('form_notification_emails').value).to eq(form.notification_emails)
+          fill_in("form_notification_emails", with: "new@email.gov")
           click_on "Update Survey"
         end
 
-        it "can edit existing Form" do
+        it "updates successfully" do
           expect(page).to have_content("Survey was successfully updated.")
-          expect(page.current_path).to eq(admin_form_path(form))
-          expect(page).to have_content("Updated Form Name")
-          expect(page).to have_content("Updated Title")
+          expect(page).to have_content("new@email.gov")
         end
       end
 
-      describe "modifying Form Sections" do
-        it "cannot delete the only remaining form section" do
-          expect(page).to_not have_content("Delete Form Section")
-        end
-      end
+      context "Edit Form page" do
+        let!(:form) { FactoryBot.create(:form, :custom, organization: organization, user: admin) }
 
-      describe "delete a Form" do
-        context "with no responses" do
-          before do
-            click_on "Delete Survey"
-            page.driver.browser.switch_to.alert.accept
-          end
-
-          it "can delete existing Form" do
-            expect(page).to have_content("Survey was successfully destroyed.")
-          end
-        end
-
-        context "with responses" do
-          let!(:submission) { FactoryBot.create(:submission, form: form)}
-
-          before do
-            click_on "Delete Survey"
-            page.driver.browser.switch_to.alert.accept
-          end
-
-          it "cannot delete existing Form" do
-            expect(page).to have_content("This form cannot be deleted because it has responses")
-          end
-        end
-      end
-
-      describe "adding Form Sections" do
         before do
-          visit questions_admin_form_path(form)
-          click_on "Add Form Section"
+          login_as(admin)
+          visit edit_admin_form_path(form)
         end
 
-        it "displays /admin/forms/:id/form_sections/new" do
-          expect(page).to have_content("New Form Section")
-        end
-
-        describe "add Form Section" do
+        describe "editing a Form definition" do
           before do
-            fill_in("form_section_title", with: "Test Form Section Title")
-            select("1", from: "form_section_position")
-            click_on "Create Form section"
+            fill_in "form_name", with: "Updated Form Name"
+            fill_in "form_title", with: "Updated Title"
+            click_on "Update Survey"
           end
 
-          it "create Form Section successfully" do
-            expect(page).to have_content("Form section was successfully created.")
+          it "can edit existing Form" do
+            expect(page).to have_content("Survey was successfully updated.")
+            expect(page.current_path).to eq(admin_form_path(form))
+            expect(page).to have_content("Updated Form Name")
+            expect(page).to have_content("Updated Title")
           end
         end
-      end
 
-      describe "adding Questions" do
-        describe "add a Text Field question" do
-          before do
-            visit questions_admin_form_path(form)
-            click_on "Add Question"
-            expect(page).to have_content("New Question")
-            fill_in "question_text", with: "New Test Question"
-            select("text_field", from: "question_question_type")
-            select("answer_01", from: "question_answer_field")
-            select(form.form_sections.first.title, from: "question_form_section_id")
-            expect(find_field('question_position').value).to eq '1'
-            click_on "Create Question"
+        describe "modifying Form Sections" do
+          it "cannot delete the only remaining form section" do
+            expect(page).to_not have_content("Delete Form Section")
+          end
+        end
+
+        describe "delete a Form" do
+          context "with no responses" do
+            before do
+              click_on "Delete Survey"
+              page.driver.browser.switch_to.alert.accept
+            end
+
+            it "can delete existing Form" do
+              expect(page).to have_content("Survey was successfully destroyed.")
+            end
           end
 
-          it "can add a Text Field Question" do
-            expect(page).to have_content("Question was successfully created.")
-            expect(page.current_path).to eq(questions_admin_form_path(form))
-            within ".form-builder .question" do
-              expect(page).to have_content("New Test Question")
-              expect(page).to have_css("input[type='text']")
+          context "with responses" do
+            let!(:submission) { FactoryBot.create(:submission, form: form)}
+
+            before do
+              click_on "Delete Survey"
+              page.driver.browser.switch_to.alert.accept
+            end
+
+            it "cannot delete existing Form" do
+              expect(page).to have_content("This form cannot be deleted because it has responses")
             end
           end
         end
 
-        describe "add a Text Area question" do
+        context "Form Sections" do
           before do
-            visit questions_admin_form_path(form)
-            click_on "Add Question"
-            expect(page).to have_content("New Question")
-            fill_in "question_text", with: "New Text Area"
-            select("textarea", from: "question_question_type")
-            select("answer_01", from: "question_answer_field")
-            select(form.form_sections.first.title, from: "question_form_section_id")
-            expect(find_field('question_position').value).to eq '1'
-            click_on "Create Question"
+            login_as(admin)
           end
 
-          it "can add a Text Area question" do
-            expect(page).to have_content("Question was successfully created.")
-            expect(page.current_path).to eq(questions_admin_form_path(form))
-            within ".form-builder .question" do
-              expect(page).to have_content("New Text Area")
-              expect(page).to have_css("textarea")
+          describe "adding Form Sections" do
+            before do
+              visit questions_admin_form_path(form)
+              click_on "Add Section"
+            end
+
+            it "displays /admin/forms/:id/form_sections/new" do
+              expect(page).to have_content("New Form Section")
+            end
+
+            describe "add Form Section" do
+              before do
+                fill_in("form_section_title", with: "Test Form Section Title")
+                select("1", from: "form_section_position")
+                click_on "Create Section"
+              end
+
+              it "create Form Section successfully" do
+                expect(page).to have_content("Form section was successfully created.")
+              end
+            end
+          end
+
+          describe "delete Form Sections" do
+            before do
+              visit questions_admin_form_path(form)
+            end
+
+            it "defaults to 1 section" do
+              expect(find_all(".section").size).to eq(1)
+            end
+
+            describe "with at least 2 Sections" do
+              let!(:form_section2) { FactoryBot.create(:form_section, form: form) }
+
+              before do
+                visit questions_admin_form_path(form)
+              end
+
+              it "display successful flash message" do
+                expect(find_all(".section").size).to eq(2)
+                within(first(".section")) do
+                  click_on "Delete Section"
+                  page.driver.browser.switch_to.alert.accept
+                end
+
+                expect(page).to have_content("Form section was successfully destroyed.")
+                expect(find_all(".section").size).to eq(1)
+                expect(page.current_path).to eq(questions_admin_form_path(form))
+              end
+            end
+
+            describe "add Form Section" do
+              before do
+                click_on "Add Section"
+                expect(page).to have_content("New Form Section")
+                fill_in("form_section_title", with: "Test Form Section Title")
+                select("1", from: "form_section_position")
+                click_on "Create Section"
+              end
+
+              it "create Form Section successfully" do
+                expect(page).to have_content("Form section was successfully created.")
+              end
             end
           end
         end
 
-        describe "add a Radio Buttons question" do
-          before do
-            visit questions_admin_form_path(form)
-            click_on "Add Question"
-            expect(page).to have_content("New Question")
-            fill_in "question_text", with: "New Test Question Radio Buttons"
-            select("radio_buttons", from: "question_question_type")
-            select("answer_01", from: "question_answer_field")
-            select(form.form_sections.first.title, from: "question_form_section_id")
-
-            expect(find_field('question_position').value).to eq '1'
-            click_on "Create Question"
-          end
-
-          it "can add a Text Field Question" do
-            expect(page).to have_content("Question was successfully created.")
-            expect(page.current_path).to eq(questions_admin_form_path(form))
-            within ".form-builder .question" do
-              expect(page).to have_content("New Test Question Radio Buttons")
-              # Radio buttons won't be showing yet. Because they need to be added.
-            end
-          end
-        end
-
-        describe "add a Checkbox question" do
-          before do
-            visit questions_admin_form_path(form)
-            click_on "Add Question"
-            expect(page.current_path).to eq(new_admin_form_question_path(form))
-            expect(page).to have_content("New Question")
-            fill_in "checkbox", with: "New Test Question Radio Buttons"
-            select("radio_buttons", from: "question_question_type")
-            select("answer_01", from: "question_answer_field")
-
-            expect(find_field('question_position').value).to eq '1'
-            click_on "Create Question"
-          end
-
-          xit "can add a Checkbox Question" do
-            expect(page).to have_content("Question was successfully created.")
-            within ".form-preview .question" do
-              # expect(page).to have_content("New Test Question Radio Buttons")
-              # Radio buttons won't be showing yet. Because they need to be added.
-            end
-          end
-        end
-
-        context "Dropdown Question" do
-          describe "#create" do
+        describe "adding Questions" do
+          describe "add a Text Field question" do
             before do
               visit questions_admin_form_path(form)
               click_on "Add Question"
-              expect(page.current_path).to eq(questions_admin_form_path(form))
               expect(page).to have_content("New Question")
-              select("dropdown", from: "question_question_type")
-              fill_in "question_text", with: "New dropdown field"
+              fill_in "question_text", with: "New Test Question"
+              select("text_field", from: "question_question_type")
+              select("answer_01", from: "question_answer_field")
+              select(form.form_sections.first.title, from: "question_form_section_id")
+              expect(find_field('question_position').value).to eq '1'
+              click_on "Create Question"
+            end
+
+            it "can add a Text Field Question" do
+              expect(page).to have_content("Question was successfully created.")
+              expect(page.current_path).to eq(questions_admin_form_path(form))
+              within ".form-builder .question" do
+                expect(page).to have_content("New Test Question")
+                expect(page).to have_css("input[type='text']")
+              end
+            end
+          end
+
+          describe "add a Text Area question" do
+            before do
+              visit questions_admin_form_path(form)
+              click_on "Add Question"
+              expect(page).to have_content("New Question")
+              fill_in "question_text", with: "New Text Area"
+              select("textarea", from: "question_question_type")
+              select("answer_01", from: "question_answer_field")
+              select(form.form_sections.first.title, from: "question_form_section_id")
+              expect(find_field('question_position').value).to eq '1'
+              click_on "Create Question"
+            end
+
+            it "can add a Text Area question" do
+              expect(page).to have_content("Question was successfully created.")
+              expect(page.current_path).to eq(questions_admin_form_path(form))
+              within ".form-builder .question" do
+                expect(page).to have_content("New Text Area")
+                expect(page).to have_css("textarea")
+              end
+            end
+          end
+
+          describe "add a Radio Buttons question" do
+            before do
+              visit questions_admin_form_path(form)
+              click_on "Add Question"
+              expect(page).to have_content("New Question")
+              fill_in "question_text", with: "New Test Question Radio Buttons"
+              select("radio_buttons", from: "question_question_type")
+              select("answer_01", from: "question_answer_field")
+              select(form.form_sections.first.title, from: "question_form_section_id")
+
+              expect(find_field('question_position').value).to eq '1'
+              click_on "Create Question"
+            end
+
+            it "can add a Text Field Question" do
+              expect(page).to have_content("Question was successfully created.")
+              expect(page.current_path).to eq(questions_admin_form_path(form))
+              within ".form-builder .question" do
+                expect(page).to have_content("New Test Question Radio Buttons")
+                # Radio buttons won't be showing yet. Because they need to be added.
+              end
+            end
+          end
+
+          describe "add a Checkbox question" do
+            before do
+              visit questions_admin_form_path(form)
+              click_on "Add Question"
+              expect(page.current_path).to eq(new_admin_form_question_path(form))
+              expect(page).to have_content("New Question")
+              fill_in "checkbox", with: "New Test Question Radio Buttons"
+              select("radio_buttons", from: "question_question_type")
               select("answer_01", from: "question_answer_field")
 
               expect(find_field('question_position').value).to eq '1'
               click_on "Create Question"
             end
 
-            it "can add a dropdown Question" do
+            xit "can add a Checkbox Question" do
               expect(page).to have_content("Question was successfully created.")
-              expect(page.current_path).to eq(questions_admin_form_path(form))
-              within ".form-builder" do
-                expect(page).to have_content("New dropdown field")
+              within ".form-preview .question" do
+                # expect(page).to have_content("New Test Question Radio Buttons")
                 # Radio buttons won't be showing yet. Because they need to be added.
               end
             end
+          end
 
-            describe "#edit" do
+          context "Dropdown Question" do
+            describe "#create" do
               before do
                 visit questions_admin_form_path(form)
-                click_on "Edit Question"
-                expect(page.current_path).to eq(questions_admin_form_path(form))
-                expect(page).to have_content("Editing Question")
-                expect(find_field('question_text').value).to eq 'New dropdown field'
-              end
-
-              it "add a Question Option for a dropdown" do
-                fill_in "question_text", with: "Updated question text"
-                click_on "Update Question"
-
-                expect(page).to have_content("Question was successfully updated.")
-                expect(page.current_path).to eq(questions_admin_form_path(form))
-                within ".form-builder" do
-                  expect(page).to have_content("1. Updated question text")
-                end
-              end
-            end
-
-            describe "Question Options for a dropdown" do
-              before do
-                visit questions_admin_form_path(form)
-                click_on "Add Dropdown Option"
+                click_on "Add Question"
                 expect(page.current_path).to eq(questions_admin_form_path(form))
                 expect(page).to have_content("New Question")
-                fill_in "question_option_text", with: "Dropdown option #1"
-                fill_in "question_option_value", with: "value1"
-                expect(find_field('question_option_position').value).to eq '1'
-                click_on "Create Question option"
+                select("dropdown", from: "question_question_type")
+                fill_in "question_text", with: "New dropdown field"
+                select("answer_01", from: "question_answer_field")
+
+                expect(find_field('question_position').value).to eq '1'
+                click_on "Create Question"
               end
 
-              it "add a Question Option for a dropdown" do
-                expect(page).to have_content("Question option was successfully created.")
+              it "can add a dropdown Question" do
+                expect(page).to have_content("Question was successfully created.")
                 expect(page.current_path).to eq(questions_admin_form_path(form))
                 within ".form-builder" do
-                  expect(page).to have_content("Dropdown option #1")
-                  expect(page).to have_link("Edit")
+                  expect(page).to have_content("New dropdown field")
+                  # Radio buttons won't be showing yet. Because they need to be added.
+                end
+              end
+
+              describe "#edit" do
+                before do
+                  visit questions_admin_form_path(form)
+                  click_on "Edit Question"
+                  expect(page.current_path).to eq(questions_admin_form_path(form))
+                  expect(page).to have_content("Editing Question")
+                  expect(find_field('question_text').value).to eq 'New dropdown field'
+                end
+
+                it "add a Question Option for a dropdown" do
+                  fill_in "question_text", with: "Updated question text"
+                  click_on "Update Question"
+
+                  expect(page).to have_content("Question was successfully updated.")
+                  expect(page.current_path).to eq(questions_admin_form_path(form))
+                  within ".form-builder" do
+                    expect(page).to have_content("1. Updated question text")
+                  end
+                end
+              end
+
+              describe "Question Options for a dropdown" do
+                before do
+                  visit questions_admin_form_path(form)
+                  click_on "Add Dropdown Option"
+                  expect(page.current_path).to eq(questions_admin_form_path(form))
+                  expect(page).to have_content("New Question")
+                  fill_in "question_option_text", with: "Dropdown option #1"
+                  fill_in "question_option_value", with: "value1"
+                  expect(find_field('question_option_position').value).to eq '1'
+                  click_on "Create Question option"
+                end
+
+                it "add a Question Option for a dropdown" do
+                  expect(page).to have_content("Question option was successfully created.")
+                  expect(page.current_path).to eq(questions_admin_form_path(form))
+                  within ".form-builder" do
+                    expect(page).to have_content("Dropdown option #1")
+                    expect(page).to have_link("Edit")
+                  end
                 end
               end
             end
           end
-        end
 
-        describe "add a text display element" do
-          before do
-            visit questions_admin_form_path(form)
-            click_on "Add Question"
-            expect(page.current_path).to eq(questions_admin_form_path(form))
-            expect(page).to have_content("New Question")
+          describe "add a text display element" do
+            before do
+              visit questions_admin_form_path(form)
+              click_on "Add Question"
+              expect(page.current_path).to eq(questions_admin_form_path(form))
+              expect(page).to have_content("New Question")
 
-            select("text_display", from: "question_question_type")
-            fill_in "question_text", with: 'Some custom <a href="#">html</a>'
-            select("answer_20", from: "question_answer_field")
-            expect(find_field('question_position').value).to eq '1'
-            click_on "Create Question"
-          end
-
-          it "display text display element with html" do
-            expect(page).to have_content("Question was successfully created.")
-            within ".form-builder .question" do
-              expect(page).to have_content("Some custom")
-              expect(page).to have_link("html")
+              select("text_display", from: "question_question_type")
+              fill_in "question_text", with: 'Some custom <a href="#">html</a>'
+              select("answer_20", from: "question_answer_field")
+              expect(find_field('question_position').value).to eq '1'
+              click_on "Create Question"
             end
-          end
-        end
 
-      end
-
-      describe "deleting Questions" do
-        let(:form2) { FactoryBot.create(:form, :custom, organization: organization, user: admin) }
-        let(:form_section2) { FactoryBot.create(:form_section, form: form2) }
-        let!(:question) { FactoryBot.create(:question, form: form2, form_section: form_section2) }
-        let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: admin, form: form2) }
-
-        context "with Form Manager permissions" do
-          before do
-            visit questions_admin_form_path(form2)
-          end
-
-          it "display the Delete Question button" do
-            expect(page).to have_link("Delete Question")
-          end
-        end
-      end
-
-      describe "adding Question Options" do
-        describe "add Radio Button options" do
-          let!(:radio_button_question) { FactoryBot.create(:question, :with_radio_buttons, form: form, form_section: form.form_sections.first) }
-
-          before do
-            visit questions_admin_form_path(form)
-            click_on "Add Radio Button Option"
-            expect(page).to have_content("New Question Option")
-            expect(page).to have_content("for the question: #{radio_button_question.text}")
-            expect(page).to have_content("with a question_type of: radio_buttons")
-            expect(page).to have_content("on the form #{form.name}")
-          end
-
-          it "create a Radio Button option" do
-            fill_in("question_option_text", with: "New Test Radio Option")
-            fill_in("question_option_value", with: "123")
-            click_on("Create Question option")
-            expect(page).to have_content("Question option was successfully created.")
-            within ".form-section-div" do
-              expect(all("label").last).to have_content("New Test Radio Option")
-            end
-          end
-        end
-
-        xdescribe "adding Checkbox options" do
-        end
-
-        xdescribe "adding Dropdown options" do
-        end
-      end
-
-      describe "click through to edit Question Option" do
-        describe "edit Radio Button option" do
-          let!(:radio_button_question) { FactoryBot.create(:question, :with_radio_buttons, form: form, form_section: form.form_sections.first) }
-          let!(:radio_button_option) { FactoryBot.create(:question_option, question: radio_button_question, position: 1) }
-
-          before do
-            visit questions_admin_form_path(form)
-
-            within (".question") do
-              within all(".usa-checkbox").first do
-                click_on "Edit"
+            it "display text display element with html" do
+              expect(page).to have_content("Question was successfully created.")
+              within ".form-builder .question" do
+                expect(page).to have_content("Some custom")
+                expect(page).to have_link("html")
               end
             end
           end
 
-          it "click through to Edit page" do
-            expect(page).to have_content("Editing Question Option")
-            expect(find_field("question_option_text").value).to eq(radio_button_option.text)
-          end
         end
-      end
 
-      describe "editing Question Options" do
-        describe "edit Radio Button option" do
-          let!(:radio_button_question) { FactoryBot.create(:question, :with_radio_buttons, form: form, form_section: form.form_sections.first) }
-          let!(:radio_button_option) { FactoryBot.create(:question_option, question: radio_button_question, position: 1) }
+        describe "deleting Questions" do
+          let(:form2) { FactoryBot.create(:form, :custom, organization: organization, user: admin) }
+          let(:form_section2) { FactoryBot.create(:form_section, form: form2) }
+          let!(:question) { FactoryBot.create(:question, form: form2, form_section: form_section2) }
+          let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: admin, form: form2) }
 
-          before do
-            visit edit_admin_form_question_question_option_path(form, radio_button_question, radio_button_option)
-            fill_in "question_option_text", with: "Edited Question Option Text"
-            fill_in "question_option_value", with: "100"
-            click_on "Update Question option"
-          end
-
-          it "click through to Edit page" do
-            expect(page).to have_content("Question option was successfully updated.")
-            within (".question") do
-              expect(page).to have_content("Edited Question Option Text")
+          context "with Form Manager permissions" do
+            before do
+              visit questions_admin_form_path(form2)
             end
 
-            # Ensure other (non UI-visible) data persists
-            visit edit_admin_form_question_question_option_path(form, radio_button_question, radio_button_option)
-            expect(page.find_field("question_option_text").value).to eq("Edited Question Option Text")
-            expect(page.find_field("question_option_value").value).to eq("100")
+            it "display the Delete Question button" do
+              expect(page).to have_link("Delete Question")
+            end
           end
         end
+
+        describe "adding Question Options" do
+          describe "add Radio Button options" do
+            let!(:radio_button_question) { FactoryBot.create(:question, :with_radio_buttons, form: form, form_section: form.form_sections.first) }
+
+            before do
+              visit questions_admin_form_path(form)
+              click_on "Add Radio Button Option"
+              expect(page).to have_content("New Question Option")
+              expect(page).to have_content("for the question: #{radio_button_question.text}")
+              expect(page).to have_content("with a question_type of: radio_buttons")
+              expect(page).to have_content("on the form #{form.name}")
+            end
+
+            it "create a Radio Button option" do
+              fill_in("question_option_text", with: "New Test Radio Option")
+              fill_in("question_option_value", with: "123")
+              click_on("Create Question option")
+              expect(page).to have_content("Question option was successfully created.")
+              within ".form-section-div" do
+                expect(all("label").last).to have_content("New Test Radio Option")
+              end
+            end
+          end
+
+          xdescribe "adding Checkbox options" do
+          end
+
+          xdescribe "adding Dropdown options" do
+          end
+        end
+
+        describe "click through to edit Question Option" do
+          describe "edit Radio Button option" do
+            let!(:radio_button_question) { FactoryBot.create(:question, :with_radio_buttons, form: form, form_section: form.form_sections.first) }
+            let!(:radio_button_option) { FactoryBot.create(:question_option, question: radio_button_question, position: 1) }
+
+            before do
+              visit questions_admin_form_path(form)
+
+              within (".question") do
+                within all(".usa-checkbox").first do
+                  click_on "Edit"
+                end
+              end
+            end
+
+            it "click through to Edit page" do
+              expect(page).to have_content("Editing Question Option")
+              expect(find_field("question_option_text").value).to eq(radio_button_option.text)
+            end
+          end
+        end
+
+        describe "editing Question Options" do
+          describe "edit Radio Button option" do
+            let!(:radio_button_question) { FactoryBot.create(:question, :with_radio_buttons, form: form, form_section: form.form_sections.first) }
+            let!(:radio_button_option) { FactoryBot.create(:question_option, question: radio_button_question, position: 1) }
+
+            before do
+              visit edit_admin_form_question_question_option_path(form, radio_button_question, radio_button_option)
+              fill_in "question_option_text", with: "Edited Question Option Text"
+              fill_in "question_option_value", with: "100"
+              click_on "Update Question option"
+            end
+
+            it "click through to Edit page" do
+              expect(page).to have_content("Question option was successfully updated.")
+              within (".question") do
+                expect(page).to have_content("Edited Question Option Text")
+              end
+
+              # Ensure other (non UI-visible) data persists
+              visit edit_admin_form_question_question_option_path(form, radio_button_question, radio_button_option)
+              expect(page.find_field("question_option_text").value).to eq("Edited Question Option Text")
+              expect(page.find_field("question_option_value").value).to eq("100")
+            end
+          end
+        end
+
       end
-
     end
-
   end
 
   context "form owner with Form Manager permissions" do
@@ -897,7 +860,7 @@ feature "Forms", js: true do
           before do
             visit edit_admin_form_form_section_path(form_section2.form, form_section2)
             fill_in("form_section[title]", with: new_title)
-            click_button "Update Form section"
+            click_button "Update Section"
           end
 
           it "redirect to /admin/forms/:id/edit with a success flash message" do
@@ -923,6 +886,101 @@ feature "Forms", js: true do
         expect(page).to have_content("form")
         expect(page).to have_content("questions")
         expect(page).to have_content("question_options")
+      end
+    end
+  end
+
+  context "as Response Viewer" do
+    # as a Response Viewer
+    describe "/admin/forms/:uuid" do
+      let(:response_viewer) { FactoryBot.create(:user, organization: organization) }
+      let(:form) { FactoryBot.create(:form, :open_ended_form, organization: organization, user: response_viewer)}
+      let!(:user_role) { FactoryBot.create(:user_role, :response_viewer, user: response_viewer, form: form) }
+
+      before do
+        login_as(response_viewer)
+        visit admin_form_path(form)
+      end
+
+      describe "unavailable UI features" do
+        it "does not display 'Publish' component" do
+          expect(page).not_to have_content("Publish your form")
+        end
+
+        it "does not display 'Roles and Permissions' component" do
+          expect(page).not_to have_content("Roles & Permissions")
+        end
+      end
+
+      describe "Submission Export button" do
+        let(:form) { FactoryBot.create(:form, :open_ended_form, organization: organization, user: admin)}
+
+        context "when no Submissions exist" do
+        end
+
+        context "when Submissions exist" do
+          let!(:submission) { FactoryBot.create(:submission, form: form)}
+
+          before do
+            visit responses_admin_form_path(form)
+          end
+
+          it "display table list of Responses and Export CSV button link" do
+            within("table.submissions") do
+              expect(page).to have_content(submission.answer_01)
+            end
+            expect(page).to have_link("Export All Responses to CSV")
+          end
+        end
+      end
+    end
+
+
+    context "user for another Form" do
+      let(:form) { FactoryBot.create(:form, :open_ended_form, organization: organization, user: admin)}
+
+      before do
+        login_as(user)
+      end
+
+      describe "insufficient privileges to /permissions" do
+        before do
+          visit permissions_admin_form_path(form)
+        end
+
+        it "is redirected away and shown a message" do
+          expect(page).to have_content("Authorization is Required")
+          expect(page.current_path).to eq admin_root_path
+        end
+      end
+
+      describe "insufficient privileges to /questions" do
+        before do
+          visit questions_admin_form_path(form)
+        end
+
+        it "is redirected away and shown a message" do
+          expect(page).to have_content("Authorization is Required")
+          expect(page.current_path).to eq admin_root_path
+        end
+      end
+    end
+
+    describe "/admin/forms/:uuid/example" do
+      describe "Form with `inline` delivery_method" do
+        let(:form2) { FactoryBot.create(:form, :open_ended_form, :inline, organization: organization, user: admin)}
+
+        before "/admin/forms/:uiid/example" do
+          login_as(admin)
+          visit example_admin_form_path(form2)
+        end
+
+        it "can complete then submit the inline Form and see a Success message" do
+          fill_in "answer_01", with: "We the People of the United States, in Order to form a more perfect Union..."
+          click_on "Submit"
+          expect(page).to have_content("Success")
+          expect(page).to have_content("Thank you. Your feedback has been received.")
+        end
       end
     end
   end


### PR DESCRIPTION
* redirect to questions/form-builder page after a form section is deleted
* move toward "Section" instead of "Form section"