### PR TITLE
TP-1081 Drag questions across sections

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -492,5 +492,5 @@ a.form-section-save {
   width: 400px;
 }
 .questions {
-  min-height: 100px;
+  min-height: 10px;
 }

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -491,3 +491,6 @@ a.form-section-save {
 .form-title {
   width: 400px;
 }
+.questions {
+  min-height: 100px;
+}

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -19,8 +19,9 @@ class Admin::QuestionsController < AdminController
   end
 
   def sort
+    form_section_id = params[:form_section_id].split("_").last.to_i
     params[:question].each_with_index do |id, index|
-      Question.where(id: id).update_all(position: index + 1)
+      Question.where(id: id).update_all(position: index + 1, form_section_id: form_section_id)
     end
 
     head :ok

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -40,39 +40,41 @@
         </div>
       </div>
 
-      <div class="section well2 list-group questions">
-        <% section.questions.each_with_index do |question, index| %>
-          <% multi_section_question_number += 1 %>
-          <div class="question well3 list-group-item" id="<%= dom_id(question) %>" >
-            <%= render 'components/forms/edit/button_dropdown', { form: form, question: question } if form_permissions?(form: form) %>
+      <div class="section well2 list-group">
+        <div class="questions">
+          <% section.questions.each_with_index do |question, index| %>
+            <% multi_section_question_number += 1 %>
+            <div class="question well3 list-group-item" id="<%= dom_id(question) %>" >
+              <%= render 'components/forms/edit/button_dropdown', { form: form, question: question } if form_permissions?(form: form) %>
 
-            <% if question.question_type == "text_field" %>
-              <%= render 'components/forms/edit/question_types/text_field', form: form, question: question, question_number: multi_section_question_number %>
-            <% elsif question.question_type == "radio_buttons" %>
-              <%= render 'components/forms/edit/question_types/radio_buttons', form: form, question: question, question_number: multi_section_question_number %>
-            <% elsif question.question_type == "thumbs_up_down_buttons" %>
-              <%= render 'components/forms/question_types/thumbs_up_down_buttons', form: form, question: question, question_number: multi_section_question_number %>
-              <br>
-            <% elsif question.question_type == "dropdown" %>
-              <%= render 'components/forms/edit/question_types/dropdown', form: form, question: question, question_number: multi_section_question_number %>
-            <% elsif question.question_type == "checkbox" %>
-              <%= render 'components/forms/edit/question_types/checkbox', form: form, question: question, question_number: multi_section_question_number %>
-            <% elsif question.question_type == "textarea" %>
-              <%= render 'components/forms/edit/question_types/text_area', form: form, question: question, question_number: multi_section_question_number %>
-            <% elsif question.question_type == "custom_text_display" %>
-              <%= render 'components/forms/question_types/custom_text_display', form: form, question: question, question_number: multi_section_question_number %>
-              <br>
-            <% elsif question.question_type == "star_radio_buttons" %>
-              <%= render 'components/forms/question_types/star_radio_buttons', form: form, question: question, question_number: multi_section_question_number %>
-            <% elsif question.question_type == "matrix_checkboxes" %>
-              <%= render 'components/forms/edit/question_types/matrix_checkboxes', form: form, question: question, question_number: multi_section_question_number %>
-            <% elsif question.question_type == "yes_no_buttons" %>
-              <%= render 'components/forms/question_types/yes_no_buttons', form: form, question: question, question_number: multi_section_question_number %>
-            <% elsif question.question_type == "text_display" %>
-              <%= render 'components/forms/question_types/text_display', form: form, question: question, question_number: multi_section_question_number %>
-            <% end %>
-          </div>
-        <% end %>
+              <% if question.question_type == "text_field" %>
+                <%= render 'components/forms/edit/question_types/text_field', form: form, question: question, question_number: multi_section_question_number %>
+              <% elsif question.question_type == "radio_buttons" %>
+                <%= render 'components/forms/edit/question_types/radio_buttons', form: form, question: question, question_number: multi_section_question_number %>
+              <% elsif question.question_type == "thumbs_up_down_buttons" %>
+                <%= render 'components/forms/question_types/thumbs_up_down_buttons', form: form, question: question, question_number: multi_section_question_number %>
+                <br>
+              <% elsif question.question_type == "dropdown" %>
+                <%= render 'components/forms/edit/question_types/dropdown', form: form, question: question, question_number: multi_section_question_number %>
+              <% elsif question.question_type == "checkbox" %>
+                <%= render 'components/forms/edit/question_types/checkbox', form: form, question: question, question_number: multi_section_question_number %>
+              <% elsif question.question_type == "textarea" %>
+                <%= render 'components/forms/edit/question_types/text_area', form: form, question: question, question_number: multi_section_question_number %>
+              <% elsif question.question_type == "custom_text_display" %>
+                <%= render 'components/forms/question_types/custom_text_display', form: form, question: question, question_number: multi_section_question_number %>
+                <br>
+              <% elsif question.question_type == "star_radio_buttons" %>
+                <%= render 'components/forms/question_types/star_radio_buttons', form: form, question: question, question_number: multi_section_question_number %>
+              <% elsif question.question_type == "matrix_checkboxes" %>
+                <%= render 'components/forms/edit/question_types/matrix_checkboxes', form: form, question: question, question_number: multi_section_question_number %>
+              <% elsif question.question_type == "yes_no_buttons" %>
+                <%= render 'components/forms/question_types/yes_no_buttons', form: form, question: question, question_number: multi_section_question_number %>
+              <% elsif question.question_type == "text_display" %>
+                <%= render 'components/forms/question_types/text_display', form: form, question: question, question_number: multi_section_question_number %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
         <%= link_to new_admin_form_question_path(form), class: "usa-button form-add-question" do %>
           <span class="fa fa-plus"></span>
           Add Question

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -246,12 +246,17 @@ $(function() {
   });
 
   $(".questions").sortable({
+    items: '.question',
+    connectWith: ".questions",
     distance: 20,
     update: function(e, ui) {
+      var section_id = $(this).closest(".form-section-div").attr('id');
+      var data = $(this).sortable('serialize');
+      data = data + "&form_section_id=" + section_id
       $.ajax({
         url: $(this).data("url"),
         type: "PATCH",
-        data: $(this).sortable('serialize')
+        data: data
       });
     }
   });
@@ -267,7 +272,6 @@ $(function() {
       });
     }
   });
-
 
   $(".ma-dropdown").on("click", function(event) {
     $(event.target).parent().parent().find(".dropdown-content").toggle();


### PR DESCRIPTION
TP-1081 Drag questions across sections

Works, but UI might be better if we provided a "Move" icon and used it as a drag handle.  It' might be confusing as to what part of the UI is the section and which is individual questions when dragging.