### PR TITLE
queue by ID

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,9 +5,9 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.submission_notification.subject
   #
-  def submission_notification(submission:, emails: [])
+  def submission_notification(submission_id:, emails: [])
     attachments.inline["logo.png"] = @@header_logo
-    @submission = submission
+    @submission = Submission.find(submission_id)
     @form = @submission.form
     admin_emails = ENV.fetch("TOUCHPOINTS_ADMIN_EMAILS").split(",")
     mail subject: "New Submission to #{@form.name}",

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -42,15 +42,14 @@ class Submission < ApplicationRecord
     Event.log_event(Event.names[:touchpoint_form_submitted], 'Submission', self.id, "Submission received for organization '#{self.organization_name}' form '#{self.form.name}' ")
     return unless ENV["ENABLE_EMAIL_NOTIFICATIONS"] == "true"
     return unless self.form.send_notifications?
-    return unless self.form.notification_emails?
     emails_to_notify = self.form.notification_emails.split(",")
 
     # Add Form Manager(s) to notification distribution list
-    self.form.users.select { | u | self.form.user_role?(user: u) == UserRole::Role::FormManager }.each do |mgr|
+    self.form.users.select { |u| self.form.user_role?(user: u) == UserRole::Role::FormManager }.each do |mgr|
       emails_to_notify << mgr.email
     end
 
-    UserMailer.submission_notification(submission: self, emails: emails_to_notify.uniq).deliver_later
+    UserMailer.submission_notification(submission_id: self.id, emails: emails_to_notify.uniq).deliver_later
   end
 
   def to_rows

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UserMailer, type: :mailer do
     let(:user) { FactoryBot.create(:user, organization: organization) }
     let(:form) { FactoryBot.create(:form, organization: organization, user: user)}
     let!(:submission) { FactoryBot.create(:submission, form: form) }
-    let(:mail) { UserMailer.submission_notification(submission: submission, emails: [user.email]) }
+    let(:mail) { UserMailer.submission_notification(submission_id: submission.id, emails: [user.email]) }
 
     it "renders the headers" do
       expect(mail.subject).to eq("New Submission to #{submission.form.name}")


### PR DESCRIPTION
re-lookup the object for the queued job, rather than passing the object as an arg