### PR TITLE
TP-1111 Allow custom input when checkbox option is other

### DIFF
--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -88,16 +88,15 @@
   </div>
 </form>
 <script>
-  // Set other type checkbox option values as associated option text field is updated
+  // Set 'other' type checkbox option values when associated option text field is updated
   $('.usa-input.other-option').keyup(function() {
     // strip commas
     var val = $(this).val().replace(/,/g, '');
-    // if user has cleared custom text, then reset cb value to "other"
-    if (val == '') val = 'other';
+    // if user has cleared custom text, then reset checkbox value to "other"
+    if (val == '') { val = 'other'; }
     // set the value of the checkbox option to the custom text as entered
-    var option_selector = "#" + $(this).attr("cb_id");
+    var option_selector = "#" + $(this).attr("data-checkbox-id");
     $(option_selector).prop('checked',true);
     $(option_selector).val(val);
   });
 </script>
-

--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -87,3 +87,17 @@
     <% end %>
   </div>
 </form>
+<script>
+  // Set other type checkbox option values as associated option text field is updated
+  $('.usa-input.other-option').keyup(function() {
+    // strip commas
+    var val = $(this).val().replace(/,/g, '');
+    // if user has cleared custom text, then reset cb value to "other"
+    if (val == '') val = 'other';
+    // set the value of the checkbox option to the custom text as entered
+    var option_selector = "#" + $(this).attr("cb_id");
+    $(option_selector).prop('checked',true);
+    $(option_selector).val(val);
+  });
+</script>
+

--- a/app/views/components/forms/question_types/_checkbox.html.erb
+++ b/app/views/components/forms/question_types/_checkbox.html.erb
@@ -10,8 +10,8 @@
       <%= label_tag(nil, for: "#{question.answer_field}_#{(index + 1).to_s}", class: "usa-checkbox__label") do %>
         <%= option.text %>
       <% end %>
-      <% if option.text.upcase == "OTHER" %>
-        <input type="text" name="<%= question.answer_field %>_other" id="<%= question.answer_field %>_other" cb_id="<%= @option_id %>" placeholder="Enter other text" class="usa-input other-option" />
+      <% if ["OTHER", "OTRO"].include?(option.text.upcase) %>
+        <input type="text" name="<%= question.answer_field %>_other" id="<%= question.answer_field %>_other" data-checkbox-id="<%= @option_id %>" placeholder="Enter other text" class="usa-input other-option" />
         <br/>
       <% end %>
     </div>

--- a/app/views/components/forms/question_types/_checkbox.html.erb
+++ b/app/views/components/forms/question_types/_checkbox.html.erb
@@ -18,16 +18,3 @@
     <% end %>
   </div>
 </fieldset>
-<script>
-  // Set radio option value as option text field is updated
-  $('.other-option').keyup(function() {
-    // strip commas
-    var val = $(this).val().replace(/,/g, '');
-    // if user has cleared custom text, then reset cb value to "other"
-    if (val == '') val = 'other';
-    // set the value of the checkbox option to the custom text as entered
-    var option_selector = "#" + $(this).attr("cb_id");
-    $(option_selector).prop('checked',true);
-    $(option_selector).val(val);
-  });
-</script>

--- a/app/views/components/forms/question_types/_checkbox.html.erb
+++ b/app/views/components/forms/question_types/_checkbox.html.erb
@@ -5,11 +5,29 @@
   <div class="question-options">
     <% question.question_options.each_with_index do |option, index| %>
     <div class="usa-checkbox">
-      <%= check_box_tag("#{question.answer_field}_#{(index + 1).to_s}", index + 1, nil, { name: question.answer_field, multiple: true, value: option.text , class: "usa-checkbox__input", required: question.is_required  }) %>
+      <% @option_id = "#{question.answer_field}_#{(index + 1).to_s}" %>
+      <%= check_box_tag("#{@option_id}", index + 1, nil, { name: question.answer_field, multiple: true, value: option.text , class: "usa-checkbox__input", required: question.is_required  }) %>
       <%= label_tag(nil, for: "#{question.answer_field}_#{(index + 1).to_s}", class: "usa-checkbox__label") do %>
         <%= option.text %>
+      <% end %>
+      <% if option.text.upcase == "OTHER" %>
+        <input type="text" name="<%= question.answer_field %>_other" id="<%= question.answer_field %>_other" cb_id="<%= @option_id %>" placeholder="Enter other text" class="usa-input other-option" />
+        <br/>
       <% end %>
     </div>
     <% end %>
   </div>
 </fieldset>
+<script>
+  // Set radio option value as option text field is updated
+  $('.other-option').keyup(function() {
+    // strip commas
+    var val = $(this).val().replace(/,/g, '');
+    // if user has cleared custom text, then reset cb value to "other"
+    if (val == '') val = 'other';
+    // set the value of the checkbox option to the custom text as entered
+    var option_selector = "#" + $(this).attr("cb_id");
+    $(option_selector).prop('checked',true);
+    $(option_selector).val(val);
+  });
+</script>

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -62,6 +62,46 @@ feature "Touchpoints", js: true do
         expect(Submission.last.answer_03).to eq "One,Two,Three,Four"
       end
 
+      context "with an question option of 'other'" do
+        before do
+          checkbox_form.questions.first.question_options.create!(text: "other", position: 5)
+          checkbox_form.questions.first.question_options.create!(text: "otro", position: 6)
+          visit touchpoint_path(checkbox_form)
+        end
+
+        context "default 'other' value" do
+          before do
+            all('.usa-checkbox__label').each do |checkbox_label|
+              checkbox_label.click
+            end
+            click_on "Submit"
+          end
+
+          it "persists 'other' checkbox question default values to db as comma separated list" do
+            expect(page).to have_content("Thank you. Your feedback has been received.")
+            expect(Submission.last.answer_03).to eq "One,Two,Three,Four,other,otro"
+          end
+        end
+
+        context "user-entered 'other' value" do
+          before do
+            all('.usa-checkbox__label').each do |checkbox_label|
+              checkbox_label.click
+            end
+
+            inputs = find_all("input")
+            inputs.first.set("hi")
+            inputs.last.set("bye")
+            click_on "Submit"
+          end
+
+          it "persists 'other' checkbox question custom values to db as comma separated list" do
+            expect(page).to have_content("Thank you. Your feedback has been received.")
+            expect(Submission.last.answer_03).to eq "One,Two,Three,Four,hi,bye"
+          end
+        end
+      end
+
     end
 
     describe "required question" do


### PR DESCRIPTION
TP-1111 Allow custom input when checkbox option is other

1st pass least intrusive implementation

If an admin user creates a checkbox option with text == other ( case insensitive ), then when that checkbox option is rendered on a submission form it will be accompanied by a text field.

As the user enters their custom option text into the text field , the checkbox is checked and the checkbox value is set to whatever the user types into the text field.

If the user clears the text field, the checkbox option value is reset to "other"

When the form is submitted, the value tied to the checkbox question will be what the user has entered.

Have also stripped commas from the custom user input so we don't confuse the custom text with multiple checkbox values on the backend.

