### PR TITLE
internationalize yes/no buttons

### DIFF
--- a/app/views/components/forms/question_types/_yes_no_buttons.html.erb
+++ b/app/views/components/forms/question_types/_yes_no_buttons.html.erb
@@ -4,7 +4,7 @@
   </label>
   <p class="submit-button">
     <input type="hidden" class="fba-touchpoints-page-form" name="<%= question.answer_field.to_sym %>" value="">
-    <input type="submit" class="usa-button" value="yes">
-    <input type="submit" class="usa-button" value="no">
+    <input type="submit" class="usa-button" value="<%= t 'yes' %>">
+    <input type="submit" class="usa-button" value="<%= t 'no' %>">
   </p>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="<%= locale %>">
   <head>
     <title>
       Touchpoints

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="<%= locale %>">
   <head>
     <title>
       Touchpoints

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -1,34 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en-US:
   touchpoint: "Touchpoint"
   touchpoints: "Touchpoints"
@@ -41,6 +10,8 @@ en-US:
   or: "or"
   success: "Success"
   error: "Error"
+  "yes": "yes"
+  "no": "no"
   the_feedback_and_analytics_team: " the Feedback and Analytics Team"
   form:
     submit: "Submit"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -10,6 +10,8 @@ es:
   or: "o"
   success: "Éxito"
   error: "Error"
+  "yes": "sí"
+  "no": "no"
   the_feedback_and_analytics_team: " el equipo de retroalimentación y análisis"
   form:
     submit: "Enviar"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -30,6 +30,8 @@ zh-CN:
   or: "要么"
   success: "成功"
   error: "错误"
+  "yes": "是的"
+  "no": "不"
   the_feedback_and_analytics_team: " 反馈和分析团队"
   form:
     submit: "提交"


### PR DESCRIPTION
If translations are stored in YAML files, certain keys must be escaped. They are:

true, on, yes
false, off, no

https://guides.rubyonrails.org/i18n.html