### PR TITLE
TP-1142 add response_count, last_response_created_at to form, update …

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -46,8 +46,9 @@ class SubmissionsController < ApplicationController
     @submission.referer = submission_params[:referer]
     @submission.page = submission_params[:page]
     @submission.ip_address = request.remote_ip
-
-    create_in_local_database(@submission)
+    @result = create_in_local_database(@submission)
+    @form.update(response_count: @form.submissions.size, last_response_created_at: @submission.created_at)
+    @result
   end
 
 
@@ -105,7 +106,6 @@ class SubmissionsController < ApplicationController
           @short_uuid = LEGACY_TOUCHPOINTS_URL_MAP[params[:touchpoint_id].to_s]
         end
       end
-
       @form = FormCache.fetch(@short_uuid)
       raise ActiveRecord::RecordNotFound, "no form with ID of #{@short_uuid}" unless @form.present?
     end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -46,9 +46,7 @@ class SubmissionsController < ApplicationController
     @submission.referer = submission_params[:referer]
     @submission.page = submission_params[:page]
     @submission.ip_address = request.remote_ip
-    @result = create_in_local_database(@submission)
-    @form.update(response_count: @form.submissions.size, last_response_created_at: @submission.created_at)
-    @result
+    create_in_local_database(@submission)
   end
 
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,11 +1,12 @@
 class Submission < ApplicationRecord
-  belongs_to :form
+  belongs_to :form, counter_cache: :response_count
 
   validate :validate_custom_form
   validates :uuid, uniqueness: true
 
   before_create :set_uuid
   after_create :send_notifications
+  after_create :update_form
 
   scope :non_flagged, -> { where(flagged: false) }
 
@@ -50,6 +51,10 @@ class Submission < ApplicationRecord
     end
 
     UserMailer.submission_notification(submission_id: self.id, emails: emails_to_notify.uniq).deliver_later
+  end
+
+  def update_form
+    form.update(last_response_created_at: created_at)
   end
 
   def to_rows

--- a/app/views/admin/forms/show.html.erb
+++ b/app/views/admin/forms/show.html.erb
@@ -234,10 +234,18 @@
     <% end %>
     <p>
       <strong>Created on:</strong>
-      <%= @form.created_at.to_date %>
+      <%= @form.created_at.to_date  %>
       <small>
         (<%= time_ago_in_words(@form.created_at) %> ago)
       </small>
     </p>
+  </div>
+  <div>
+    <p>
+      <strong>Number of responses:</strong> <%= @form.response_count %>
+      <% if @form.last_response_created_at.present? %>
+        ( <small>last response created on <%= format_time(@form.last_response_created_at, current_user.time_zone) %></small> )
+      <% end %>
+    <p>
   </div>
 </div>

--- a/app/views/admin/forms/show.html.erb
+++ b/app/views/admin/forms/show.html.erb
@@ -234,7 +234,7 @@
     <% end %>
     <p>
       <strong>Created on:</strong>
-      <%= @form.created_at.to_date  %>
+      <%= @form.created_at.to_date %>
       <small>
         (<%= time_ago_in_words(@form.created_at) %> ago)
       </small>

--- a/app/views/admin/forms/show.html.erb
+++ b/app/views/admin/forms/show.html.erb
@@ -242,7 +242,7 @@
   </div>
   <div>
     <p>
-      <strong>Number of responses:</strong> <%= @form.response_count %>
+      <strong>Number of responses:</strong> <%= @form.submissions.size %>
       <% if @form.last_response_created_at.present? %>
         ( <small>last response created on <%= format_time(@form.last_response_created_at, current_user.time_zone) %></small> )
       <% end %>

--- a/db/migrate/20201130200350_add_fields_to_form.rb
+++ b/db/migrate/20201130200350_add_fields_to_form.rb
@@ -2,5 +2,11 @@ class AddFieldsToForm < ActiveRecord::Migration[5.2]
   def change
     add_column :forms, :response_count, :integer, default: 0
     add_column :forms, :last_response_created_at, :datetime
+
+
+    Form.all.each do |form|
+    	Form.reset_counters(form.id, :submissions)
+		form.update(last_response_created_at: form.submissions.last.created_at) if form.submissions.size > 0
+    end
   end
 end

--- a/db/migrate/20201130200350_add_fields_to_form.rb
+++ b/db/migrate/20201130200350_add_fields_to_form.rb
@@ -1,0 +1,6 @@
+class AddFieldsToForm < ActiveRecord::Migration[5.2]
+  def change
+    add_column :forms, :response_count, :integer, default: 0
+    add_column :forms, :last_response_created_at, :datetime
+  end
+end

--- a/db/migrate/20201130200350_add_fields_to_form.rb
+++ b/db/migrate/20201130200350_add_fields_to_form.rb
@@ -3,10 +3,9 @@ class AddFieldsToForm < ActiveRecord::Migration[5.2]
     add_column :forms, :response_count, :integer, default: 0
     add_column :forms, :last_response_created_at, :datetime
 
-
     Form.all.each do |form|
-    	Form.reset_counters(form.id, :submissions)
-		form.update(last_response_created_at: form.submissions.last.created_at) if form.submissions.size > 0
+      Form.reset_counters(form.id, :submissions)
+      form.update(last_response_created_at: form.submissions.last.created_at) if form.submissions.size > 0
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_11_135309) do
+ActiveRecord::Schema.define(version: 2020_11_30_200350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,8 @@ ActiveRecord::Schema.define(version: 2020_11_11_135309) do
     t.string "logo"
     t.string "occasion"
     t.string "time_zone", default: "Eastern Time (US & Canada)"
+    t.integer "response_count", default: 0
+    t.datetime "last_response_created_at"
     t.index ["legacy_touchpoint_id"], name: "index_forms_on_legacy_touchpoint_id"
     t.index ["legacy_touchpoint_uuid"], name: "index_forms_on_legacy_touchpoint_uuid"
     t.index ["uuid"], name: "index_forms_on_uuid"

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -88,6 +88,13 @@ RSpec.describe SubmissionsController, type: :controller do
         }.to change(Submission, :count).by(1)
       end
 
+      it "updates the form response_count and last_response_created_at" do
+        post :create, params: {submission: valid_attributes, form_id: form.short_uuid }, session: valid_session
+        form.reload
+        expect(form.response_count).to be > 0
+        expect(form.last_response_created_at).not_to be nil
+      end
+
       it "redirects to the created submission" do
         post :create, params: { submission: valid_attributes, form_id: form.short_uuid }, session: valid_session
         expect(response).to redirect_to(submit_touchpoint_path(form))


### PR DESCRIPTION
P-1142 add response_count, last_response_created_at to form, update on submission create

These fields will be set appropriately whenever a submission is created, however we could create a rake task to update all existing surveys that may no longer be active