### PR TITLE
TP-1170 cancelling out of create question option form hides the form

### DIFF
--- a/app/views/admin/question_options/new.html.erb
+++ b/app/views/admin/question_options/new.html.erb
@@ -12,6 +12,7 @@
 <script>
   $('.question-option-cancel').on("click", function(event) {
     event.preventDefault();
-    $(this).closest('div.new-question-options-div').find('.question-option-edit').hide();
+    $(this).closest('div.new-question-options-div').find('.question-option-form').hide();
+    $(this).closest('div.new-question-options-div').find('.form-add-question-option').show();
   });
 </script>

--- a/app/views/admin/question_options/new.html.erb
+++ b/app/views/admin/question_options/new.html.erb
@@ -7,5 +7,11 @@
   </p>
 
   <%= render 'form', form: @question.form, question: @question, question_option: @question_option %>
-  <%= link_to 'Cancel', questions_admin_form_path(@question.form) %>
+  <%= link_to 'Cancel', questions_admin_form_path(@question.form), class: "question-option-cancel" %>
 </div>
+<script>
+  $('.question-option-cancel').on("click", function(event) {
+    event.preventDefault();
+    $(this).closest('div.new-question-options-div').find('.question-option-edit').hide();
+  });
+</script>

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -335,13 +335,14 @@ $(function() {
 
   $('.form-add-question-option').on("click", function(event) {
     event.preventDefault();
-    var contentDiv =  $(this).closest('div.new-question-options-div');
+    var editDiv =  $(this).closest('div.new-question-options-div').find('.question-option-edit');
     $.ajax({
       type: "GET",
       url: $(this).attr("href"),
       success: function (data) {
-        contentDiv.html(data);
-        contentDiv.find("#question_option_text").focus();
+        editDiv.html(data);
+        $(editDiv).show();
+        editDiv.find("#question_option_text").focus();
       }
     });
   });

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -335,7 +335,8 @@ $(function() {
 
   $('.form-add-question-option').on("click", function(event) {
     event.preventDefault();
-    var editDiv =  $(this).closest('div.new-question-options-div').find('.question-option-edit');
+    $(this).closest('div.new-question-options-div').find('.form-add-question-option').hide();
+    var editDiv =  $(this).closest('div.new-question-options-div').find('.question-option-form');
     $.ajax({
       type: "GET",
       url: $(this).attr("href"),

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -221,7 +221,7 @@ $(function() {
     }
   });
 
-  $(".form-delete-question-option").on("click", function(event) {
+  $(".form-builder").on("click", ".form-delete-question-option", function(event) {
     event.preventDefault();
     if (confirm('Are you sure?')) {
       $(this).closest('div.question-option').remove();

--- a/app/views/components/forms/edit/question_types/_checkbox.html.erb
+++ b/app/views/components/forms/edit/question_types/_checkbox.html.erb
@@ -8,8 +8,10 @@
   </div>
 </fieldset>
 <div class="new-question-options-div">
+  <div class="question-option-edit"></div>
   <%= link_to new_admin_form_question_question_option_path(question.form, question), class: "usa-button usa-button--outline form-add-question-option" do %>
     <i class="fa fa-plus"></i>
     Add Checkbox Option
   <% end %>
+
 </div>

--- a/app/views/components/forms/edit/question_types/_checkbox.html.erb
+++ b/app/views/components/forms/edit/question_types/_checkbox.html.erb
@@ -8,10 +8,9 @@
   </div>
 </fieldset>
 <div class="new-question-options-div">
-  <div class="question-option-edit"></div>
+  <div class="question-option-form"></div>
   <%= link_to new_admin_form_question_question_option_path(question.form, question), class: "usa-button usa-button--outline form-add-question-option" do %>
     <i class="fa fa-plus"></i>
     Add Checkbox Option
   <% end %>
-
 </div>

--- a/app/views/components/forms/edit/question_types/_dropdown.html.erb
+++ b/app/views/components/forms/edit/question_types/_dropdown.html.erb
@@ -10,6 +10,7 @@
   </div>
 </div>
 <div class="new-question-options-div">
+  <div class="question-option-form"></div>
   <%= link_to new_admin_form_question_question_option_path(question.form, question), class: "usa-button usa-button--outline form-add-question-option" do %>
     <i class="fa fa-plus"></i>
     Add Dropdown Option

--- a/app/views/components/forms/edit/question_types/_radio_buttons.html.erb
+++ b/app/views/components/forms/edit/question_types/_radio_buttons.html.erb
@@ -8,6 +8,7 @@
   </div>
 </fieldset>
 <div class="new-question-options-div">
+  <div class="question-option-form"></div>
   <%= link_to new_admin_form_question_question_option_path(question.form, question), class: "usa-button usa-button--outline form-add-question-option" do %>
     <i class="fa fa-plus"></i>
     Add Radio Button Option

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -560,6 +560,14 @@ feature "Forms", js: true do
               expect(page).to have_content("Question was successfully created.")
               expect(page).to have_link("Add Checkbox Option")
             end
+
+            it "can cancel a Checkbox Question" do
+              click_on "Add Checkbox Option"
+              expect(page).to have_content("New Question Option")
+              click_on "Cancel"
+              expect(page.current_path).to eq(admin_form_questions_path(form))
+              expect(page).not_to have_content("New Question Option")
+            end
           end
 
           describe "answer display" do
@@ -651,6 +659,13 @@ feature "Forms", js: true do
                   end
                   expect(page).to have_content("Edited Question Option Text (100)")
                 end
+
+                it "can cancel a Dropdown Question option" do
+                  expect(page).to have_content("New Question Option")
+                  click_on "Cancel"
+                  expect(page.current_path).to eq(admin_form_questions_path(form))
+                  expect(page).not_to have_content("New Question Option")
+                end
               end
             end
           end
@@ -725,6 +740,13 @@ feature "Forms", js: true do
               within ".form-builder .question-options .question-option[data-id='#{QuestionOption.last.id}']" do
                 expect(all("label").last).to have_content("New Test Radio Option")
               end
+            end
+
+            it "can cancel a Radio Button question" do
+              expect(page).to have_content("New Question Option")
+              click_on "Cancel"
+              expect(page.current_path).to eq(admin_form_questions_path(form))
+              expect(page).not_to have_content("New Question Option")
             end
           end
 


### PR DESCRIPTION
TP-1170 Cancelling out of create question option form simply hides the form rather than refreshing the entire page