### PR TITLE
Form Manager can add a hidden field

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,8 @@ module ApplicationHelper
   def question_type_javascript_params(question)
     if question.question_type == "text_field"
       "form.querySelector(\"##{question.answer_field}\") && form.querySelector(\"##{question.answer_field}\").value"
+    elsif question.question_type == "hidden"
+      "form.querySelector(\"##{question.answer_field}\") && form.querySelector(\"##{question.answer_field}\").value"
     elsif question.question_type == "text_email_field"
       "form.querySelector(\"##{question.answer_field}\") && form.querySelector(\"##{question.answer_field}\").value"
     elsif question.question_type == "textarea"

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -19,6 +19,7 @@ class Question < ApplicationRecord
     "checkbox",
     "radio_buttons",
     "dropdown",
+    "hidden",
     # Custom elements
     "text_display",
     "custom_text_display",

--- a/app/views/admin/questions/update.html.erb
+++ b/app/views/admin/questions/update.html.erb
@@ -16,6 +16,8 @@
 <% @form_component_path = 'components/forms/edit/question_types/checkbox' %>
 <% elsif @question.question_type == "textarea" %>
 <% @form_component_path = 'components/forms/edit/question_types/text_area' %>
+<% elsif @question.question_type == "hidden" %>
+<% @form_component_path = 'components/forms/edit/question_types/hidden_field' %>
 <% elsif @question.question_type == "custom_text_display" %>
 <% @form_component_path = 'components/forms/question_types/custom_text_display' %>
 <% elsif @question.question_type == "star_radio_buttons" %>

--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -12,6 +12,7 @@
               <%= link_to (t 'form.back'), "#previous-page", class: "usa-button previous-section", 'data-form-section-target' => "" %>
             <% end %>
           </div>
+          <br>
         <% end %>
 
         <% if section.title.present? -%>
@@ -25,12 +26,13 @@
         <div class="questions">
           <% section.questions.each_with_index do |question, index| %>
           <%
-            # Don't increment question numbers for display text
-            if !["text_display", "custom_text_display"].include?(question.question_type)
+            # Don't increment question numbers for these type of questions
+            if !["text_display", "custom_text_display", "hidden"].include?(question.question_type)
               multi_section_question_number += 1
             end
           %>
 
+        <% if question.question_type != "hidden" %>
           <div class="question white-bg">
             <% if question.question_type == "text_field" %>
               <%= render 'components/forms/question_types/text_field', form: form, question: question, question_number: multi_section_question_number %>
@@ -58,7 +60,10 @@
               <%= render 'components/forms/question_types/custom_text_display', form: form, question: question, question_number: multi_section_question_number %>
             <% end %>
           </div>
+          <% else %>
+            <%= render 'components/forms/question_types/hidden_field', form: form, question: question, question_number: multi_section_question_number %>
           <% end %>
+        <% end %>
         </div>
 
         <% if (section != form.form_sections.first) || (section != form.form_sections.last) %>

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -61,6 +61,8 @@
                 <% @form_component_path = 'components/forms/edit/question_types/checkbox' %>
               <% elsif question.question_type == "textarea" %>
                 <% @form_component_path = 'components/forms/edit/question_types/text_area' %>
+              <% elsif question.question_type == "hidden" %>
+                <% @form_component_path = 'components/forms/edit/question_types/hidden_field' %>
               <% elsif question.question_type == "custom_text_display" %>
                 <% @form_component_path = 'components/forms/question_types/custom_text_display' %>
               <% elsif question.question_type == "star_radio_buttons" %>

--- a/app/views/components/forms/edit/question_types/_hidden_field.html.erb
+++ b/app/views/components/forms/edit/question_types/_hidden_field.html.erb
@@ -1,0 +1,4 @@
+<div class="radios" role="group" aria-labelledby="<%= question.answer_field %>">
+  <%= render 'components/question_title', question: question, form_builder: true %>
+  <%= text_field_tag question.answer_field.to_sym, nil, class: "usa-input", placeholder: question.text %>
+</div>

--- a/app/views/components/forms/question_types/_hidden_field.html.erb
+++ b/app/views/components/forms/question_types/_hidden_field.html.erb
@@ -1,0 +1,1 @@
+<%= hidden_field_tag question.answer_field.to_sym, question.text %>

--- a/db/seeds/forms/kitchen_sink.rb
+++ b/db/seeds/forms/kitchen_sink.rb
@@ -191,6 +191,16 @@ module Seeds
         is_required: false
       })
 
+      Question.create!({
+        form: custom_form,
+        form_section: custom_elements_section,
+        text: "hidden value",
+        question_type: "hidden",
+        position: 11,
+        answer_field: :answer_11,
+        is_required: false
+      })
+
       custom_form
     end
   end


### PR DESCRIPTION
* the value of the hidden field is currently the question text.
* example: this field can be defaulted to "Fiscal Year" or "Quarter"