### PR TITLE
TP-1201 fix error thrown when a question option text has not value

### DIFF
--- a/app/controllers/admin/question_options_controller.rb
+++ b/app/controllers/admin/question_options_controller.rb
@@ -51,7 +51,7 @@ class Admin::QuestionOptionsController < AdminController
           @question_options << question_option
           position += 1
         else
-          @errors << question_option.errors
+          @errors << question_option.errors.full_messages
         end
       end
     else
@@ -64,14 +64,19 @@ class Admin::QuestionOptionsController < AdminController
         if question_option.save
           @question_options << question_option
         else
-          @errors << question_option.errors + "\n" unless result
+          @errors << question_option.errors.full_messages
         end
       end
     end
 
     respond_to do |format|
-      format.html { redirect_to questions_admin_form_path(@question.form), notice: 'Question option was successfully created.' }
-      format.js { }
+      if @errors.empty?
+        format.html { redirect_to questions_admin_form_path(@question.form), notice: 'Question option was successfully created.' }
+        format.js { }
+      else
+        format.html { redirect_to questions_admin_form_path(@question.form), alert: "Question option could not be created! #{@errors.join(', ')}" }
+        format.js { render json: @errors, status: :unprocessable_entity }        
+      end
     end
   end
 

--- a/app/views/admin/question_options/_form.html.erb
+++ b/app/views/admin/question_options/_form.html.erb
@@ -15,7 +15,7 @@
 
   <div class="field">
     <%= form.label :text, class: "usa-label" %>
-    <%= form.text_area :text, class: "usa-input", rows: 5 %>
+    <%= form.text_area :text, class: "usa-input question-option-text", rows: 5 %>
   </div>
 
   <div class="field">
@@ -24,7 +24,7 @@
   </div>
 
   <p>
-    <%= form.submit class: "usa-button" %>
+    <%= form.submit class: "usa-button question-option-save" %>
 
   <% if question_option.persisted? %>
     <%= link_to admin_form_question_question_option_path(form, question, question_option), class: "usa-button bg-red float-right", method: :delete, data: { confirm: 'Are you sure?' } do %>
@@ -34,3 +34,12 @@
   <% end %>
   </p>
 <% end %>
+<script>
+  $('.question-option-save').on("click", function(event) {
+      var text_value = $.trim($('.question-option-text').val())
+      if (text_value.length == 0) {
+        alert("Please enter a value for question option text!");
+        return false;
+      }
+  }); 
+</script> 

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -713,6 +713,14 @@ feature "Forms", js: true do
                   expect(page).to have_content("Edited Question Option Text (100)")
                 end
 
+                it "will prevent updating a question option with no text" do
+                  click_on "Add Dropdown Option"
+                  expect(page).to have_content("New Question Option")
+                  click_on "Create Question option"
+                  page.driver.browser.switch_to.alert.accept
+                  expect(page).to have_button("Create Question option")
+                end  
+
                 it "can cancel a Dropdown Question option" do
                   click_on "Add Dropdown Option"
                   expect(page).to have_content("New Question Option")


### PR DESCRIPTION
TP-1201 fix error thrown when a question option text has not value

Linked Trello ticket: https://trello.com/c/FniByxWM/1201-app-throws-error-if-try-to-save-question-option-without-value

Fixed back end to return the appropriate error messages on validation failure.  Added front end validation to prevent submitting an empty question option text value.

