### PR TITLE
TP-1204 change survey and section title fields to be inputs and fix test cases

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -506,3 +506,14 @@ span.usa-hint.save-notice {
     padding-top: 1px;
   }
 }
+
+.survey-title-input, .section-title {
+  width: 400px;
+  border-radius: 4px;
+  border: 1px solid;
+  padding-bottom: 4px;
+  padding-left: 10px;
+  padding-right: 4px;
+  padding-top: 4px;  
+  margin-top: 0px;
+}

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -432,6 +432,16 @@ tbody tr:hover td {
   margin-block-end: 0em;
   color: #FFFFFF;
 }
+.form-builder {
+  .section {
+    border-bottom: 2px solid white;
+    padding-bottom: 20px;
+  }
+  .section-title-view {
+    padding-top: 0px ;
+  }
+
+}
 a.form-section-save {
   color: white;
 }
@@ -505,11 +515,4 @@ span.usa-hint.save-notice {
     padding-right: 20px;
     padding-top: 1px;
   }
-}
-
-.survey-title-input, .section-title {
-  width: 400px;
-  border-radius: 4px;
-  border: 1px solid;
-  margin-top: 0px;
 }

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -511,9 +511,5 @@ span.usa-hint.save-notice {
   width: 400px;
   border-radius: 4px;
   border: 1px solid;
-  padding-bottom: 4px;
-  padding-left: 10px;
-  padding-right: 4px;
-  padding-top: 4px;  
   margin-top: 0px;
 }

--- a/app/views/admin/form_sections/_view.html.erb
+++ b/app/views/admin/form_sections/_view.html.erb
@@ -2,7 +2,7 @@
   <div class="section">
     <div class="section-header">
       <h4 class="section-title-view">
-        <input class="usa-label section-title" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_form_section_path(form, section) %>" value="<%= section.title %>" />
+        <input class="usa-input section-title" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_form_section_path(form, section) %>" value="<%= section.title %>" />
         &nbsp;&nbsp;
         <span class="usa-hint save-notice" id="section-<%= section.id %>">
           <i class="fa fa-check-circle" aria-hidden="true"></i> section title saved

--- a/app/views/admin/form_sections/_view.html.erb
+++ b/app/views/admin/form_sections/_view.html.erb
@@ -2,7 +2,7 @@
   <div class="section">
     <div class="section-header">
       <h4 class="section-title-view">
-        <span class="section-title" contenteditable="true" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_form_section_path(form, section) %>"><%= section.title %></span>
+        <input class="usa-label section-title" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_form_section_path(form, section) %>" value="<%= section.title %>" />
         &nbsp;&nbsp;
         <span class="usa-hint save-notice" id="section-<%= section.id %>">
           <i class="fa fa-check-circle" aria-hidden="true"></i> section title saved
@@ -36,7 +36,7 @@
         type: "PATCH",
         url:  $(this).attr("data-url") + "/update_title",
         data: {
-          title: $(this).text()
+          title: $(this).val()
         }
       }).done(function(data) {
         $("#section-" + data['id']).show();

--- a/app/views/admin/form_sections/_view.html.erb
+++ b/app/views/admin/form_sections/_view.html.erb
@@ -1,13 +1,16 @@
 <div class="form-section-div" id="<%= dom_id(section) %>" data-id="<%= section.id %>">
   <div class="section">
     <div class="section-header">
-      <h4 class="section-title-view">
+      <div class="section-title-view">
+        <label class="usa-label text-uppercase font-body-3xs" style="margin-top: 0;" for="instructions">
+          Form section title
+        </label>
         <input class="usa-input section-title" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_form_section_path(form, section) %>" value="<%= section.title %>" />
         &nbsp;&nbsp;
         <span class="usa-hint save-notice" id="section-<%= section.id %>">
           <i class="fa fa-check-circle" aria-hidden="true"></i> section title saved
         </span>
-      </h4>
+      </div>
     </div>
     <div class="questions">
       <% section.questions.each_with_index do |question, index| %>
@@ -42,11 +45,5 @@
         $("#section-" + data['id']).show();
         $("#section-" + data['id']).fadeOut(2000);
       });
-    });
-    $(".section-title").click(function() {
-      $(this).focus();
-    });
-    $(".section-title-view").click(function() {
-      $(this).find(".section-title").focus();
     });
 </script>

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -1,14 +1,12 @@
 <% @tabindex = 0 %>
 <div class="form-title-edit">
-  <h2>
-    <span type="text" contenteditable="true" tabindex="<%= @tabindex += 1 %>" class="survey-title-input" data-url="<%= admin_form_path(form) %>">
-      <%= form.title.present? ? form.title : 'Survey Title'  %>
-    </span>
+    <input type="text" tabindex="<%= @tabindex += 1 %>" class="usa-label survey-title-input" 
+      data-url="<%= admin_form_path(form) %>"
+      value="<%= form.title.present? ? form.title : 'Survey Title'  %>" />
     &nbsp;&nbsp;
     <span class="usa-hint save-notice survey-title">
       <i class="fa fa-check-circle" aria-hidden="true"></i> survey title saved
     </span>
-  </h2>
 </div>
 <div class="fba-instructions">
   Instructions:
@@ -68,7 +66,7 @@ $(function() {
       $.ajax({
         type: "PATCH",
         url: $(this).attr("data-url") + "/update_title",
-        data: {title: $(this).text()}
+        data: {title: $(this).val()}
       });
     });
 

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -1,6 +1,6 @@
 <% @tabindex = 0 %>
 <div class="form-title-edit">
-    <input type="text" tabindex="<%= @tabindex += 1 %>" class="usa-label survey-title-input" 
+    <input type="text" tabindex="<%= @tabindex += 1 %>" class="usa-input survey-title-input"
       data-url="<%= admin_form_path(form) %>"
       value="<%= form.title.present? ? form.title : 'Survey Title'  %>" />
     &nbsp;&nbsp;

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -1,25 +1,28 @@
 <% @tabindex = 0 %>
 <div class="form-title-edit">
-    <input type="text" tabindex="<%= @tabindex += 1 %>" class="usa-input survey-title-input"
-      data-url="<%= admin_form_path(form) %>"
-      value="<%= form.title.present? ? form.title : 'Survey Title'  %>" />
-    &nbsp;&nbsp;
-    <span class="usa-hint save-notice survey-title">
-      <i class="fa fa-check-circle" aria-hidden="true"></i> survey title saved
-    </span>
+  <div class="text-uppercase font-body-3xs">
+    Form title
+  </div>
+  <input type="text" tabindex="<%= @tabindex += 1 %>" class="usa-input survey-title-input"
+    data-url="<%= admin_form_path(form) %>"
+    value="<%= form.title.present? ? form.title : 'Survey Title'  %>" />
+  <span class="usa-hint save-notice survey-title">
+    <i class="fa fa-check-circle" aria-hidden="true"></i> survey title saved
+  </span>
 </div>
 <div class="fba-instructions">
-  Instructions:
-  <br>
-  <textarea class="instructions" name="instructions" rows="8" cols="80" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_path(form) %>"><%= form.instructions %></textarea>
+  <label class="usa-label text-uppercase font-body-3xs" for="instructions">
+    Instructions
+  </label>
+  <textarea class="usa-textarea instructions" name="instructions" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_path(form) %>"><%= form.instructions %></textarea>
   <span class="usa-hint save-notice survey-instructions">
     <i class="fa fa-check-circle" aria-hidden="true"></i> saved
   </span>
   <br>
   <span class="display-inline instructions-show">
-    <%= form.instructions.present? ? sanitize(form.instructions) : 'Survey Instructions' %>
+    <%= form.instructions.present? ? sanitize(form.instructions) : 'Preview instructions here' %>
   </span>
-  &nbsp;&nbsp;
+  &nbsp;
 </div>
 <br>
 
@@ -39,9 +42,12 @@
 <div class="grid-row">
   <div class="grid-col-12">
     <div class="touchpoints-form-disclaimer">
+      <label class="usa-label text-uppercase font-body-3xs" for="disclaimer-text">
+        Disclaimer text
+      </label>
       <small id="fba-dialog-privacy">
         <p class="fba-disclaimer-text">
-          <textarea id="disclaimer_text" name="disclaimer-text" rows="8" cols="80" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_path(form) %>"><%= form.disclaimer_text %></textarea>
+          <textarea id="disclaimer_text" class="usa-textarea" name="disclaimer-text" tabindex="<%= @tabindex += 1 %>" data-url="<%= admin_form_path(form) %>"><%= form.disclaimer_text %></textarea>
           <span class="usa-hint save-notice survey-disclaimer">
             <i class="fa fa-check-circle" aria-hidden="true"></i> saved
           </span>

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -401,13 +401,13 @@ feature "Forms", js: true do
           describe "adding Form Sections" do
             before do
               visit questions_admin_form_path(form)
+              click_on "Add Section"
+              find_all(".section-title").last.native.send_keys :tab
             end
 
             it "displays /admin/forms/:id/form_sections/new" do
-              click_on "Add Section"
               expect(find_all(".section-title").last.value).to eq("New Section")
             end
-
           end
 
           describe "editing Form Sections" do

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -222,7 +222,7 @@ feature "Forms", js: true do
               expect(page).to have_content("survey title saved")
               # and persists after refresh
               visit questions_admin_form_path(form)
-              expect(find(".survey-title-input")).to have_content("Updated Form Title")
+              expect(find(".survey-title-input").value).to eq("Updated Form Title")
             end
 
             it "has inline editable instructions textbox that can be updated and saved" do
@@ -401,19 +401,13 @@ feature "Forms", js: true do
           describe "adding Form Sections" do
             before do
               visit questions_admin_form_path(form)
-              click_on "Add Section"
             end
 
             it "displays /admin/forms/:id/form_sections/new" do
-              expect(page).to have_content("New Section")
+              click_on "Add Section"
+              expect(find_all(".section-title").last.value).to eq("New Section")
             end
 
-            it "can edit new form section title" do
-              find('.section-title',text: 'New Section').click
-              find('.section-title',text: 'New Section').set("New Form Section Title")
-              find('.section-title',text: 'New Form Section Title').native.send_keys :tab
-              expect(page).to have_content("New Form Section Title")
-            end
           end
 
           describe "editing Form Sections" do
@@ -422,19 +416,16 @@ feature "Forms", js: true do
             end
 
             describe "FormSection.title" do
-              before do
-                find(".section-title").click
-              end
 
               it "displays editable input that can be updated and saved" do
-                expect(find(".section-title").text).to eq("Page 1")
-                find(".section-title").set("New Form Section Title")
+                expect(find(".section-title").value).to eq("Page 1")
+                find(".section-title").fill_in with: "New Form Section Title"
                 find(".section-title").native.send_keys :tab
 
-                expect(find(".section-title").text).to eq("New Form Section Title")
+                expect(find(".section-title").value).to eq("New Form Section Title")
                 # and persists after refresh
                 visit questions_admin_form_path(form)
-                expect(find(".section-title").text).to eq("New Form Section Title")
+                expect(find(".section-title").value).to eq("New Form Section Title")
               end
             end
           end
@@ -1142,7 +1133,7 @@ feature "Forms", js: true do
           it "redirect to /admin/forms/:id/edit with a success flash message" do
             expect(page.current_path).to eq(questions_admin_form_path(form_section2.form))
             expect(page).to have_content("Form section was successfully updated.")
-            expect(page).to have_content(new_title)
+            expect(find_all(".section-title").last.value).to eq(new_title)
           end
         end
 


### PR DESCRIPTION
TP-1204 change survey and section title fields to be inputs and fix test cases

Linked Trello ticket:  https://trello.com/c/Tp6Sb4uw/1204-reinstate-input-text-field-instead-of-content-editable-on-form-title-and-form-section-in-the-builder