### PR TITLE
TP-1205 Add email front end validation as well as tests

### DIFF
--- a/app/views/components/forms/question_types/_text_email_field.html.erb
+++ b/app/views/components/forms/question_types/_text_email_field.html.erb
@@ -9,3 +9,17 @@
     <%= text_field_tag question.answer_field.to_sym, nil, type: :email, class: "usa-input", required: question.is_required, maxlength: question.max_length %>
   <% end %>
 </div>
+<script>
+	$('#<%= question.answer_field.to_sym %>').blur(function() {
+		var EmailRegex = /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+		var email = $.trim($(this).val());
+		if (email.length == 0) return;
+		result = EmailRegex.test(email);
+		if (!result) {
+			alert('Please enter a valid email address');
+			$(this).val("");
+			$(this).focus();
+		}
+	});
+</script>
+

--- a/app/views/components/forms/question_types/_text_email_field.html.erb
+++ b/app/views/components/forms/question_types/_text_email_field.html.erb
@@ -1,13 +1,6 @@
 <div class="radios" role="group" aria-labelledby="<%= question.answer_field %>">
   <%= render 'components/question_title', question: question %>
-  <% if question.character_limit && question.character_limit > 0 %>
-    <%= text_field_tag question.answer_field.to_sym, nil, type: :email, class: "usa-input", required: question.is_required, maxlength: question.max_length, onkeyup: "touchpointForm#{form.short_uuid}.textCounter(this,#{question.max_length});" %>
-	<span class="counter-msg usa-hint usa-character-count__message  aria-live="polite">
-		<%= question.max_length %> characters allowed
-	</span>
-  <% else %>
-    <%= text_field_tag question.answer_field.to_sym, nil, type: :email, class: "usa-input", required: question.is_required, maxlength: question.max_length %>
-  <% end %>
+  <%= text_field_tag question.answer_field.to_sym, nil, type: :email, class: "usa-input", required: question.is_required %>
 </div>
 <script>
 	$('#<%= question.answer_field.to_sym %>').blur(function() {
@@ -17,9 +10,13 @@
 		result = EmailRegex.test(email);
 		if (!result) {
 			alert('Please enter a valid email address');
+			$(this).addClass("usa-input--error");
+			$(this).removeClass("usa-input--success");
 			$(this).val("");
 			$(this).focus();
-		}
+		} else {
+			$(this).removeClass("usa-input--error");
+			$(this).addClass("usa-input--success");
+    }
 	});
 </script>
-

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -196,6 +196,19 @@ FactoryBot.define do
       end
     end
 
+    trait :email do
+      name { "Email text form" }
+      kind { "custom" }
+      after(:create) do |f, evaluator|
+        FactoryBot.create(:question,
+          :email,
+          form: f,
+          answer_field: :answer_03,
+          form_section: f.form_sections.first
+        )
+      end
+    end
+
     trait :radio_button_form do
       name { "Radio button form" }
       kind { "custom" }

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -11,6 +11,11 @@ FactoryBot.define do
       question_type { "text_phone_field" }
     end
 
+    trait :email do
+      text { "Email" }
+      question_type { "text_email_field" }
+    end
+
     trait :states_dropdown do
       question_type { "states_dropdown" }
     end

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -192,6 +192,27 @@ feature "Touchpoints", js: true do
       end
     end
 
+    describe "email question" do
+      let!(:dropdown_form) { FactoryBot.create(:form, :email, organization: organization, user: user) }
+
+      before do
+        visit touchpoint_path(dropdown_form)
+      end
+
+      it "allows valid email address" do
+        fill_in "answer_03", with: "test@test.com"
+        find("#answer_03").native.send_key :tab
+        expect(find("#answer_03").value).to eq("test@test.com")
+      end
+
+      it "disallows invalid text input" do
+        fill_in "answer_03", with: "test@testcom"
+        find("#answer_03").native.send_key :tab
+        page.driver.browser.switch_to.alert.accept        
+        expect(find("#answer_03").value).to eq("")
+      end
+    end
+
     describe "required question" do
       before do
         form.questions.first.update(is_required: true)


### PR DESCRIPTION
TP-1205 Add email front end validation as well as tests

Linked Trello ticket: https://trello.com/c/z8yd0gxl/1205-ensure-a-email-text-field-validates-on-the-frontend