### PR TITLE
TP-1220 Capture user url intent when not logged in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,10 @@ class ApplicationController < ActionController::Base
 
   # Enforce Permissions
   def ensure_user
-    redirect_to(index_path, notice: "Authorization is Required") unless current_user
+    if !current_user
+      store_location_for(:user, request.fullpath)
+      redirect_to(index_path, notice: "Authorization is Required") unless current_user
+    end
   end
 
   def ensure_admin
@@ -80,4 +83,13 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource_or_scope)
     index_path
   end
+
+  def after_sign_in_path_for(resource_or_scope)
+    redirect_url = stored_location_for(resource_or_scope)
+    if redirect_url.present?
+      "#{request.base_url}#{redirect_url}"
+    else
+      super
+    end
+  end  
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe ApplicationController, type: :controller do
+
+  describe ProfileController, type: :controller do
+
+    let(:organization) { FactoryBot.create(:organization)}
+    let(:admin) { FactoryBot.create(:user, :admin, organization: organization) }
+
+    context "save url intent" do
+
+      it "should save redirect when not logged in" do
+        get :show
+        expect(controller.stored_location_for(:user)).to eq '/profile'
+        expect(response).to redirect_to '/index'
+      end
+
+      it "should not save redirect when logged in" do
+        sign_in(admin)
+        get :show
+        expect(controller.stored_location_for(:user)).to eq nil
+      end
+    end
+  end
+end

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -16,6 +16,11 @@ feature "Profile", js: true do
           expect(page.current_path).to eq(index_path)
           expect(page).not_to have_content("Your API Key was last updated more than")
         end
+
+        it 'sets the redirect path' do
+          login_as(user)
+          expect(page.current_path).to eq(profile_path)          
+        end
       end
     end
 

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -16,11 +16,6 @@ feature "Profile", js: true do
           expect(page.current_path).to eq(index_path)
           expect(page).not_to have_content("Your API Key was last updated more than")
         end
-
-        it 'sets the redirect path' do
-          login_as(user)
-          expect(page.current_path).to eq(profile_path)          
-        end
       end
     end
 


### PR DESCRIPTION
TP-1220 Capture user url intent when not logged in

Linked Trello Issue: https://trello.com/c/e4jOOLDH/1220-maintain-url-intent-when-logging-in

Utilizes Devise store user location functionality to save user url intent and then redirect after successful sign in.