### PR TITLE
TP-1228 Add account deactivation job and enail notifications on 7 and…

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -24,6 +24,14 @@ class UserMailer < ApplicationMailer
     mail subject: "New Submissions to #{@form.name} since #{@begin_day}", to: emails
   end
 
+  def account_deactivation_scheduled_notification(email, active_days)
+    return unless ENV["ENABLE_EMAIL_NOTIFICATIONS"] == "true"
+    @active_days = active_days
+    set_logo
+
+    mail subject: "Your account is scheduled to be deactivated in #{@active_days} days due to inactivity", to: email
+  end
+
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -130,7 +130,7 @@
 <p>
   <strong>Reflection</strong>
   <br>
-  <%= @collection.reflection %>
+  <%= simple_format(@collection.reflection) %>
 </p>
 <p>
   <strong>Integrity hash</strong>

--- a/app/views/admin/websites/scorecard.html.erb
+++ b/app/views/admin/websites/scorecard.html.erb
@@ -8,22 +8,9 @@ Website Scorecard for <%= @website.domain %>
   <% end %>
 </p>
 
-<div class="grid-row grid-gap">
-  <div class="grid-col-6">
-    <h2>
-      Web domain
-    </h2>
-    <h3>
-      <%= @website.domain %>
-    </h3>
-  </div>
-  <div class="grid-col-6">
-    <h2>Site Score</h2>
-    <h3 id="siteScore">55</h3>
-  </div>
+<div class="well">
+  <%= render 'components/site_scanner_results' %>
 </div>
-
-<%= render 'components/site_scanner_results' %>
 
 <div class="usa-summary-box" role="complementary">
   <div class="usa-summary-box__body">

--- a/app/views/components/_site_scanner_results.html.erb
+++ b/app/views/components/_site_scanner_results.html.erb
@@ -8,114 +8,140 @@
   Site Scanner results
 </h3>
 
-<div class="text-uppercase font-body-3xs">
-  Web Domain
-  <!-- Target URL -->
+<div class="grid-row">
+  <div class="grid-col-6">
+  </div>
+  <div class="grid-col-6">
+  </div>
 </div>
-<%= hash["target_url"] %>
-<br>
-<div class="text-uppercase font-body-3xs">
-  final_url:
+
+
+<div class="grid-row">
+  <div class="grid-col-6">
+
+  </div>
+  <div class="grid-col-6">
+  </div>
 </div>
-<%= hash["final_url"] %>
-<br>
-<br>
-<div class="text-uppercase font-body-3xs">
-  og_title_final_url:
-</div>
-<%= hash["og_title_final_url"] %>
-<br>
-<div class="text-uppercase font-body-3xs">
-  og_description_final_url:
-</div>
-<%= hash["og_description_final_url"] %>
-<br>
-<div class="text-uppercase font-body-3xs">
-  final_url_same_domain:
-</div>
-<%= hash["final_url_same_domain"] %>
+
 <div class="well">
-  <div class="text-uppercase font-body-3xs">
-    Agency branch
-    <!-- Target URL Branch: -->
+  <div class="grid-row">
+    <div class="grid-col-6">
+      <div class="text-uppercase font-body-3xs">
+        Web Domain
+      </div>
+      <%= hash["target_url"] %>
+      <br>
+      <br>
+      <div class="text-uppercase font-body-3xs">
+        Final URL
+      </div>
+      <%= link_to hash["final_url"], hash["final_url"], class: "usa-link", target: "_blank", rel: "noopener" %>
+      <br>
+      <br>
+      <div class="text-uppercase font-body-3xs">
+        Title
+      </div>
+      <%= hash["og_title_final_url"] %>
+      <br>
+      <br>
+      <div class="text-uppercase font-body-3xs">
+        Description
+      </div>
+      <%= hash["og_description_final_url"] %>
+    </div>
+    <div class="grid-col-6">
+      <div class="text-uppercase font-body-3xs">
+        Agency branch
+      </div>
+      <%= hash["target_url_branch"] %>
+      <br>
+      <br>
+      <div class="text-uppercase font-body-3xs" data-agency-code="<%= hash["target_url_agency_code"] %>">
+        Agency
+      </div>
+      <%= hash["target_url_agency_owner"] %>
+      <% begin %>
+        <% @org = Organization.find_by(name: hash["target_url_agency_owner"]) %>
+        <br>
+        <%= @org.present? ? link_to(@org.name, admin_organization_path(@org.id)) : hash["target_url_agency_owner"] %>
+      <% rescue %>
+      <% end %>
+      <br>
+      <br>
+      <div class="text-uppercase font-body-3xs" data-bureau-code="<%= hash["target_url_bureau_code"] %>">
+        Bureau
+      </div>
+      <%= hash["target_url_bureau_owner"] %>
+    </div>
   </div>
-  <%= hash["target_url_branch"] %>
-  <br>
-  <div class="text-uppercase font-body-3xs" data-agency-code="<%= hash["target_url_agency_code"] %>">
-    Agency
-    <!-- target_url_agency_owner: -->
-  </div>
-  <%= hash["target_url_agency_owner"] %>
-  <br>
-  <div class="text-uppercase font-body-3xs" data-bureau-code="<%= hash["target_url_bureau_code"] %>">
-    target_url_bureau_owner:
-  </div>
-  <%= hash["target_url_bureau_owner"] %>
-  <br>
 </div>
+
 <div class="well">
-  <div class="text-uppercase font-body-3xs">
-    scan_date:
+  <div class="grid-row">
+    <div class="grid-col-6">
+      <div class="text-uppercase font-body-3xs">
+        DAP DETECTED FINAL URL
+      </div>
+      <%= hash["dap_detected_final_url"] %>
+    </div>
+    <div class="grid-col-6">
+      <div class="text-uppercase font-body-3xs">
+        DAP Parameters
+      </div>
+      <%= hash["dap_parameters_final_url"] %>
+    </div>
   </div>
-  <%= hash["scan_date"] %>
-  <br>
-  <div class="text-uppercase font-body-3xs">
-    scan_status:
+</div>
+
+<div class="well">
+  <div class="grid-row">
+    <div class="grid-col-6">
+      <div class="text-uppercase font-body-3xs">
+        Sitemap URL
+      </div>
+      <%= link_to hash["sitemap_xml_final_url"], hash["sitemap_xml_final_url"], class: "usa-link", target: "_blank", rel: "noopener" %>
+    </div>
+    <div class="grid-col-6">
+      <div class="text-uppercase font-body-3xs">
+        Robots TXT URL
+      </div>
+      <%= link_to hash["robots_txt_final_url"], hash["robots_txt_final_url"], class: "usa-link", target: "_blank", rel: "noopener" %>
+    </div>
   </div>
-  <%= hash["scan_status"] %>
+</div>
+
+<div class="well">
+  <div class="grid-row">
+    <div class="grid-col-6">
+      <div class="text-uppercase font-body-3xs">
+        USWDS Version
+      </div>
+      <%= hash["uswds_semantic_version"] %>
+    </div>
+    <div class="grid-col-6">
+      <div class="text-uppercase font-body-3xs">
+        Latest Version
+      </div>
+      <!-- TODO: Automate. For now: Update by hand -->
+      2.11.2
+    </div>
+  </div>
 </div>
 
 <div class="well">
   <div class="text-uppercase font-body-3xs">
-    uswds_semantic_version:
+    Third party domains
   </div>
-  <%= hash["uswds_semantic_version"] %>
+  <ul class="usa-list">
+    <% hash["third_party_service_domains"].sort.each do |d| %>
+    <li>
+      <%= d %>
+    </li>
+    <% end %>
+  </ul>
 </div>
-
-<div class="well">
-  <div class="text-uppercase font-body-3xs">
-    dap_detected_final_url:
-  </div>
-  <%= hash["dap_detected_final_url"] %>
-  <br>
-  <div class="text-uppercase font-body-3xs">
-    dap_parameters_final_url:
-  </div>
-  <%= hash["dap_parameters_final_url"] %>
-</div>
-
-<div class="well">
-  <div class="text-uppercase font-body-3xs">
-    robots_txt_detected:
-  </div>
-  <%= hash["robots_txt_detected"] %>
-  <br>
-  <div class="text-uppercase font-body-3xs">
-    robots_txt_final_url:
-  </div>
-  <%= hash["robots_txt_final_url"] %>
-</div>
-
-<div class="well">
-  <div class="text-uppercase font-body-3xs">
-    sitemap_xml_detected:
-  </div>
-  <%= hash["sitemap_xml_detected"] %>
-  <br>
-  <div class="text-uppercase font-body-3xs">
-    sitemap_xml_final_url:
-  </div>
-  <%= hash["sitemap_xml_final_url"] %>
-</div>
-
-<div class="well">
-  <div class="text-uppercase font-body-3xs">
-    third_party_service_domains:
-  </div>
-  <%= hash["third_party_service_domains"] %>
-</div>
-
-<% rescue %>
+<%# rescue %>
 <div class="usa-alert usa-alert--error usa-alert--slim">
   <div class="usa-alert__body">
     <p class="usa-alert__text">

--- a/app/views/user_mailer/account_deactivation_scheduled_notification.html.erb
+++ b/app/views/user_mailer/account_deactivation_scheduled_notification.html.erb
@@ -1,0 +1,10 @@
+<div class="email-header">
+  <%= image_tag(attachments['logo.png'].url, alt: "Touchpoints logo") %>
+</div>
+<h3>Account deactivation scheduled in <%= @active_days %> days.</h3>
+<p>
+  Your account is scheduled to be deactivated in <%= @active_days %> days due to inactivity.
+</p>
+<p>
+  Login to Touchpoints at <%= link_to ENV.fetch("INDEX_URL"), ENV.fetch("INDEX_URL") %> to keep your account active.
+</p>

--- a/app/views/user_mailer/account_deactivation_scheduled_notification.text.erb
+++ b/app/views/user_mailer/account_deactivation_scheduled_notification.text.erb
@@ -1,0 +1,5 @@
+Account deactivation scheduled in <%= @active_days %> days.
+
+Your account is scheduled to be deactivated in <%= @active_days %> days due to inactivity.
+
+Login to Touchpoints at <%= ENV.fetch("INDEX_URL") %> to keep your account active.

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -13,6 +13,18 @@ every 1.day, :at => "09:00pm" do
   runner "Submission.send_daily_notifications"
 end
 
+every 1.days, :at => "10:00pm" do
+  runner "User.deactivate_inactive_accounts"
+end
+
+every 1.day, :at => "10:15pm" do
+  runner "User.send_account_deactivation_notifications(7)"
+end
+
+every 1.days, :at => "10:30pm" do
+  runner "User.send_account_deactivation_notifications(14)"
+end
+
 every :monday, :at => "05:00am" do
   runner "Submission.send_weekly_notifications"
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -44,6 +44,28 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
+  describe "account_deactivation_scheduled_notification" do
+    let!(:organization) { FactoryBot.create(:organization) }
+    let(:user) { FactoryBot.create(:user, organization: organization) }
+    let(:active_days) { 14 }
+    let(:mail) { UserMailer.account_deactivation_scheduled_notification(user.email, active_days) }
+
+    before do
+      ENV["ENABLE_EMAIL_NOTIFICATIONS"] = "true"
+    end
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Your account is scheduled to be deactivated in #{active_days} days due to inactivity")
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq([ENV.fetch("TOUCHPOINTS_EMAIL_SENDER")])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Account deactivation scheduled in #{ active_days } days.")
+      expect(mail.body.encoded).to match("Your account is scheduled to be deactivated in #{ active_days } days due to inactivity.")
+    end
+  end
+
   describe "admin_summary" do
     let(:mail) { UserMailer.admin_summary }
 


### PR DESCRIPTION
TP-1228 Add account deactivation job and enail notifications on 7 and 14 days to expire.

Linked Trello issue: https://trello.com/c/1jVbQ0Zn/1228-system-admin-can-send-automated-emails-once-a-week-to-inform-users-who-will-be-de-activated-in-2-weeks-and-1-week

@ryanwoldatwork I added a job to schedule.rb to deativate accounts who have never signed in and were created at more than 90 days ago or who's last sign in was more than 90 days ago.   Let me know if we already have something like this in place and I'll remove.
