### PR TITLE
TP-1217 API date filter

### DIFF
--- a/app/controllers/api/v0/forms_controller.rb
+++ b/app/controllers/api/v0/forms_controller.rb
@@ -8,17 +8,25 @@ class Api::V0::FormsController < ::ApiController
   end
 
   def show
-    @form = current_user.forms.find_by_short_uuid(params[:id])
-    @page_num = (params[:page].present? ? params[:page].to_i : 0)
-    @page_size = (params[:page_size].present? ? params[:page_size].to_i : 500)
-    @page_size = 5000 if @page_size > 5000
+    form = current_user.forms.find_by_short_uuid(params[:id])
+    page_num = (params[:page].present? ? params[:page].to_i : 0)
+    page_size = (params[:page_size].present? ? params[:page_size].to_i : 500)
+    page_size = 5000 if page_size > 5000
+    # Date filter defaults to 1 year ago and 1 day from now
+    # Is there ever a case where we'd want to see submissions older than a year via the API?
+    begin
+      start_date = params[:start_date] ? Date.parse(params[:start_date]).to_date : 1.year.ago
+      end_date = params[:end_date] ? Date.parse(params[:end_date]).to_date : 1.day.from_now
+    rescue
+      render json: { error: { message: "invalid date format, should be 'YYYY-MM-DD'", status: 400 } }, status: 400 and return
+    end
 
     respond_to do |format|
       format.json {
-        if @form
+        if form
           render json: {
-            form: @form,
-            responses: @form.submissions.limit(@page_size).offset(@page_size * @page_num)
+            form: form,
+            responses: form.submissions.where('created_at BETWEEN ? AND ?',start_date,end_date).limit(page_size).offset(page_size * page_num)
           }
         else
           render json: { error: { message: "no form with Short UUID of #{params[:id]}", status: 404 } }, status: 404

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -8,15 +8,22 @@ class Api::V1::FormsController < ::ApiController
   end
 
   def show
-    @form = current_user.forms.find_by_short_uuid(params[:id])
-    @page_num = (params[:page].present? ? params[:page].to_i : 0)
-    @page_size = (params[:page_size].present? ? params[:page_size].to_i : 500)
-    @page_size = 5000 if @page_size > 5000
-
+    form = current_user.forms.find_by_short_uuid(params[:id])
+    page_num = (params[:page].present? ? params[:page].to_i : 0)
+    page_size = (params[:page_size].present? ? params[:page_size].to_i : 500)
+    page_size = 5000 if page_size > 5000
+    # Date filter defaults to 1 year ago and 1 day from now
+    # Is there ever a case where we'd want to see submissions older than a year via the API?
+    begin
+      start_date = params[:start_date] ? Date.parse(params[:start_date]).to_date : 1.year.ago
+      end_date = params[:end_date] ? Date.parse(params[:end_date]).to_date : 1.day.from_now
+    rescue
+      render json: { error: { message: "invalid date format, should be 'YYYY-MM-DD'", status: 400 } }, status: 400 and return
+    end
     respond_to do |format|
       format.json {
-        if @form
-          render json: @form, include: [:questions, :submissions], serializer: FullFormSerializer, page_num: @page_num, page_size: @page_size
+        if form
+          render json: form, include: [:questions, :submissions], serializer: FullFormSerializer, page_num: page_num, page_size: page_size, start_date: start_date, end_date: end_date
         else
           render json: { error: { message: "no form with Short UUID of #{params[:id]}", status: 404 } }, status: 404
         end

--- a/app/serializers/full_form_serializer.rb
+++ b/app/serializers/full_form_serializer.rb
@@ -1,6 +1,6 @@
 class FullFormSerializer < ActiveModel::Serializer
 
-  attributes :page_num, :page_size
+  attributes :page_num, :page_size, :start_date, :end_date
 
   def page_num
     @instance_options[:page_num]
@@ -8,6 +8,14 @@ class FullFormSerializer < ActiveModel::Serializer
 
   def page_size
     @instance_options[:page_size]
+  end
+
+  def start_date
+    @instance_options[:start_date]
+  end
+
+  def end_date
+    @instance_options[:end_date]
   end
 
   attributes :id,
@@ -62,6 +70,6 @@ class FullFormSerializer < ActiveModel::Serializer
   has_many :submissions
 
   def submissions
-    object.submissions.limit(page_size).offset(page_size * page_num)
+    object.submissions.where('created_at BETWEEN ? AND ?',start_date,end_date).limit(page_size).offset(page_size * page_num)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,8 +106,8 @@ ActiveRecord::Schema.define(version: 2021_06_30_200420) do
     t.integer "response_count", default: 0
     t.datetime "last_response_created_at"
     t.boolean "ui_truncate_text_responses", default: true
-    t.string "notification_frequency", default: "instant"
     t.string "success_text_heading"
+    t.string "notification_frequency", default: "instant"
     t.index ["legacy_touchpoint_id"], name: "index_forms_on_legacy_touchpoint_id"
     t.index ["legacy_touchpoint_uuid"], name: "index_forms_on_legacy_touchpoint_uuid"
     t.index ["uuid"], name: "index_forms_on_uuid"
@@ -242,7 +242,8 @@ ActiveRecord::Schema.define(version: 2021_06_30_200420) do
     t.integer "service_id"
     t.text "notes"
     t.integer "time"
-    t.integer "total_eligble_population"
+    t.integer "total_eligible_population"
+    t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,8 +106,8 @@ ActiveRecord::Schema.define(version: 2021_06_30_200420) do
     t.integer "response_count", default: 0
     t.datetime "last_response_created_at"
     t.boolean "ui_truncate_text_responses", default: true
-    t.string "success_text_heading"
     t.string "notification_frequency", default: "instant"
+    t.string "success_text_heading"
     t.index ["legacy_touchpoint_id"], name: "index_forms_on_legacy_touchpoint_id"
     t.index ["legacy_touchpoint_uuid"], name: "index_forms_on_legacy_touchpoint_uuid"
     t.index ["uuid"], name: "index_forms_on_uuid"
@@ -242,8 +242,7 @@ ActiveRecord::Schema.define(version: 2021_06_30_200420) do
     t.integer "service_id"
     t.text "notes"
     t.integer "time"
-    t.integer "total_eligible_population"
-    t.integer "position"
+    t.integer "total_eligble_population"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/controllers/api/v1/forms_controller_spec.rb
+++ b/spec/controllers/api/v1/forms_controller_spec.rb
@@ -141,6 +141,62 @@ describe Api::V1::FormsController, type: :controller do
           expect(parsed_response["data"]["relationships"]["submissions"]["data"].size).to eq(0)
         end
       end
+
+      context "date_filter" do
+        let!(:user) { FactoryBot.create(:user) }
+        let(:form) { FactoryBot.create(:form, :with_responses, user: user, organization: user.organization) }
+        let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: user, form: form) }
+
+        before do
+          user.update(api_key: TEST_API_KEY)
+          form.submissions[0].created_at = 2.days.ago
+          form.submissions[0].save
+          form.submissions[1].created_at = 1.day.ago
+          form.submissions[1].save
+          request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(ENV.fetch("API_HTTP_USERNAME"), ENV.fetch("API_HTTP_PASSWORD"))
+        end
+
+        it "returns an array of forms with date filter defaults" do
+          get :show, format: :json, params: { id: form.short_uuid, "API_KEY" => user.api_key }
+          parsed_response = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(parsed_response["data"]["relationships"]["submissions"]["data"].size).to eq(3)
+        end
+
+        it "returns an array of forms with submissions which occurred during the past day" do
+          get :show, format: :json, params: { id: form.short_uuid, "API_KEY" => user.api_key, start_date: Date.today.strftime("%Y-%m-%d"), end_date: 1.day.from_now.strftime("%Y-%m-%d") }
+          parsed_response = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(parsed_response["data"]["relationships"]["submissions"]["data"].size).to eq(1)
+        end
+
+        it "returns an array of forms with submissions which occurred during the past two days" do
+          get :show, format: :json, params: { id: form.short_uuid, "API_KEY" => user.api_key, start_date: 1.days.ago.strftime("%Y-%m-%d"), end_date: 1.day.from_now.strftime("%Y-%m-%d") }
+          parsed_response = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(parsed_response["data"]["relationships"]["submissions"]["data"].size).to eq(2)
+        end
+
+        it "returns an array of forms with submissions which occurred during the past week" do
+          get :show, format: :json, params: { id: form.short_uuid, "API_KEY" => user.api_key, start_date: 7.days.ago.strftime("%Y-%m-%d"), end_date: 1.day.from_now.strftime("%Y-%m-%d") }
+          parsed_response = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(parsed_response["data"]["relationships"]["submissions"]["data"].size).to eq(3)
+        end
+
+        it "returns an array of forms with submissions which occurred during the past week with paging" do
+          get :show, format: :json, params: { id: form.short_uuid, "API_KEY" => user.api_key, page: 0, page_size: 2, start_date: 7.days.ago.strftime("%Y-%m-%d"), end_date: 1.day.from_now.strftime("%Y-%m-%d") }
+          parsed_response = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(parsed_response["data"]["relationships"]["submissions"]["data"].size).to eq(2)
+        end
+
+        it "returns an invalid input response for a bad date input" do
+          get :show, format: :json, params: { id: form.short_uuid, "API_KEY" => user.api_key, start_date: 'Foo', end_date: 7.days.from_now.strftime("%Y-%m-%d") }
+          parsed_response = JSON.parse(response.body)
+          expect(response.status).to eq(400)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
TP-1217 API date filter

See note in code code comments:  Defaulting start_date to 1 year ago under the assumption that a user would never need to pull responses over 1 year old via the API.

Linked Trello Ticket: https://trello.com/c/Qb7ABrNt/1217-add-date-filter-to-responses-api