### PR TITLE
TP-1254 Add other option handler to inline widget js

### DIFF
--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -1,5 +1,6 @@
 class Website < ApplicationRecord
   validates :domain, presence: true
+  validates :domain, uniqueness: true
   validates :type_of_site, presence: true
 
   belongs_to :organization, optional: true

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -92,6 +92,10 @@ function FBAform(d, N) {
 			d.body.appendChild(this.dialogEl);
 
 			d.querySelector('.fba-modal-close').addEventListener('click', this.handleDialogClose.bind(this), false);
+			var otherElements = d.querySelectorAll(".usa-input.other-option");
+			for (var i = 0; i < otherElements.length; i++) {
+			    otherElements[i].addEventListener('keyup', this.handleOtherOption.bind(this), false);
+			}
 		<% end %>
 
 		<%# add button behaviors for custom-button-modal %>
@@ -153,6 +157,14 @@ function FBAform(d, N) {
 		handleDialogClose: function(e) {
 			e.preventDefault();
 			this.closeDialog();
+		},
+		handleOtherOption: function(e) {
+			var selectorId =  "#" + e.srcElement.getAttribute("data-option-id");
+			var other_val = e.target.value.replace(/,/g, '');
+			if (other_val == '') other_val = 'other';
+			var option = this.formElement().querySelector(selectorId);
+			option.checked = true;
+			option.value = other_val;
 		},
 		handleSubmitClick: function(e) {
 			e.preventDefault();

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -125,20 +125,155 @@ FactoryBot.define do
         )
         FactoryBot.create(:question,
           form: f,
-          question_type: "text_display",
+          question_type: "text_email_field",
           form_section: f.form_sections.first,
-          answer_field: "answer_20",
+          answer_field: "answer_02",
           position: 2,
-          text: "Some custom <a href='#'>html</a>"
+          text: "An email field"
         )
         FactoryBot.create(:question,
           form: f,
           question_type: "textarea",
           form_section: f.form_sections.first,
-          answer_field: "answer_02",
+          answer_field: "answer_03",
           position: 3,
           text: "A textarea field"
         )
+        FactoryBot.create(:question,
+          form: f,
+          question_type: "text_display",
+          form_section: f.form_sections.first,
+          answer_field: "answer_20",
+          position: 20,
+          text: "Some custom <a href='#'>html</a>"
+        )
+
+        option_elements_section = f.form_sections.create(title: "Option elements", position: 2)
+        radio_button_question = FactoryBot.create(:question,
+          form: f,
+          form_section: option_elements_section,
+          question_type: "text_display",
+          text: "Custom Question Radio Buttons",
+          question_type: "radio_buttons",
+          help_text: "This is help text for radio buttons.",
+          answer_field: :answer_04,
+          position: 4,
+          is_required: false,
+        )
+
+        QuestionOption.create!({
+          question: radio_button_question,
+          text: "Option 1",
+          value: 1,
+          position: 1
+        })
+        QuestionOption.create!({
+          question: radio_button_question,
+          text: "Option 2",
+          value: 2,
+          position: 2
+        })
+        QuestionOption.create!({
+          question: radio_button_question,
+          text: "Option 3",
+          value: 3,
+          position: 3
+        })
+        QuestionOption.create!({
+          question: radio_button_question,
+          text: "Otro",
+          value: 4,
+          position: 4
+        })
+
+        checkbox_question = FactoryBot.create(:question,
+          form: f,
+          form_section: option_elements_section,
+          text: "Custom Question Checkboxes",
+          question_type: "checkbox",
+          help_text: "This is help text for checkboxes.",
+          position: 5,
+          answer_field: :answer_05,
+          is_required: false,
+        )
+        QuestionOption.create!({
+          question: checkbox_question,
+          text: "Option 1",
+          value: 1,
+          position: 1
+        })
+        QuestionOption.create!({
+          question: checkbox_question,
+          text: "Option 2",
+          value: 2,
+          position: 2
+        })
+        QuestionOption.create!({
+          question: checkbox_question,
+          text: "Other",
+          value: 3,
+          position: 3
+        })
+
+        dropdown_question = Question.create!({
+          form: f,
+          form_section: option_elements_section,
+          text: "Custom Question Dropdown",
+          question_type: "dropdown",
+          help_text: "This is help text for a dropdown.",
+          position: 5,
+          answer_field: :answer_06,
+          is_required: false,
+        })
+        QuestionOption.create!({
+          question: dropdown_question,
+          text: "Option 1",
+          value: 1,
+          position: 1
+        })
+        QuestionOption.create!({
+          question: dropdown_question,
+          text: "Option 2",
+          value: 2,
+          position: 2
+        })
+        QuestionOption.create!({
+          question: dropdown_question,
+          text: "Option 3",
+          value: 3,
+          position: 3
+        })
+
+        Question.create!({
+          form: f,
+          form_section: option_elements_section,
+          text: "hidden value",
+          question_type: "hidden",
+          position: 11,
+          answer_field: :answer_07,
+          is_required: false
+        })
+
+        custom_elements_section = f.form_sections.create(title: "Custom elements", position: 3)
+        Question.create!({
+          form: f,
+          form_section: custom_elements_section,
+          text: '<p>Custom text <a href="#">that supports HTML</a> goes here.</p>',
+          question_type: "text_display",
+          position: 6,
+          answer_field: :answer_15,
+          is_required: false,
+        })
+
+        Question.create!({
+          form: f,
+          form_section: custom_elements_section,
+          text: "Star radio buttons",
+          question_type: "star_radio_buttons",
+          position: 8,
+          answer_field: :answer_17,
+          is_required: false
+        })
       end
     end
 

--- a/spec/factories/website.rb
+++ b/spec/factories/website.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :website do
     domain { "subdomain.example.gov" }
+    type_of_site { "application" }
     parent_domain { "example.gov" }
     office { "OFFICE" }
     sub_office { "SUBOFFICE" }

--- a/spec/features/embedded_touchpoints_spec.rb
+++ b/spec/features/embedded_touchpoints_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+feature "Touchpoints", js: true do
+  let(:organization) { FactoryBot.create(:organization) }
+
+  context "as Admin" do
+    let!(:user) { FactoryBot.create(:user, :admin, organization: organization) }
+    let!(:form) { FactoryBot.create(:form, :kitchen_sink, organization: organization, user: user) }
+
+    describe "/forms/:id/example" do
+      before do
+        login_as(user)
+      end
+
+      context "default success text" do
+        before do
+          visit example_admin_form_path(form)
+          click_on("Help improve this site") # opens modal
+          expect(page).to have_content("Help improve this site")
+
+          expect(page).to have_content("Do you have a few minutes to help us test this site?")
+          fill_in "answer_01", with: "input field"
+          fill_in "answer_02", with: "email"
+          fill_in "answer_03", with: "textarea"
+
+          click_on "Next"
+          expect(page).to have_content("Please enter a valid value")
+          expect(page).to have_content("This is help text")
+
+          fill_in "answer_02", with: "email@example.gov"
+          click_on "Next"
+
+          expect(page).to have_content("Option elements")
+          find("#question_option_4 label").click
+          fill_in("answer_04_other", with: "otro 2")
+
+          all('.usa-checkbox__label').each do |z|; z.click; end
+          fill_in("answer_05_other", with: "other 3")
+          select("Option 2", from: "answer_06")
+          click_on "Next"
+          expect(page).to have_content("Custom elements")
+          click_on "Submit"
+
+          # shows success flash message
+          expect(page).to have_content("Success")
+          expect(page).to have_content("Thank you. Your feedback has been received.")
+        end
+
+        it "renders success flash message" do
+          @submission = Submission.last
+          expect(@submission.answer_01).to eq("input field")
+          expect(@submission.answer_02).to eq("email@example.gov")
+          expect(@submission.answer_03).to eq("textarea")
+          expect(@submission.answer_04).to eq("otro 2")
+          expect(@submission.answer_05).to eq("1,2,other 3")
+          expect(@submission.answer_06).to eq("2")
+        end
+      end
+    end
+
+  end
+end

--- a/spec/models/website_spec.rb
+++ b/spec/models/website_spec.rb
@@ -15,4 +15,18 @@ RSpec.describe Website, type: :model do
       expect(@website.errors.full_messages).to eq(["Domain can't be blank", "Type of site can't be blank"])
     end
   end
+
+  describe "try to create a new website" do
+    let!(:existing_website) { FactoryBot.create(:website) }
+    let(:new_website) { FactoryBot.build(:website) }
+
+    before do
+      new_website
+    end
+
+    it "does not save and adds an error indicating type_of_site is required" do
+      expect(new_website.valid?).to eq(false)
+      expect(new_website.errors.full_messages).to eq(["Domain has already been taken"])
+    end
+  end
 end


### PR DESCRIPTION
TP-1254 Add other option handler to inline widget js

The js which handles other options was not in place for the embedded widget.  I ported from jquery to POJS and added.   Also verified multiple questions with OTHER options can be persisted.