### PR TITLE
Delivery method as it's own step

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -69,6 +69,13 @@ footer {
   max-height: 32px;
 }
 
+.delivery-options-preview {
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 20px;
+  margin: 20px;
+}
+
 // USWDS Overrides
 @media (min-width: 64em) {
   .usa-header nav {

--- a/app/controllers/admin/forms_controller.rb
+++ b/app/controllers/admin/forms_controller.rb
@@ -8,7 +8,7 @@ class Admin::FormsController < AdminController
   before_action :set_form, only: [
     :show, :edit, :update, :destroy,
     :compliance,
-    :permissions, :questions, :responses,
+    :permissions, :questions, :responses, :delivery_method,
     :copy, :copy_by_id,
     :invite,
     :notifications,
@@ -130,6 +130,10 @@ class Admin::FormsController < AdminController
     end
   end
 
+  def delivery_method
+    ensure_form_manager(form: @form)
+  end
+
   def example
     redirect_to touchpoint_path, notice: "Previewing Touchpoint" and return if @form.delivery_method == "touchpoints-hosted-only"
     redirect_to admin_forms_path, notice: "Form does not have a delivery_method of 'modal' or 'inline' or 'custom-button-modal'" and return unless @form.delivery_method == "modal" || @form.delivery_method == "inline" || @form.delivery_method == "custom-button-modal"
@@ -235,13 +239,22 @@ class Admin::FormsController < AdminController
     respond_to do |format|
       if @form.update(form_params)
         format.html {
-          redirect_to admin_form_path(@form), notice: 'Survey was successfully updated.'
+          redirect_to get_edit_path(@form), notice: 'Survey was successfully updated.'
         }
         format.json { render :show, status: :ok, location: @form }
       else
-        format.html { render :edit }
+        format.html { render (params[:form][:delivery_method].present? ? :delivery_method : :edit) }
         format.json { render json: @form.errors, status: :unprocessable_entity }
       end
+    end
+  end
+
+  # Start building our wizard workflow
+  def get_edit_path(form)
+    if params[:form][:delivery_method].present?
+      delivery_method_admin_form_path(form)
+    else
+      admin_form_path(form)
     end
   end
 

--- a/app/views/admin/forms/_form.html.erb
+++ b/app/views/admin/forms/_form.html.erb
@@ -172,69 +172,6 @@
     </script>
   </div>
   <br>
-  <br>
-  <div class="well">
-    <h2>
-      How will users access this survey?
-    </h2>
-    <div class="usa-alert usa-alert--info">
-      <div class="usa-alert__body">
-        <p class="usa-alert__text">
-          <strong>Options for Publishing Your Survey</strong>
-          <br>
-          When a Touchpoint is published,
-          it will be available at a URL on Touchpoints.
-          <br>
-
-          Additionally, a survey form can be embedded on an existing web property
-          using one of three different methods:
-          <ol>
-            <li>
-              <strong>Tab button &amp; modal</strong> -
-              Touchpoints will insert a default button on your website with
-              the text that you indicate.  The button will launch
-              a modal box displaying your survey
-            </li>
-            <li>
-              <strong>Custom button &amp; modal</strong> -
-              Works like the modal, except you provide your own custom
-              styled button with the use of a
-              #html-element-id
-            </li>
-            <li>
-              <strong>Inline</strong> -
-              Touchpoints will embed your survey directly onto your
-              website using a #html-element-id
-            </li>
-          </ol>
-        </p>
-      </div>
-    </div>
-    <br>
-    <fieldset class="usa-fieldset">
-      <legend class="usa-sr-only">Delivery Methods</legend>
-      <% Form::DELIVERY_METHODS.each_with_index do |delivery_method, index| %>
-        <div class="usa-checkbox">
-          <%= f.radio_button :delivery_method, delivery_method[0], class: "usa-radio__input"  %>
-          <%= f.label delivery_method[1], class: "usa-radio__label", for: "form_delivery_method_#{delivery_method[0]}" %>
-        </div>
-      <% end %>
-    </fieldset>
-    <div class="grid-row">
-      <div class="grid-col-6">
-        <div class="field" id="delivery-method-text" hidden="true">
-          <%= f.label :modal_button_text, class: "usa-label" %>
-          <%= f.text_field :modal_button_text, class: "usa-input" %>
-        </div>
-        <div class="field" id="delivery-method-html-id" hidden="true">
-          <%= f.label :element_selector, class: "usa-label" %>
-          <%= f.text_field :element_selector, class: "usa-input", placeholder: "#html-element-id" %>
-        </div>
-      </div>
-    </div>
-    <br>
-    <%= render 'components/whitelist_options', f: f %>
-  </div>
   <% end %>
   <p>
     <%= f.submit (form.persisted? ? "Update Survey" : "Create Survey"), class: "usa-button" %>

--- a/app/views/admin/forms/_nav.html.erb
+++ b/app/views/admin/forms/_nav.html.erb
@@ -10,6 +10,11 @@
     <% end %>
   </li>
   <li class="usa-button-group__item">
+    <%= link_to delivery_method_admin_form_path(form), class: "usa-button #{current_path == delivery_method_admin_form_path(form) ? nil : 'usa-button--outline'}" do %>
+      Delivery Method
+    <% end %>
+  </li>
+  <li class="usa-button-group__item">
     <%= link_to responses_admin_form_path(form), class: "usa-button #{current_path == responses_admin_form_path(form) ? nil : 'usa-button--outline'}" do %>
       Responses
     <% end %>

--- a/app/views/admin/forms/_nav.html.erb
+++ b/app/views/admin/forms/_nav.html.erb
@@ -11,7 +11,7 @@
   </li>
   <li class="usa-button-group__item">
     <%= link_to delivery_method_admin_form_path(form), class: "usa-button #{current_path == delivery_method_admin_form_path(form) ? nil : 'usa-button--outline'}" do %>
-      Delivery Method
+      Delivery method
     <% end %>
   </li>
   <li class="usa-button-group__item">

--- a/app/views/admin/forms/delivery_method.html.erb
+++ b/app/views/admin/forms/delivery_method.html.erb
@@ -28,11 +28,7 @@
   <% end %>
   <div class="grid-row">
     <div class="grid-col">
-
-      <div class="well">
-        <h2>
-          Delivery Options
-        </h2>
+      <div>
         <div class="usa-alert usa-alert--info">
           <div class="usa-alert__body">
             <p class="usa-alert__text">
@@ -69,7 +65,9 @@
 
         <br>
         <fieldset class="usa-fieldset">
-          <legend class="usa-sr-only">Delivery Methods</legend>
+          How will users access this survey?
+          <br>
+          <legend class="usa-sr-only">Delivery methods</legend>
           <% Form::DELIVERY_METHODS.each_with_index do |delivery_method, index| %>
             <div class="usa-checkbox">
               <%= f.radio_button :delivery_method, delivery_method[0], class: "usa-radio__input"  %>
@@ -85,7 +83,7 @@
             </div>
             <div class="field" id="delivery-method-html-id" hidden="true">
               <%= f.label :element_selector, class: "usa-label" %>
-              <%= f.text_field :element_selector, class: "usa-input", placeholder: "#html-element-id" %>
+              <%= f.text_field :element_selector, class: "usa-input", placeholder: "html-element-id" %>
             </div>
           </div>
         </div>
@@ -101,15 +99,15 @@
               <div class="usa-alert usa-alert--info">
                   <div class="usa-alert__body">
                     <p class="usa-alert__text">
-                      Once delivery options have been saved you can preview this survey by clicking the below button:
+                      After the delivery method has been saved you can preview this survey.
                     </p>
-                    <br/>
-                    <%= link_to example_admin_form_path(@form), class: "usa-button", target: "_blank", rel: "noopener" do %>
-                      <i class="fa fa-eye"></i>
-                      Preview
-                    <% end %>
                   </div>
               </div>
+              <br>
+              <%= link_to example_admin_form_path(@form), class: "usa-button usa-button--outline full-width", target: "_blank", rel: "noopener" do %>
+                <i class="fa fa-eye"></i>
+                Preview
+              <% end %>
             </div>
           </div>
     </div>

--- a/app/views/admin/forms/delivery_method.html.erb
+++ b/app/views/admin/forms/delivery_method.html.erb
@@ -1,0 +1,144 @@
+<% content_for :navigation_title do %>
+  Editing Delivery Method for: <%= @form.name %>
+<% end %>
+<p>
+  <%= link_to admin_forms_path do %>
+    <i class="fa fa-arrow-circle-left"></i>
+    Back to Surveys
+  <% end %>
+</p>
+<%= render 'admin/forms/nav', form: @form %>
+<br>
+<%= form_with(model: @form, url: (@form.persisted? ? admin_form_path(@form) : admin_forms_path), local: true) do |f| %>
+  <% if @form.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@form.errors.count, "error") %> prohibited this form from being saved:</h2>
+
+      <% @form.errors.full_messages.each do |message| %>
+        <div class="usa-alert usa-alert--error" >
+          <div class="usa-alert__body">
+            <h3 class="usa-alert__heading">Error</h3>
+            <p class="usa-alert__text">
+              <%= message %>
+            </p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <div class="grid-row">
+    <div class="grid-col">
+
+      <div class="well">
+        <h2>
+          Delivery Options
+        </h2>
+        <div class="usa-alert usa-alert--info">
+          <div class="usa-alert__body">
+            <p class="usa-alert__text">
+              <strong>How will users access this survey?</strong>
+              <br>
+              When a Touchpoint is published,
+              it will be available at a URL on Touchpoints.
+              <br>
+
+              Additionally, a survey form can be embedded on an existing web property
+              using one of three different methods:
+              <ol>
+                <li>
+                  <strong>Tab button &amp; modal</strong> -
+                  Touchpoints will insert a default button on your website with
+                  the text that you indicate.  The button will launch
+                  a modal box displaying your survey
+                </li>
+                <li>
+                  <strong>Custom button &amp; modal</strong> -
+                  Works like the modal, except you provide your own custom
+                  styled button with the use of a
+                  #html-element-id
+                </li>
+                <li>
+                  <strong>Inline</strong> -
+                  Touchpoints will embed your survey directly onto your
+                  website using a #html-element-id
+                </li>
+              </ol>
+            </p>
+          </div>
+        </div>
+
+        <br>
+        <fieldset class="usa-fieldset">
+          <legend class="usa-sr-only">Delivery Methods</legend>
+          <% Form::DELIVERY_METHODS.each_with_index do |delivery_method, index| %>
+            <div class="usa-checkbox">
+              <%= f.radio_button :delivery_method, delivery_method[0], class: "usa-radio__input"  %>
+              <%= f.label delivery_method[1], class: "usa-radio__label", for: "form_delivery_method_#{delivery_method[0]}" %>
+            </div>
+          <% end %>
+        </fieldset>
+        <div class="grid-row">
+          <div class="grid-col-6">
+            <div class="field" id="delivery-method-text" hidden="true">
+              <%= f.label :modal_button_text, class: "usa-label" %>
+              <%= f.text_field :modal_button_text, class: "usa-input" %>
+            </div>
+            <div class="field" id="delivery-method-html-id" hidden="true">
+              <%= f.label :element_selector, class: "usa-label" %>
+              <%= f.text_field :element_selector, class: "usa-input", placeholder: "#html-element-id" %>
+            </div>
+          </div>
+        </div>
+        <br>
+        <%= render 'components/whitelist_options', f: f %>
+        <p>
+          <%= f.submit (@form.persisted? ? "Update Survey" : "Create Survey"), class: "usa-button" %>
+        </p>
+        </div>
+        <div class="grid-row">
+          <div class="grid-col">
+            <div class="well">
+              <div class="usa-alert usa-alert--info">
+                  <div class="usa-alert__body">
+                    <p class="usa-alert__text">
+                      Once delivery options have been saved you can preview this survey by clicking the below button:
+                    </p>
+                    <br/>
+                    <%= link_to example_admin_form_path(@form), class: "usa-button", target: "_blank", rel: "noopener" do %>
+                      <i class="fa fa-eye"></i>
+                      Preview
+                    <% end %>
+                  </div>
+              </div>
+            </div>
+          </div>
+    </div>
+</div>
+<% end %>
+
+<script>
+  $(function() {
+    $("#form_delivery_method_touchpoints-hosted-only").click(function() {
+      $('#delivery-method-text').hide();
+      $('#delivery-method-html-id').hide();
+      $('#allowlist-options').hide();
+    });
+    $("#form_delivery_method_modal").click(function() {
+      $('#delivery-method-text').show();
+      $('#delivery-method-html-id').hide();
+      $('#allowlist-options').show();
+    });
+    $("#form_delivery_method_custom-button-modal").click(function() {
+      $('#delivery-method-text').hide();
+      $('#delivery-method-html-id').show();
+      $('#allowlist-options').show();
+    });
+    $("#form_delivery_method_inline").click(function() {
+      $('#delivery-method-text').hide();
+      $('#delivery-method-html-id').show();
+      $('#allowlist-options').show();
+    });
+
+    $("#form_delivery_method_<%= @form.delivery_method %>").click();
+  });
+</script>

--- a/app/views/components/_whitelist_options.html.erb
+++ b/app/views/components/_whitelist_options.html.erb
@@ -1,4 +1,4 @@
-<div id="allowlist-options">
+<div id="allowlist-options" class="well">
   <h3>
     Allow responses from specified hosts
   </h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
         get "compliance", to: "forms#compliance", as: :compliance
         get "questions", to: "forms#questions", as: :questions
         get "responses", to: "forms#responses", as: :responses
+        get "delivery_method", to: "forms#delivery_method", as: :delivery_method
         post "add_user", to: "forms#add_user", as: :add_user
         post "copy", to: "forms#copy", as: :copy
         post "publish", to: "forms#publish", as: :publish

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -339,6 +339,40 @@ feature "Forms", js: true do
         end
       end
 
+      context "Edit Delivery Method" do
+        let!(:form) { FactoryBot.create(:form, :custom, organization: organization, user: admin) }
+        let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: admin, form: form) }
+
+        before do
+          login_as(admin)
+          visit delivery_method_admin_form_path(form)
+        end
+
+        describe "editing the whitelist url" do
+          before do
+            fill_in "form_whitelist_url", with: "example.com"
+            click_on "Update Survey"
+          end
+
+          it "can edit existing Form" do
+            expect(page).to have_content("Survey was successfully updated.")
+            expect(page.current_path).to eq(delivery_method_admin_form_path(form))
+            expect(find("#form_whitelist_url").value).to eq("example.com")
+          end
+        end
+
+        describe "editing the delivery method" do
+          before do
+            find('label', :text => 'Custom button & modal').click
+            click_on "Update Survey"
+          end
+
+          it "fails without specifying the selector" do
+            expect(page).to have_content("Element selector can't be blank for an inline form")
+          end
+        end
+      end
+
       context "Edit Form page" do
         let!(:form) { FactoryBot.create(:form, :custom, organization: organization, user: admin) }
         let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user: admin, form: form) }


### PR DESCRIPTION
Delivery method as it's own step

Linked Issue:  https://trello.com/c/5Y1sQrLE/1259-the-delivery-method-as-a-step

@ryanwoldatwork   Just wanted to note that I put preview at the bottom of the page and stripped out all the published / not-published logic and embed scripts and such.  It is my opinion that at this point the user just wants to see what each delivery method will look like.   And I didn't want to put the preview button in-line with all the delivery mode options as the preview button will on show the new options after they are saved.   

So I added that note and added it as a last step on the page.   

Let me know if you think this approach makes sense and is intuitive for the users.