### PR TITLE
TP-1258 move success text and heading to questions page

### DIFF
--- a/app/controllers/admin/forms_controller.rb
+++ b/app/controllers/admin/forms_controller.rb
@@ -22,7 +22,7 @@ class Admin::FormsController < AdminController
     :publish,
     :archive,
     :update_ui_truncation,
-    :update_title, :update_instructions, :update_disclaimer_text
+    :update_title, :update_instructions, :update_disclaimer_text, :update_success_text
   ]
 
   def index
@@ -97,6 +97,11 @@ class Admin::FormsController < AdminController
   def update_disclaimer_text
     @form.update!(disclaimer_text: params[:disclaimer_text])
     render json: @form
+  end
+
+  def update_success_text
+    @form.update!(success_text: params[:success_text], success_text_heading: params[:success_text_heading])
+    render(partial: "admin/questions/success_text", locals: { form: @form })
   end
 
   def show
@@ -413,6 +418,8 @@ class Admin::FormsController < AdminController
         :whitelist_url,
         :whitelist_test_url,
         :disclaimer_text,
+        :success_text,
+        :success_text_heading,
 
         # PRA Info
         :omb_approval_number,

--- a/app/views/admin/forms/_form.html.erb
+++ b/app/views/admin/forms/_form.html.erb
@@ -143,34 +143,6 @@
       </fieldset>
     </div>
   </div>
-  <div class="grid-row grid-gap-md">
-    <div class="grid-col-6">
-      <div class="field">
-        <%= f.label :success_text_heading, class: "usa-label" %>
-        <%= f.text_field :success_text_heading, class: "usa-input" %>
-      </div>
-      <div class="field">
-        <%= f.label :success_text, class: "usa-label" %>
-        <div>
-          <em>
-            Displayed after a Form is submitted.
-          </em>
-        </div>
-        <%= f.text_area :success_text, class: "usa-textarea" %>
-      </div>
-    </div>
-    <div class="grid-col-6 flash-preview">
-      <br>
-      <br>
-      <br>
-      <%= render 'components/forms/flash', form: @form %>
-    </div>
-    <script>
-      $(function() {
-        $(".flash-preview .usa-alert--success").removeAttr("hidden");
-      });
-    </script>
-  </div>
   <br>
   <% end %>
   <p>

--- a/app/views/admin/questions/_success_text.html.erb
+++ b/app/views/admin/questions/_success_text.html.erb
@@ -1,0 +1,43 @@
+<%= form_with(model: form, url: (form.persisted? ? admin_form_path(form) : admin_forms_path), local: true) do |f| %>
+  <div class="grid-row grid-gap-md">
+    <div class="grid-col-6">
+      <div class="field">
+        <%= f.label :success_text_heading, "SUCCESS TEXT HEADING", class: "usa-label text-uppercase font-body-3xs" %>
+        <%= f.text_field :success_text_heading, class: "usa-input success_text", data_url:  admin_form_path(form) %>
+      </div>
+      <div class="field">
+        <%= f.label :success_text, "SUCCESS TEXT", class: "usa-label text-uppercase font-body-3xs" %>
+        <div>
+          <em>
+            Displayed after a Form is submitted.
+          </em>
+        </div>
+        <%= f.text_area :success_text, class: "usa-textarea success_text", data_url:  admin_form_path(form)  %>
+      </div>
+    </div>
+    <div class="grid-col-6 flash-preview">
+      <br>
+      <br>
+      <br>
+      <%= render 'components/forms/flash', form: form %>
+    </div>
+    <script>
+      $(function() {
+        $(".flash-preview .usa-alert--success").removeAttr("hidden");
+      });
+      $(".success_text").on("blur", function(event) {
+        event.preventDefault();
+        $.ajax({
+          type: "PATCH",
+          url: $(this).attr("data_url") + "/update_success_text",
+          data: {
+            success_text: $(form_success_text).val(),
+            success_text_heading: $(form_success_text_heading).val()
+          }
+        }).done(function(data) {
+          $("#success_text_div").html(data);
+        });
+      });
+    </script>
+  </div>
+<% end %>

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -57,6 +57,11 @@
     </div>
   </div>
 </div>
+<br/>
+<hr style="border: none; border-top: 1px solid #E5E5E5;">
+<div id="success_text_div">
+  <%= render "admin/questions/success_text", {form: form} %>
+</div>
 <br>
 
 <script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
         patch "update_title", to: "forms#update_title", as: :update_title
         patch "update_instructions", to: "forms#update_instructions", as: :update_instructions
         patch "update_disclaimer_text", to: "forms#update_disclaimer_text", as: :update_disclaimer_text
+        patch "update_success_text", to: "forms#update_success_text", as: :update_success_text
         patch "update_ui_truncation", to: "forms#update_ui_truncation", as: :update_ui_truncation
       end
       collection do

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -253,6 +253,30 @@ feature "Forms", js: true do
               expect(find("#disclaimer_text-show")).to have_content("Disclaaaaaaaimer!")
               expect(find("#disclaimer_text-show")).to have_link("a new link")
             end
+
+            it "has inline editable success text heading that can be updated and saved" do
+              fill_in("form_success_text_heading", with: "Sucesssss Header!")
+              within "#success_text_div" do
+                find("#form_success_text_heading").native.send_key :tab
+                expect(page).to have_content( "Sucesssss Header!")
+              end
+
+              # and persists after refresh
+              visit questions_admin_form_path(form)
+              expect(page).to have_content("Sucesssss Header!")
+            end
+
+            it "has inline editable success text textbox that can be updated and saved" do
+              fill_in("form_success_text", with: "Sucesssss!")
+              within "#success_text_div" do
+                find("#form_success_text").native.send_key :tab
+                expect(page).to have_content("Sucesssss!")
+              end
+
+              # and persists after refresh
+              visit questions_admin_form_path(form)
+              expect(page).to have_content("Sucesssss!")
+            end
           end
         end
 


### PR DESCRIPTION
TP-1258 move success text and heading to questions page

Linked Trello ticket: https://trello.com/c/rXEEFTcI/1258-show-this-success-modal-on-the-questions-design-page