### PR TITLE
TP-393 Disable submit button

### DIFF
--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -87,9 +87,8 @@
         <% end %>
         <% if section == form.form_sections.last && !form.suppress_submit_button %>
           <p class="submit-button">
-            <button type="submit" id="submit_form_button" class="usa-button"><%= t 'form.submit' %></button>
+            <button type="submit" class="usa-button submit_form_button"><%= t 'form.submit' %></button>
           </p>
-          <span class="submit-notice" hidden="true">Your submission has been sent...</span>
         <% end %>
       </div>
     <% end %>

--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -87,14 +87,20 @@
         <% end %>
         <% if section == form.form_sections.last && !form.suppress_submit_button %>
           <p class="submit-button">
-            <button type="submit" class="usa-button"><%= t 'form.submit' %></button>
+            <button type="submit" id="submit_form_button" class="usa-button"><%= t 'form.submit' %></button>
           </p>
+          <span class="submit-notice" hidden="true">Your submission has been sent...</span>
         <% end %>
       </div>
     <% end %>
   </div>
 </form>
 <script>
+  $('#submit_form_button').click(function(e) {
+    $(this).prop("disabled",true);
+    $(this).addClass("aria-disabled");
+    $(".submit-notice").show();
+  });
   // Set 'other' type checkbox option values when associated option text field is updated
   $('.usa-input.other-option').keyup(function() {
     // strip commas

--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -87,20 +87,14 @@
         <% end %>
         <% if section == form.form_sections.last && !form.suppress_submit_button %>
           <p class="submit-button">
-            <button type="submit" id="submit_form_button" class="usa-button"><%= t 'form.submit' %></button>
+            <button type="submit" class="usa-button"><%= t 'form.submit' %></button>
           </p>
-          <span class="submit-notice" hidden="true">Your submission has been sent...</span>
         <% end %>
       </div>
     <% end %>
   </div>
 </form>
 <script>
-  $('#submit_form_button').click(function(e) {
-    $(this).prop("disabled",true);
-    $(this).addClass("aria-disabled");
-    $(".submit-notice").show();
-  });
   // Set 'other' type checkbox option values when associated option text field is updated
   $('.usa-input.other-option').keyup(function() {
     // strip commas

--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -87,8 +87,9 @@
         <% end %>
         <% if section == form.form_sections.last && !form.suppress_submit_button %>
           <p class="submit-button">
-            <button type="submit" class="usa-button"><%= t 'form.submit' %></button>
+            <button type="submit" id="submit_form_button" class="usa-button"><%= t 'form.submit' %></button>
           </p>
+          <span class="submit-notice" hidden="true">Your submission has been sent...</span>
         <% end %>
       </div>
     <% end %>

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -283,6 +283,10 @@ function FBAform(d, N) {
 			questionDiv.appendChild(input);
 			questionDiv.scrollIntoView();
 			questionDiv.focus();
+			// enable submit button ( so user can fix error and resubmit )
+		    document.querySelector('#submit_form_button').disabled = false;
+		    document.querySelector('#submit_form_button').classList.remove("aria-disabled");
+		    document.querySelector(".submit-notice").style.display = "none";
 		},
 		hideValidationError: function(form) {
 			var elem = form.querySelector('.usa-form-group--error');
@@ -292,6 +296,10 @@ function FBAform(d, N) {
 			if (elem != null) elem.parentNode.removeChild(elem);
 			elem = form.querySelector('#input-error');
 			if (elem != null) elem.parentNode.removeChild(elem);
+			// disable submit button
+		    document.querySelector('#submit_form_button').disabled = true;
+		    document.querySelector('#submit_form_button').classList.add("aria-disabled");
+		    document.querySelector(".submit-notice").style.display = "block";
 		},
 		textCounter: function(field,maxlimit)
 			{

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -172,8 +172,11 @@ function FBAform(d, N) {
 			var formElement = this.formElement();
 			var self = this;
 			if (self.validateForm(formElement)) {
+				// disable submit button and show sending feedback message
 				var submitButton = formElement.querySelector("[type='submit']");
 				submitButton.disabled = true;
+				submitButton.classList.add("aria-disabled");
+		    	document.querySelector(".submit-notice").style.display = "block";
 				self.sendFeedback();
 			}
 		},
@@ -284,8 +287,9 @@ function FBAform(d, N) {
 			questionDiv.scrollIntoView();
 			questionDiv.focus();
 			// enable submit button ( so user can fix error and resubmit )
-		    document.querySelector('#submit_form_button').disabled = false;
-		    document.querySelector('#submit_form_button').classList.remove("aria-disabled");
+			var submitButton = document.querySelector("[type='submit']");
+			submitButton.disabled = false;
+			submitButton.classList.remove("aria-disabled");
 		    document.querySelector(".submit-notice").style.display = "none";
 		},
 		hideValidationError: function(form) {
@@ -296,10 +300,6 @@ function FBAform(d, N) {
 			if (elem != null) elem.parentNode.removeChild(elem);
 			elem = form.querySelector('#input-error');
 			if (elem != null) elem.parentNode.removeChild(elem);
-			// disable submit button
-		    document.querySelector('#submit_form_button').disabled = true;
-		    document.querySelector('#submit_form_button').classList.add("aria-disabled");
-		    document.querySelector(".submit-notice").style.display = "block";
 		},
 		textCounter: function(field,maxlimit)
 			{

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -176,7 +176,6 @@ function FBAform(d, N) {
 				var submitButton = formElement.querySelector("[type='submit']");
 				submitButton.disabled = true;
 				submitButton.classList.add("aria-disabled");
-		    	document.querySelector(".submit-notice").style.display = "block";
 				self.sendFeedback();
 			}
 		},
@@ -286,11 +285,11 @@ function FBAform(d, N) {
 			questionDiv.appendChild(input);
 			questionDiv.scrollIntoView();
 			questionDiv.focus();
+
 			// enable submit button ( so user can fix error and resubmit )
 			var submitButton = document.querySelector("[type='submit']");
 			submitButton.disabled = false;
 			submitButton.classList.remove("aria-disabled");
-		    document.querySelector(".submit-notice").style.display = "none";
 		},
 		hideValidationError: function(form) {
 			var elem = form.querySelector('.usa-form-group--error');

--- a/spec/features/embedded_touchpoints_spec.rb
+++ b/spec/features/embedded_touchpoints_spec.rb
@@ -39,7 +39,7 @@ feature "Touchpoints", js: true do
           select("Option 2", from: "answer_06")
           click_on "Next"
           expect(page).to have_content("Custom elements")
-          click_on "Submit"
+          find("#submit_form_button").click
 
           # shows success flash message
           expect(page).to have_content("Success")

--- a/spec/features/embedded_touchpoints_spec.rb
+++ b/spec/features/embedded_touchpoints_spec.rb
@@ -39,7 +39,7 @@ feature "Touchpoints", js: true do
           select("Option 2", from: "answer_06")
           click_on "Next"
           expect(page).to have_content("Custom elements")
-          find("#submit_form_button").click
+          find(".submit_form_button").click
 
           # shows success flash message
           expect(page).to have_content("Success")

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -256,7 +256,7 @@ feature "Touchpoints", js: true do
 
       it "can successfully submit after completing the required question" do
         fill_in("answer_01", with: "a response to this required question")
-        click_button "Submit"
+        find("#submit_form_button").click
         expect(page).to have_content("Thank you. Your feedback has been received.")
       end
     end

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -256,7 +256,7 @@ feature "Touchpoints", js: true do
 
       it "can successfully submit after completing the required question" do
         fill_in("answer_01", with: "a response to this required question")
-        find("#submit_form_button").click
+        find(".submit_form_button").click
         expect(page).to have_content("Thank you. Your feedback has been received.")
       end
     end


### PR DESCRIPTION
TP-393 Disable submit button

Linked PR:  https://trello.com/c/WYxQR7lZ/393-on-submit-disable-the-button-and-indicate-to-the-user-the-request-has-been-made-and-were-waiting-on-a-response

@ryanwoldatwork This disables the submit button and shows a "submitted message", but I wonder how useful this is since the page disappears so quickly on submit and is redirected to the success page.

I'm wondering if the intent of this ticket is really to prevent multiple submissions by  disabling the submit if a submission for the form already exists for the user?