### PR TITLE
TP-1266 Add new accounts over time chart to admin dashboard

### DIFF
--- a/app/controllers/admin/site_controller.rb
+++ b/app/controllers/admin/site_controller.rb
@@ -1,10 +1,10 @@
 class Admin::SiteController < AdminController
   def index
     @forms = Form.non_templates
-    @response_groups = Submission.group("date(created_at)").size.sort.last(45)
-    @user_groups = User.group("date(created_at)").size.sort.last(45)
 
-    @days_since = params[:recent] && params[:recent].to_i <= 30 ? params[:recent].to_i : 3
+    @days_since = params[:recent] && params[:recent].to_i <= 90 ? params[:recent].to_i : 3
+    @response_groups = Submission.group("date(created_at)").size.sort.last(@days_since.days)
+    @user_groups = User.group("date(created_at)").size.sort.last(@days_since.days)
     todays_submissions = Submission.where("created_at > ?", Time.now - @days_since.days)
     form_ids = todays_submissions.collect(&:form_id).uniq
     @recent_forms = Form.find(form_ids)

--- a/app/controllers/admin/site_controller.rb
+++ b/app/controllers/admin/site_controller.rb
@@ -3,9 +3,20 @@ class Admin::SiteController < AdminController
     @forms = Form.non_templates
 
     @days_since = params[:recent] && params[:recent].to_i <= 90 ? params[:recent].to_i : 3
-    @response_groups = Submission.group("date(created_at)").size.sort.last(@days_since.days)
-    @user_groups = User.group("date(created_at)").size.sort.last(@days_since.days)
+    @dates = (@days_since.days.ago.to_date..Date.today).map{ |date| date }
+
+    @response_groups = Submission.group("date(created_at)").count.sort.last(@days_since.days)
+    @user_groups = User.group("date(created_at)").count.sort.last(@days_since.days)
     todays_submissions = Submission.where("created_at > ?", Time.now - @days_since.days)
+
+    # Add in 0 count days to fetched analytics
+    @dates.each do | date |
+      @user_groups << [date, 0] unless @user_groups.detect{ | row | row[0].strftime("%m %d %Y") == date.strftime("%m %d %Y")}
+      @response_groups << [date, 0] unless @response_groups.detect{ | row | row[0].strftime("%m %d %Y") == date.strftime("%m %d %Y")}
+    end
+    @user_groups = @user_groups.sort
+    @response_groups = @response_groups.sort
+
     form_ids = todays_submissions.collect(&:form_id).uniq
     @recent_forms = Form.find(form_ids)
   end

--- a/app/controllers/admin/site_controller.rb
+++ b/app/controllers/admin/site_controller.rb
@@ -2,6 +2,7 @@ class Admin::SiteController < AdminController
   def index
     @forms = Form.non_templates
     @response_groups = Submission.group("date(created_at)").size.sort.last(45)
+    @user_groups = User.group("date(created_at)").size.sort.last(45)
 
     @days_since = params[:recent] && params[:recent].to_i <= 30 ? params[:recent].to_i : 3
     todays_submissions = Submission.where("created_at > ?", Time.now - @days_since.days)

--- a/app/views/admin/site/index.html.erb
+++ b/app/views/admin/site/index.html.erb
@@ -125,9 +125,36 @@
         </p>
       </div>
       <%= render 'components/weekly_metrics', forms: @forms %>
-      <%= render 'components/admin/recent_responses', forms: @recent_forms, days_since: @days_since %>
-      <%= render 'components/admin/responses_per_day', response_groups: @response_groups %>
-      <%= render 'components/admin/new_users_over_time', user_groups: @user_groups %>
+      <div class="well">
+        <h3>
+          Data collected over past <%= @days_since %> days
+        </h3>
+        <p>
+          See the last:
+          <a href="?recent=7">
+            7 days
+          </a>
+          &middot;
+          <a href="?recent=14">
+            14 days
+          </a>
+          &middot;
+          <a href="?recent=30">
+            30 days
+          </a>
+          &middot;
+          <a href="?recent=60">
+            60 days
+          </a>
+          &middot;
+          <a href="?recent=90">
+            90 days
+          </a>
+        </p>
+        <%= render 'components/admin/recent_responses', forms: @recent_forms, days_since: @days_since %>
+        <%= render 'components/admin/responses_per_day', response_groups: @response_groups %>
+        <%= render 'components/admin/new_users_over_time', user_groups: @user_groups %>
+      </div>
       <% else %>
         <h4>
           Get started with Touchpoints:

--- a/app/views/admin/site/index.html.erb
+++ b/app/views/admin/site/index.html.erb
@@ -127,7 +127,7 @@
       <%= render 'components/weekly_metrics', forms: @forms %>
       <%= render 'components/admin/recent_responses', forms: @recent_forms, days_since: @days_since %>
       <%= render 'components/admin/responses_per_day', response_groups: @response_groups %>
-
+      <%= render 'components/admin/new_users_over_time', user_groups: @user_groups %>
       <% else %>
         <h4>
           Get started with Touchpoints:

--- a/app/views/components/admin/_new_users_over_time.html.erb
+++ b/app/views/components/admin/_new_users_over_time.html.erb
@@ -2,7 +2,7 @@
   <h3>
     New Users per day
   </h3>
-
+  <p>Total user accounts created over period: <%= user_groups.sum { | n | n[1] } %> </p>
   <div style="width:100%;">
     <canvas id="userChart"></canvas>
   </div>

--- a/app/views/components/admin/_new_users_over_time.html.erb
+++ b/app/views/components/admin/_new_users_over_time.html.erb
@@ -1,0 +1,47 @@
+<div id="daily-new-users">
+  <h3>
+    New Users per day
+  </h3>
+
+  <div style="width:100%;">
+    <canvas id="userChart"></canvas>
+  </div>
+</div>
+
+<script>
+$(function() {
+  var ctx = document.getElementById('userChart').getContext('2d');
+  var myChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: [
+      <% user_groups.each do |key, value| %>
+        '<%= key.strftime("%m-%d") %>',
+      <% end %>
+      ],
+      datasets: [{
+        label: '# of Users',
+        data: [
+        <% user_groups.each do |key, value| %>
+          <%= value %>,
+        <% end %>
+        ],
+        backgroundColor: "#E1F3F8"
+      }]
+    },
+    options: {
+      responsive: true,
+      legend: {
+        position: 'bottom',
+      },
+      scales: {
+        yAxes: [{
+          ticks: {
+            beginAtZero: true
+          }
+        }]
+      }
+    }
+  });
+})
+</script>

--- a/app/views/components/admin/_recent_responses.html.erb
+++ b/app/views/components/admin/_recent_responses.html.erb
@@ -1,7 +1,4 @@
 <div id="recent-responses">
-  <h3>
-    Recent Responses (last <%= days_since %> days)
-  </h3>
   <% if forms.present?  %>
     <table class="usa-table">
       <thead>
@@ -42,18 +39,4 @@
       </div>
     </div>
   <% end %>
-  <p>
-    See the last:
-    <a href="?recent=7">
-      7 days
-    </a>
-    &middot;
-    <a href="?recent=14">
-      14 days
-    </a>
-    &middot;
-    <a href="?recent=30">
-      30 days
-    </a>
-  </p>
 </div>

--- a/app/views/components/admin/_responses_per_day.html.erb
+++ b/app/views/components/admin/_responses_per_day.html.erb
@@ -2,7 +2,7 @@
   <h3>
     Responses per day
   </h3>
-
+  <p>Total submissions received over period: <%= response_groups.sum { | n | n[1] } %> </p>
   <div style="width:100%;">
     <canvas id="myChart"></canvas>
   </div>

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -60,13 +60,27 @@ feature "Admin Dashboard", js: true do
           answer_01: "yes",
           created_at: Time.now - 5.days
         })
+        User.create({
+          email: 'tester1@example.com',
+          created_at: Time.now - 10.days
+        })
+        User.create({
+          email: 'tester2@example.com',
+          created_at: Time.now - 5.days
+        })
+        User.create({
+          email: 'tester3@example.com',
+          created_at: Time.now - 5.days
+        })
         visit admin_dashboard_path
       end
 
       it "display weekly metrics" do
         expect(page).to have_css("#daily-responses")
-        expect(page).to have_css("canvas")
+        expect(page).to have_css("#daily-new-users")
+        expect(find_all("canvas").size).to eq(2)
       end
+
     end
 
     describe "#a11" do


### PR DESCRIPTION
TP-1266 Add new accounts over time chart to admin dashboard

Linked Trello:  https://trello.com/c/TkSl1Yy6/1266-new-users-over-time

@ryanwoldatwork This chart displays new user accounts over the past 45 days ( same as response chart ).   What do you think about adding a dropdown with options such as Last Week/Mondy/Quarter/Year?   Or maybe even "Show data from X days ago"?