### PR TITLE
TP-1308 replace inner join wiith correlated sub query

### DIFF
--- a/app/controllers/admin/reporting_controller.rb
+++ b/app/controllers/admin/reporting_controller.rb
@@ -27,12 +27,11 @@ class Admin::ReportingController < AdminController
     end
 
     render plain: row.join("\n")
-
   end
 
   def lifespan
-    @form_lifespans = Submission.select("form_id,count(*) as num_submissions,(max(submissions.created_at) - min(submissions.created_at)) as lifespan").group(:form_id)
-    @forms = Form.select(:id,:name,:organization_id).where(" exists ( select id from submissions where submissions.form_id = forms.id )")
+    @form_lifespans = Submission.select("form_id, count(*) as num_submissions, (max(submissions.created_at) - min(submissions.created_at)) as lifespan").group(:form_id)
+    @forms = Form.select(:id,:name,:organization_id).where("exists (select id from submissions where submissions.form_id = forms.id)")
     @orgs = Organization.all.order(:name)
     @org_summary = []
     @orgs.each do | org |
@@ -41,13 +40,13 @@ class Admin::ReportingController < AdminController
       org_row[:forms] = []
       total_lifespan = 0
       total_submissions = 0
-      @forms.select { | form | form.organization_id == org.id }.each do | org_form |
+      @forms.select { |form| form.organization_id == org.id }.each do |org_form|
         form_summary = {}
         form_summary[:id] = org_form.id
         form_summary[:name] = org_form.name
-        form_summary[:counts] = @form_lifespans.select { | row | row.form_id == org_form.id }.first
-        total_lifespan +=  form_summary[:counts].lifespan if form_summary[:counts].present?
-        total_submissions +=  form_summary[:counts].num_submissions if form_summary[:counts].present?
+        form_summary[:counts] = @form_lifespans.select { |row| row.form_id == org_form.id }.first
+        total_lifespan += form_summary[:counts].lifespan if form_summary[:counts].present?
+        total_submissions += form_summary[:counts].num_submissions if form_summary[:counts].present?
         org_row[:forms] << form_summary
       end
       org_row[:submissions] = total_submissions


### PR DESCRIPTION
TP-1308 replace inner join wiith correlated sub query

Correlated subquery performs much better and completes every time in under 1 second within production rails console.

Linked Ticket: https://trello.com/c/F9snvBxu/1308-https-touchpointsappcloudgov-admin-reporting-lifespan-isnt-loading-times-out