### PR TITLE
TP-1324 show page with error if hidden on form submission

### DIFF
--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -285,9 +285,19 @@ function FBAform(d, N) {
 			return true;
 		},
 		showValidationError: function(question,error) {
+
 			var questionDiv = question.closest(".question");
 			var label = questionDiv.querySelector("label");
 			var questionNum = label.innerText;
+
+			// show page with validation error
+			var errorPage = question.closest(".section");
+			if (!errorPage.classList.contains("visible")) {
+				var visiblePage = document.getElementsByClassName("section visible")[0];
+				visiblePage.classList.remove("visible");
+				errorPage.classList.add("visible");
+			}
+
 			questionDiv.setAttribute('class', 'usa-form-group usa-form-group--error');
 			var span = document.createElement('span');
 			span.setAttribute('id', 'input-error-message');

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -188,6 +188,23 @@ feature "Touchpoints", js: true do
       end
     end
 
+    describe "multi-page early submission form" do
+      let!(:multi_form) { FactoryBot.create(:form, :kitchen_sink, organization: organization, user: user) }
+
+      context "when required on 2nd page" do
+        before do
+          multi_form.update(early_submission: true)
+          multi_form.form_sections[1].questions.first.update(is_required: true)
+          visit touchpoint_path(multi_form)
+        end
+
+        it "display flash message" do
+          click_on "No, only submit these responses"
+          expect(page).to have_content("You must respond to question:")
+        end
+      end
+    end
+
     describe "phone number question" do
       let!(:dropdown_form) { FactoryBot.create(:form, :phone, organization: organization, user: user) }
 


### PR DESCRIPTION
TP-1324 show page with error if hidden on form submission

Update fba.js showValidationError to check if the page with the validation error is visible and, if not, show it.