### PR TITLE
TP-1331 adjust completions logic

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -54,6 +54,14 @@ class SubmissionsController < ApplicationController
       }, status: :unprocessable_entity and return
     end
 
+    # Prevent the submission for archived forms
+    if @form && @form.archived?
+      render json: {
+        status: :unprocessable_entity,
+        messages: { submission: [t('errors.form_is_archived')] }
+      }, status: :unprocessable_entity and return
+    end
+
     @submission = Submission.new(submission_params)
     @submission.form = @form
     @submission.user_agent = request.user_agent

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -10,7 +10,7 @@ class SubmissionsController < ApplicationController
     elsif !@form.deployable_form? && !current_user
       redirect_to index_path, alert: 'Form is not currently deployed.'
     end
-    @form.increment!(:survey_form_activations) #unless current_user
+    @form.increment!(:survey_form_activations) unless current_user
     @submission = Submission.new
     # set location code in the form based on `?location_code=`
     @submission.location_code = params[:location_code]
@@ -68,7 +68,9 @@ class SubmissionsController < ApplicationController
 
     def create_in_local_database(submission)
       respond_to do |format|
-        if submission.save
+        # Return success if the form is in preview state ( not deployable) or the form saves successfully
+        # If the form is not deployable ( live ) we should not persist the submission
+        if (!submission.form.deployable_form? || submission.save)
           format.html do
             redirect_to submit_touchpoint_path(submission.form),
                         notice: 'Thank You. Response was submitted successfully.'

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -10,7 +10,7 @@ class SubmissionsController < ApplicationController
     elsif !@form.deployable_form? && !current_user
       redirect_to index_path, alert: 'Form is not currently deployed.'
     end
-    @form.increment!(:survey_form_activations) unless current_user
+    @form.increment!(:survey_form_activations) #unless current_user
     @submission = Submission.new
     # set location code in the form based on `?location_code=`
     @submission.location_code = params[:location_code]

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -437,8 +437,6 @@ class Form < ApplicationRecord
   def completion_rate
     if self.survey_form_activations == 0
       "N/A"
-    elsif (self.survey_form_activations <= self.response_count)
-      "100%"
     else
       "#{((self.response_count / self.survey_form_activations.to_f) * 100).round(0)}%"
     end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -437,6 +437,8 @@ class Form < ApplicationRecord
   def completion_rate
     if self.survey_form_activations == 0
       "N/A"
+    elsif (self.survey_form_activations <= self.response_count)
+      "100%"
     else
       "#{((self.response_count / self.survey_form_activations.to_f) * 100).round(0)}%"
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en-US:
   errors:
     format: "%{attribute} %{message}"
+    form_is_archived: "Operation not permitted on archived survey"
     request:
       unauthorized_host: "request made from non-authorized host"
     messages:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -155,6 +155,7 @@ es:
       year: Año
   errors:
     format: "%{attribute} %{message}"
+    form_is_archived: "Operación no permitida en encuesta archivada"
     request:
       unauthorized_host: "solicitud realizada desde un host no autorizado"
     messages:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -151,6 +151,7 @@ zh-CN:
       year: 年
   errors:
     format: "%{attribute}%{message}"
+    form_is_archived: "不允许对存档的调查进行操作"
     request:
       unauthorized_host: "来自非授权主机的请求"
     messages:

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -157,6 +157,19 @@ RSpec.describe SubmissionsController, type: :controller do
         expect(JSON.parse(response.body)["status"]).to eq("unprocessable_entity")
       end
     end
+
+    context "with archived form" do
+      before do
+        form.update(aasm_state: :archived)
+        post :create, params: { submission: { answer_01: "more than 5 characters" }, touchpoint_id: form.short_uuid }, session: valid_session, format: :json
+      end
+
+      it "returns an error response indicating character limit has been exceeded" do
+        expect(response.status).to eq(422)
+        expect(JSON.parse(response.body)["messages"]).to eq({ "submission" => ["Operation not permitted on archived survey"] })
+        expect(JSON.parse(response.body)["status"]).to eq("unprocessable_entity")
+      end
+    end
   end
 
 end


### PR DESCRIPTION
@ryanwoldatwork We get completion percentage over 100% when a submission is created without a corresponding activation.

Typical flow is
1) submission#new ( increments activation count )
2) submission#create ( increments response count )

The problem is that if we have a logged in user and the touchpoint is hosted then the activation is not recorded allowing for more responses than activations.   See line 13 of submissions controller new method.

My observation is that we appear to be recording a large number of form submissions without activations for hosted form "NPS.gov Was This Page Helpful" in production.   How is this possible unless a logged in user is hammering the submit button?