### PR TITLE
TP-1344 Add tags to Services and Service_Providers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,6 +421,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   aasm (~> 5.2.0)

--- a/app/controllers/admin/service_providers_controller.rb
+++ b/app/controllers/admin/service_providers_controller.rb
@@ -4,6 +4,7 @@ class Admin::ServiceProvidersController < AdminController
 
   def index
     @service_providers = ServiceProvider.all.includes(:organization).order("organizations.name", "service_providers.name")
+    @tags = ServiceProvider.tag_counts_on(:tags)
   end
 
   def show
@@ -37,6 +38,19 @@ class Admin::ServiceProvidersController < AdminController
   def destroy
     @service_provider.destroy
     redirect_to admin_service_providers_url, notice: 'Service provider was successfully destroyed.'
+  end
+
+  def search
+    search_text = params[:search]
+    tag_name = params[:tag]
+    if search_text.present?
+      search_text = "%" + search_text + "%"
+      @service_providers = ServiceProvider.joins(:organization).where(" service_providers.name ilike ? or organizations.name ilike ?  ", search_text, search_text)
+    elsif tag_name.present?
+      @service_providers = ServiceProvider.tagged_with(tag_name)
+    else
+      @service_providers = ServiceProvider.all
+    end
   end
 
   def add_tag

--- a/app/controllers/admin/service_providers_controller.rb
+++ b/app/controllers/admin/service_providers_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ServiceProvidersController < AdminController
-  before_action :set_service_provider, only: [:show, :edit, :update, :destroy]
+  before_action :set_service_provider, only: [:show, :edit, :update, :destroy, :add_tag, :remove_tag]
   before_action :ensure_admin, except: [:show]
 
   def index
@@ -39,6 +39,16 @@ class Admin::ServiceProvidersController < AdminController
     redirect_to admin_service_providers_url, notice: 'Service provider was successfully destroyed.'
   end
 
+  def add_tag
+    @service_provider.tag_list.add(service_provider_params[:tag_list].split(","))
+    @service_provider.save
+  end
+
+  def remove_tag
+    @service_provider.tag_list.remove(service_provider_params[:tag_list].split(","))
+    @service_provider.save
+  end
+
   private
     def set_service_provider
       @service_provider = ServiceProvider.find(params[:id])
@@ -57,6 +67,7 @@ class Admin::ServiceProvidersController < AdminController
         :bureau_abbreviation,
         :inactive,
         :new,
+        :tag_list,
       )
     end
 end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -10,6 +10,7 @@ class Admin::ServicesController < AdminController
 
   def index
     @services = Service.all.includes(:organization).order("organizations.name", :name)
+    @tags = Service.tag_counts_on(:tags)
   end
 
   def show
@@ -44,6 +45,19 @@ class Admin::ServicesController < AdminController
   def destroy
     @service.destroy
     redirect_to admin_services_url, notice: 'Service was successfully destroyed.'
+  end
+
+  def search
+    search_text = params[:search]
+    tag_name = params[:tag]
+    if search_text.present?
+      search_text = "%" + search_text + "%"
+      @services = Service.joins(:organization).where(" services.name ilike ? or organizations.name ilike ?  ", search_text, search_text)
+    elsif tag_name.present?
+      @services = Service.tagged_with(tag_name)
+    else
+      @services = Service.all
+    end
   end
 
   def add_tag

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -4,6 +4,8 @@ class Admin::ServicesController < AdminController
     :show, :edit, :update, :destroy,
     :equity_assessment,
     :omb_cx_reporting,
+    :add_tag,
+    :remove_tag,
   ]
 
   def index
@@ -44,6 +46,16 @@ class Admin::ServicesController < AdminController
     redirect_to admin_services_url, notice: 'Service was successfully destroyed.'
   end
 
+  def add_tag
+    @service.tag_list.add(service_params[:tag_list].split(","))
+    @service.save
+  end
+
+  def remove_tag
+    @service.tag_list.remove(service_params[:tag_list].split(","))
+    @service.save
+  end
+
   def equity_assessment
   end
 
@@ -69,6 +81,7 @@ class Admin::ServicesController < AdminController
         :service_abbreviation,
         :service_slug,
         :url,
+        :tag_list,
       )
     end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,6 +4,7 @@ class Service < ApplicationRecord
   has_many :service_stages
   has_many :omb_cx_reporting_collections
   has_many :collections, through: :omb_cx_reporting_collections
+  acts_as_taggable_on :tags
 
   validates :name, presence: true
 

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -2,6 +2,7 @@ class ServiceProvider < ApplicationRecord
   belongs_to :organization
   has_many :services
   has_many :collections, through: :services
+  acts_as_taggable_on :tags
 
   validates :slug, presence: true
 

--- a/app/views/admin/service_providers/_results.html.erb
+++ b/app/views/admin/service_providers/_results.html.erb
@@ -1,0 +1,21 @@
+<table class="usa-table">
+  <thead>
+    <tr>
+      <th>Organization</th>
+      <th>Name</th>
+      <th># of services</th>
+      <th>Tags</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @service_providers.each do |service_provider| %>
+      <tr>
+        <td><%= service_provider.organization.name %></td>
+        <td><%= link_to service_provider.name, admin_service_provider_path(service_provider) %></td>
+        <td><%= service_provider.services.size %></td>
+        <td><%= service_provider.tag_list %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/service_providers/_tags.html.erb
+++ b/app/views/admin/service_providers/_tags.html.erb
@@ -1,53 +1,53 @@
 <%= form_with(model: service_provider, url: admin_service_provider_path(service_provider), local: true) do |f| %>
-	<div class="grid-row">
-	  <div class="grid-col-12">
-	  	<h3>
-				Tags
-				<%= link_to "https://github.com/gsa/touchpoints/wiki/tagging-responses", target: "_blank", rel: "noopener" do %>
-					<span class="fa fa-info-circle"></span>
-				<% end %>
-			</h3>
-	  	<p class="tag-list">
-				<ul class="usa-list usa-list--unstyled">
-					<% service_provider.tag_list.sort.each do |tag| %>
-					<li  style="margin-bottom: 3px;">
-						<span class="usa-tag">
-							<%= tag %>
-						</span>
-						<a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-							<span class="fa fa-trash"></span>
-						</a>
-					</li>
-		  			<% end %>
-				</ul>
-	  	<p>
-	    <%= f.text_field :tag_list, placeholder: "Add a tag", value: nil, class: "usa-input tag-input" %>
-	  </div>
+<div class="grid-row">
+	<div class="grid-col-12">
+		<h3>
+			Tags
+			<%= link_to "https://github.com/gsa/touchpoints/wiki/tagging-responses", target: "_blank", rel: "noopener" do %>
+			<span class="fa fa-info-circle"></span>
+		<% end %>
+	</h3>
+	<p class="tag-list">
+		<ul class="usa-list usa-list--unstyled">
+			<% service_provider.tag_list.sort.each do |tag| %>
+				<li style="margin-bottom: 3px;">
+					<span class="usa-tag">
+						<%= tag %>
+					</span>
+					<a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
+						<span class="fa fa-trash"></span>
+					</a>
+				</li>
+			<% end %>
+		</ul>
+		<p>
+			<%= f.text_field :tag_list, placeholder: "Add a tag", value: nil, class: "usa-input tag-input" %>
+		</div>
 	</div>
 <% end %>
 <script>
-$(".tag-input").blur(function(event) {
-	event.preventDefault();
-    var thisForm = $(this).closest("form");
-    $.ajax({
-		url: thisForm.attr("action") + "/add_tag",
-		type: 'post',
-		data: "service_provider[tag_list]=" + $(".tag-input").val()
-    });
-});
-$(".tag-input").keypress(function (e) {
-	if (e.which == 13) {
-		document.activeElement.blur();
-		return false;
-	}
-});
-$(".remove-tag-link").click(function(e) {
-	event.preventDefault();
-	var thisForm = $(this).closest("form");
-	$.ajax({
-	  url: thisForm.attr("action") + "/remove_tag",
-	  type: 'post',
-	  data: "service_provider[tag_list]=" + $(this).attr("data-value")
+	$(".tag-input").blur(function (event) {
+		event.preventDefault();
+		var thisForm = $(this).closest("form");
+		$.ajax({
+			url: thisForm.attr("action") + "/add_tag",
+			type: 'post',
+			data: "service_provider[tag_list]=" + $(".tag-input").val()
+		});
 	});
-})
+	$(".tag-input").keypress(function (e) {
+		if (e.which == 13) {
+			document.activeElement.blur();
+			return false;
+		}
+	});
+	$(".remove-tag-link").click(function (e) {
+		event.preventDefault();
+		var thisForm = $(this).closest("form");
+		$.ajax({
+			url: thisForm.attr("action") + "/remove_tag",
+			type: 'post',
+			data: "service_provider[tag_list]=" + $(this).attr("data-value")
+		});
+	})
 </script>

--- a/app/views/admin/service_providers/_tags.html.erb
+++ b/app/views/admin/service_providers/_tags.html.erb
@@ -1,0 +1,53 @@
+<%= form_with(model: service_provider, url: admin_service_provider_path(service_provider), local: true) do |f| %>
+	<div class="grid-row">
+	  <div class="grid-col-12">
+	  	<h3>
+				Tags
+				<%= link_to "https://github.com/gsa/touchpoints/wiki/tagging-responses", target: "_blank", rel: "noopener" do %>
+					<span class="fa fa-info-circle"></span>
+				<% end %>
+			</h3>
+	  	<p class="tag-list">
+				<ul class="usa-list usa-list--unstyled">
+					<% service_provider.tag_list.sort.each do |tag| %>
+					<li  style="margin-bottom: 3px;">
+						<span class="usa-tag">
+							<%= tag %>
+						</span>
+						<a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
+							<span class="fa fa-trash"></span>
+						</a>
+					</li>
+		  			<% end %>
+				</ul>
+	  	<p>
+	    <%= f.text_field :tag_list, placeholder: "Add a tag", value: nil, class: "usa-input tag-input" %>
+	  </div>
+	</div>
+<% end %>
+<script>
+$(".tag-input").blur(function(event) {
+	event.preventDefault();
+    var thisForm = $(this).closest("form");
+    $.ajax({
+		url: thisForm.attr("action") + "/add_tag",
+		type: 'post',
+		data: "service_provider[tag_list]=" + $(".tag-input").val()
+    });
+});
+$(".tag-input").keypress(function (e) {
+	if (e.which == 13) {
+		document.activeElement.blur();
+		return false;
+	}
+});
+$(".remove-tag-link").click(function(e) {
+	event.preventDefault();
+	var thisForm = $(this).closest("form");
+	$.ajax({
+	  url: thisForm.attr("action") + "/remove_tag",
+	  type: 'post',
+	  data: "service_provider[tag_list]=" + $(this).attr("data-value")
+	});
+})
+</script>

--- a/app/views/admin/service_providers/add_tag.js.erb
+++ b/app/views/admin/service_providers/add_tag.js.erb
@@ -1,0 +1,1 @@
+$(".tags-div").html("<%= escape_javascript render(:partial => 'admin/service_providers/tags', :locals => { :service_provider => @service_provider }) %>");

--- a/app/views/admin/service_providers/index.html.erb
+++ b/app/views/admin/service_providers/index.html.erb
@@ -42,24 +42,51 @@
   </div>
 </div>
 
-<table class="usa-table">
-  <thead>
-    <tr>
-      <th>Organization</th>
-      <th>Name</th>
-      <th># of services</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @service_providers.each do |service_provider| %>
-      <tr>
-        <td><%= service_provider.organization.name %></td>
-        <td><%= link_to service_provider.name, admin_service_provider_path(service_provider) %></td>
-        <td><%= service_provider.services.size %></td>
-      </tr>
+<div class="well">
+  <div class="field">
+    <%= label_tag :search_text, "Search by organization or name" %>
+    <%= text_field_tag :search_text, nil, class: "usa-input" %>
+    <% if @tags.size > 0 %>
+      <p>
+        Search by tag
+      </p>
+      <p class="tag-list">
+        <% @tags.order(:name).each do | tag | %>
+          <a href="#" class="search-tag-link" data-name="<%= tag.name %>">
+            <span class="usa-tag">
+              <%= tag.name %> (<%= tag.taggings_count %>)
+            </span>
+          </a>
+        <% end %>
+      <p>
     <% end %>
-  </tbody>
-</table>
+  </div>
+</div>
+<div class="search-results">
+  <%= render 'results' %>
+</div>
 
 <%= render 'admin/service_providers/csv_data' if admin_permissions? %>
+
+<script>
+  $(function() {
+    $("#search_text").keyup(function() {
+      $.ajax({
+        url: '/admin/service_providers/search',
+        data: {
+          search: $(this).val()
+        }
+      });
+    });
+    $(".search-tag-link").click(function() {
+      $("#search_text").val("");
+      $.ajax({
+        url: '/admin/service_providers/search',
+        data: {
+          tag: $(this).attr("data-name")
+        }
+      });
+    });
+  });
+</script>
+

--- a/app/views/admin/service_providers/remove_tag.js.erb
+++ b/app/views/admin/service_providers/remove_tag.js.erb
@@ -1,0 +1,1 @@
+$(".tags-div").html("<%= escape_javascript render(:partial => 'admin/service_providers/tags', :locals => { :service_provider => @service_provider }) %>");

--- a/app/views/admin/service_providers/search.js.erb
+++ b/app/views/admin/service_providers/search.js.erb
@@ -1,0 +1,1 @@
+$(".search-results").html("<%= escape_javascript render(:partial => 'admin/service_providers/results', :locals => { :service_provider => @service_provider }) %>");

--- a/app/views/admin/service_providers/show.html.erb
+++ b/app/views/admin/service_providers/show.html.erb
@@ -99,6 +99,12 @@
 </div>
 
 <div class="well">
+  <div class="tags-div">
+    <%= render 'admin/service_providers/tags', service_provider: @service_provider %>
+  </div>
+</div>
+
+<div class="well">
   <h4>
     Data Collections
   </h4>

--- a/app/views/admin/services/_results.html.erb
+++ b/app/views/admin/services/_results.html.erb
@@ -1,0 +1,30 @@
+<table class="usa-table">
+  <thead>
+    <tr>
+    <% if admin_permissions? %>
+      <th data-sortable scope="col" role="columnheader">Organization</th>
+    <% end %>
+      <th data-sortable scope="col" role="columnheader">Name</th>
+      <th data-sortable scope="col" role="columnheader"># of Stages</th>
+      <th data-sortable scope="col" role="columnheader">HISP Service</th>
+      <th data-sortable scope="col" role="columnheader">Tags</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @services.each do |service| %>
+      <tr>
+      <% if admin_permissions? %>
+        <td><%= service.organization.name %></td>
+      <% end %>
+        <td><%= link_to service.name, admin_service_path(service) %></td>
+        <td><%= link_to service.service_stages.count, admin_service_service_stages_path(service) %></td>
+        <td>
+          <% if service.service_provider %>
+            <span class="usa-tag bg-cyan">HISP</span>
+          <% end %>
+        </td>
+        <td><%= service.tag_list %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/services/_tags.html.erb
+++ b/app/views/admin/services/_tags.html.erb
@@ -1,0 +1,53 @@
+<%= form_with(model: service, url: admin_service_path(service), local: true) do |f| %>
+	<div class="grid-row">
+	  <div class="grid-col-12">
+	  	<h3>
+				Tags
+				<%= link_to "https://github.com/gsa/touchpoints/wiki/tagging-responses", target: "_blank", rel: "noopener" do %>
+					<span class="fa fa-info-circle"></span>
+				<% end %>
+			</h3>
+	  	<p class="tag-list">
+				<ul class="usa-list usa-list--unstyled">
+					<% service.tag_list.sort.each do |tag| %>
+					<li  style="margin-bottom: 3px;">
+						<span class="usa-tag">
+							<%= tag %>
+						</span>
+						<a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
+							<span class="fa fa-trash"></span>
+						</a>
+					</li>
+		  			<% end %>
+				</ul>
+	  	<p>
+	    <%= f.text_field :tag_list, placeholder: "Add a tag", value: nil, class: "usa-input tag-input" %>
+	  </div>
+	</div>
+<% end %>
+<script>
+$(".tag-input").blur(function(event) {
+	event.preventDefault();
+    var thisForm = $(this).closest("form");
+    $.ajax({
+		url: thisForm.attr("action") + "/add_tag",
+		type: 'post',
+		data: "service[tag_list]=" + $(".tag-input").val()
+    });
+});
+$(".tag-input").keypress(function (e) {
+	if (e.which == 13) {
+		document.activeElement.blur();
+		return false;
+	}
+});
+$(".remove-tag-link").click(function(e) {
+	event.preventDefault();
+	var thisForm = $(this).closest("form");
+	$.ajax({
+	  url: thisForm.attr("action") + "/remove_tag",
+	  type: 'post',
+	  data: "service[tag_list]=" + $(this).attr("data-value")
+	});
+})
+</script>

--- a/app/views/admin/services/add_tag.js.erb
+++ b/app/views/admin/services/add_tag.js.erb
@@ -1,0 +1,1 @@
+$(".tags-div").html("<%= escape_javascript render(:partial => 'admin/services/tags', :locals => { :service => @service }) %>");

--- a/app/views/admin/services/index.html.erb
+++ b/app/views/admin/services/index.html.erb
@@ -47,32 +47,48 @@
   </div>
 </div>
 
-<table class="usa-table">
-  <thead>
-    <tr>
-    <% if admin_permissions? %>
-      <th data-sortable scope="col" role="columnheader">Organization</th>
+<div class="well">
+  <div class="field">
+    <%= label_tag :search_text, "Search by organization or name" %>
+    <%= text_field_tag :search_text, nil, class: "usa-input" %>
+    <% if @tags.size > 0 %>
+      <p>
+        Search by tag
+      </p>
+      <p class="tag-list">
+        <% @tags.order(:name).each do | tag | %>
+          <a href="#" class="search-tag-link" data-name="<%= tag.name %>">
+            <span class="usa-tag">
+              <%= tag.name %> (<%= tag.taggings_count %>)
+            </span>
+          </a>
+        <% end %>
+      <p>
     <% end %>
-      <th data-sortable scope="col" role="columnheader">Name</th>
-      <th data-sortable scope="col" role="columnheader"># of Stages</th>
-      <th data-sortable scope="col" role="columnheader">HISP Service</th>
-    </tr>
-  </thead>
+  </div>
+</div>
+<div class="search-results">
+  <%= render 'results' %>
+</div>
 
-  <tbody>
-    <% @services.each do |service| %>
-      <tr>
-      <% if admin_permissions? %>
-        <td><%= service.organization.name %></td>
-      <% end %>
-        <td><%= link_to service.name, admin_service_path(service) %></td>
-        <td><%= link_to service.service_stages.count, admin_service_service_stages_path(service) %></td>
-        <td>
-          <% if service.service_provider %>
-            <span class="usa-tag bg-cyan">HISP</span>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<script>
+  $(function() {
+    $("#search_text").keyup(function() {
+      $.ajax({
+        url: '/admin/services/search',
+        data: {
+          search: $(this).val()
+        }
+      });
+    });
+    $(".search-tag-link").click(function() {
+      $("#search_text").val("");
+      $.ajax({
+        url: '/admin/services/search',
+        data: {
+          tag: $(this).attr("data-name")
+        }
+      });
+    });
+  });
+</script>

--- a/app/views/admin/services/remove_tag.js.erb
+++ b/app/views/admin/services/remove_tag.js.erb
@@ -1,0 +1,1 @@
+$(".tags-div").html("<%= escape_javascript render(:partial => 'admin/services/tags', :locals => { :service => @service }) %>");

--- a/app/views/admin/services/search.js.erb
+++ b/app/views/admin/services/search.js.erb
@@ -1,0 +1,1 @@
+$(".search-results").html("<%= escape_javascript render(:partial => 'admin/services/results', :locals => { :service => @service }) %>");

--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -97,6 +97,12 @@
 <hr>
 
 <div class="well">
+  <div class="tags-div">
+    <%= render 'admin/services/tags', service: @service %>
+  </div>
+</div>
+
+<div class="well">
   <h4>
     Data Collections
   </h4>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,11 +51,18 @@ Rails.application.routes.draw do
     get "/submissions/performance_gov", to: "submissions#performance_gov", as: :performance_gov
 
     get "a11", to: "site#a11", as: :a11
-    resources :service_providers
+    resources :service_providers do |*args|
+      member do
+        post "add_tag", to: "service_providers#add_tag", as: :add_tag
+        post "remove_tag", to: "service_providers#remove_tag", as: :remove_tag
+      end
+    end
     resources :services do
       member do
         get "equity-assessment", to: "services#equity_assessment", as: :equity_assessment
         get "cx-reporting", to: "services#omb_cx_reporting", as: :omb_cx_reporting
+        post "add_tag", to: "services#add_tag", as: :add_tag
+        post "remove_tag", to: "services#remove_tag", as: :remove_tag
       end
       resources :service_stages
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,12 +52,18 @@ Rails.application.routes.draw do
 
     get "a11", to: "site#a11", as: :a11
     resources :service_providers do |*args|
+      collection do
+        get "search", to: "service_providers#search"
+      end
       member do
         post "add_tag", to: "service_providers#add_tag", as: :add_tag
         post "remove_tag", to: "service_providers#remove_tag", as: :remove_tag
       end
     end
     resources :services do
+      collection do
+        get "search", to: "services#search"
+      end
       member do
         get "equity-assessment", to: "services#equity_assessment", as: :equity_assessment
         get "cx-reporting", to: "services#omb_cx_reporting", as: :omb_cx_reporting


### PR DESCRIPTION
Note:  Currently there is no feature to search services and services providers.  Typically we would add a tag search under the search box.

Should we implement a search box with tags?   Should we display the tags in the table on the index pages for both services and service providers?