### PR TITLE
TP-1354 make tag filter link sharable

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -9,7 +9,12 @@ class Admin::ServicesController < AdminController
   ]
 
   def index
-    @services = Service.all.includes(:organization).order("organizations.name", :name)
+    tag_name = params[:tag]
+    if tag_name.present?
+      @services = Service.tagged_with(tag_name).includes(:organization).order("organizations.name", :name)
+    else
+      @services = Service.all.includes(:organization).order("organizations.name", :name)
+    end
     @tags = Service.tag_counts_on(:tags)
   end
 

--- a/app/views/admin/services/index.html.erb
+++ b/app/views/admin/services/index.html.erb
@@ -56,12 +56,12 @@
         Search by tag
       </p>
       <p class="tag-list">
-        <% @tags.order(:name).each do | tag | %>
-          <a href="/admin/services/?tag=<%= tag.name %>" class="search-tag-link" data-name="<%= tag.name %>">
+        <% @tags.order(:name).each do |tag| %>
+          <%= link_to admin_services_path(tag: tag.name), class: "search-tag-link",  "data-name" => tag.name do %>
             <span class="usa-tag">
               <%= tag.name %> (<%= tag.taggings_count %>)
             </span>
-          </a>
+          <% end %>
         <% end %>
       <p>
     <% end %>

--- a/app/views/admin/services/index.html.erb
+++ b/app/views/admin/services/index.html.erb
@@ -57,7 +57,7 @@
       </p>
       <p class="tag-list">
         <% @tags.order(:name).each do | tag | %>
-          <a href="#" class="search-tag-link" data-name="<%= tag.name %>">
+          <a href="/admin/services/?tag=<%= tag.name %>" class="search-tag-link" data-name="<%= tag.name %>">
             <span class="usa-tag">
               <%= tag.name %> (<%= tag.taggings_count %>)
             </span>

--- a/spec/features/admin/services_spec.rb
+++ b/spec/features/admin/services_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+feature "Managing Services", js: true do
+  let!(:organization) { FactoryBot.create(:organization) }
+
+  let(:admin) { FactoryBot.create(:user, :admin, organization: organization) }
+  let(:user) { FactoryBot.create(:user, organization: organization) }
+
+  let!(:service_provider) { FactoryBot.create(:service_provider, organization: organization ) }
+  let!(:service) { FactoryBot.create(:service, organization: organization, service_provider: service_provider ) }
+  let!(:service2) { FactoryBot.create(:service, organization: organization, service_provider: service_provider) }
+
+  before do
+    service2.tag_list.add("feature-request")
+    service2.tag_list.add("policy")
+    service2.save
+  end
+
+  context "as Admin" do
+    before do
+      login_as admin
+      visit admin_services_path
+    end
+
+    it "load the Services#index page" do
+      expect(page).to have_content("Managing Services in Touchpoints")
+      expect(page.current_path).to eq(admin_services_path)
+      expect(page).to have_link("New Service")
+      expect(page).to have_css("tbody tr", count: 2)
+    end
+
+    describe "create a new Service" do
+      before "fill-in the form" do
+        click_on "New Service"
+        expect(page).to have_content("New Service")
+        select(service_provider.name, from: "service[service_provider_id]")
+        fill_in :service_name, with: "New Service Name"
+        click_on "Create Service"
+      end
+
+      it "create Website successfully" do
+        expect(page).to have_content("Service was successfully created")
+        expect(page).to have_content("New Service Name")
+      end
+    end
+
+    describe "add a tag to a Service" do
+      before "add the tag" do
+        visit admin_service_path(service2)
+        fill_in "service_tag_list", with: "new-tag"
+        find("body").click # to create the tag
+      end
+
+      it "newly created tag is displayed on the page" do
+        expect(page).to have_css(".usa-tag", text: "NEW-TAG")
+      end
+    end
+
+
+    describe "search by Tag" do
+      before do
+        find(".usa-tag", text: "FEATURE-REQUEST").click # to create the tag
+      end
+
+      it "newly created tag is displayed on the page" do
+        expect(page.current_url).to include("tag=feature-request")
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
TP-1354 make tag filter link sharable

Linked ticket: https://trello.com/c/NyNPws9g/1354-enable-tag-search-to-have-a-reliable-url

I've added the ability for the services index pages to take a "tag" parameter and filter results using that parameter.

I've also made the href of the actual tag displayed on the page to be shareable.   For example you can now right click on the tag filter and open link in new tab or copy link and share it and the selected tag filter context will be preserved.

Will this suffice for your needs?