### PR TITLE
WIP focus setting for modal open and close

### DIFF
--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -152,6 +152,7 @@ function FBAform(d, N) {
 		},
 		handleButtonClick: function(e) {
 			e.preventDefault();
+			// store a reference to the button ID so we can set focus back here when modal closes
 			this.loadDialog();
 		},
 		handleDialogClose: function(e) {
@@ -374,6 +375,7 @@ function FBAform(d, N) {
 		loadDialog: function()
 		{
 			d.querySelector('.fba-modal').removeAttribute("hidden");
+			d.getElementById("touchpoints-form-<%= form.short_uuid %>").focus();
 			this.dialogOpen = true;
 		},
 		closeDialog: function()

--- a/app/views/components/widget/_no_modal.html.erb
+++ b/app/views/components/widget/_no_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="touchpoints-form-wrapper" data-touchpoints-form-id="<%= form.short_uuid %>">
+<div class="touchpoints-form-wrapper" id="touchpoints-form-<%= form.short_uuid %>" data-touchpoints-form-id="<%= form.short_uuid %>">
   <div class="wrapper">
     <% if form.title? %>
       <h3 id="fba-modal-title">


### PR DESCRIPTION
For @ryanwoldatwork and @iamjolly to pair on.

Relates to #480 

Things to do:
- [x] Set focus on modal `div` when opened
- [x] Set focus back to touchpoints `button` when modal is closed 
- [x] Confirm listener for `esc` keypress to run the `handleDialogClose` function.
- [ ] Trap focus in modal when opened - see [Using JavaScript to trap focus in an element](https://hiddedevries.nl/en/blog/2017-01-29-using-javascript-to-trap-focus-in-an-element) for more info
- [ ] Test with keyboard only and with screen reader to confirm everything works as expected.

Note: This is a vanilla JS approach to adding accessibility to the modal. A next effort should involve looking at ways for touchpoints to use the [USWDS modal component](https://designsystem.digital.gov/components/modal/) per #481.