### PR TITLE
TP-1385 update references to website.site_owner_email in search and v…

### DIFF
--- a/app/controllers/admin/websites_controller.rb
+++ b/app/controllers/admin/websites_controller.rb
@@ -1,45 +1,45 @@
 class Admin::WebsitesController < AdminController
-  before_action :ensure_organizational_website_manager, only: %i[
-    collection_preview
-    collection_request
-    export_versions
+  before_action :ensure_organizational_website_manager, only: [
+    :collection_preview,
+    :collection_request,
+    :export_versions
   ]
   before_action :set_paper_trail_whodunnit
 
-  before_action :set_website, only: %i[
-    show costs statuscard edit update destroy collection_request
-    approve
-    deny
-    events
-    dendrogram
-    add_tag
-    remove_tag
-    versions
-    export_versions
-    add_website_manager
-    remove_website_manager
+  before_action :set_website, only: [
+    :show, :costs, :statuscard, :edit, :update, :destroy, :collection_request,
+    :approve,
+    :deny,
+    :events,
+    :dendrogram,
+    :add_tag,
+    :remove_tag,
+    :versions,
+    :export_versions,
+    :add_website_manager,
+    :remove_website_manager,
   ]
 
-  before_action :set_website_manager_options, only: %i[
-    new
-    create
-    edit
-    update
-    add_website_manager
-    remove_website_manager
+  before_action :set_website_manager_options, only: [
+    :new,
+    :create,
+    :edit,
+    :update,
+    :add_website_manager,
+    :remove_website_manager,
   ]
 
   def index
-    @websites = if params[:all]
-                  Website.all.order(:production_status, :domain)
-                else
-                  Website.active.order(:production_status, :domain)
-                end
+    if params[:all]
+      @websites = Website.all.order(:production_status, :domain)
+    else
+      @websites = Website.active.order(:production_status, :domain)
+    end
     @tags = Website.tag_counts_by_name
   end
 
   def versions
-    @versions = @website.versions.limit(500).order('created_at DESC').page params[:page]
+    @versions = @website.versions.limit(500).order("created_at DESC").page params[:page]
   end
 
   def export_versions
@@ -48,20 +48,22 @@ class Admin::WebsitesController < AdminController
     render json: { result: :ok }
   end
 
-  def dendrogram; end
+  def dendrogram
+  end
 
   def dendrogram_json
-    if params['office'] == 'true'
-      dendrogram_json_by_office
+
+    if params["office"] == "true"
+       dendrogram_json_by_office
     else
       # default
       dendrogram_json_by_domain
     end
 
     respond_to do |format|
-      format.json do
-        render 'dendrogram_json.js'
-      end
+      format.json {
+        render "dendrogram_json.js"
+      }
     end
   end
 
@@ -71,28 +73,27 @@ class Admin::WebsitesController < AdminController
     # loop all sites and build a list of top-level domains
     @active_websites = Website.active
     @active_websites.each do |website|
-      next unless website.tld?
-
-      @websites << {
-        name: website.domain,
-        children: []
-      }
+      if website.tld?
+        @websites << {
+          name: website.domain,
+          children: [
+          ]
+        }
+      end
     end
 
     @active_websites.each do |website|
-      selected_website = @websites.select do |w|
-        w[:name] == website[:domain] || w[:name] == website[:parent_domain]
-      end.first
+      selected_website = @websites.select { |w| w[:name] == website[:domain] || w[:name] == website[:parent_domain] }.first
       next unless selected_website.present?
 
-      next if website.tld?
-
-      selected_website[:children] << {
-        name: website.domain || 'N/A',
-        value: 1
-      }
+      if !website.tld?
+        selected_website[:children] << {
+          name: website.domain || "N/A",
+          value: 1
+        }
+      end
     end
-    @websites
+    return @websites
   end
 
   def dendrogram_json_by_office
@@ -109,17 +110,15 @@ class Admin::WebsitesController < AdminController
     end
 
     @active_websites.each do |website|
-      selected_website = @websites.select do |w|
-        w[:office] == website[:office] || w[:sub_office] == website[:sub_office]
-      end.first
+      selected_website = @websites.select { |w| w[:office] == website[:office] || w[:sub_office] == website[:sub_office] }.first
       next unless selected_website.present?
 
       selected_website[:children] << {
-        name: website.domain || 'N/A',
+        name: website.domain || "N/A",
         value: 1
       }
     end
-    @websites
+    return @websites
   end
 
   def export_csv
@@ -129,7 +128,8 @@ class Admin::WebsitesController < AdminController
     send_data @websites.to_csv, filename: "touchpoints-websites-#{Date.today}.csv"
   end
 
-  def statuscard; end
+  def statuscard
+  end
 
   def search
     search_text = params[:search]
@@ -151,7 +151,8 @@ class Admin::WebsitesController < AdminController
     @websites = Website.active.order(:production_status, :domain)
   end
 
-  def show; end
+  def show
+  end
 
   def collection_preview
     ensure_admin
@@ -162,14 +163,10 @@ class Admin::WebsitesController < AdminController
     # fetch all websites for site owner
     @websites = Website.active.where(site_owner_email: @website.site_owner_email)
     # only include websites which are missing data
-    @websites = @websites.select { |ws| ws.requiresDataCollection? }
-    if @website.site_owner_email.present?
-      UserMailer.website_data_collection(@website.site_owner_email,
-                                         @websites).deliver_later
-    end
+    @websites = @websites.select { | ws | ws.requiresDataCollection? }
+    UserMailer.website_data_collection(@website.site_owner_email, @websites).deliver_later if @website.site_owner_email.present?
     UserMailer.website_data_collection(current_user.email, @websites).deliver_later
-    redirect_to admin_websites_url,
-                notice: "Website data collection request was successfully sent for #{@website.domain}"
+    redirect_to admin_websites_url, notice: "Website data collection request was successfully sent for #{@website.domain}"
   end
 
   def new
@@ -190,8 +187,7 @@ class Admin::WebsitesController < AdminController
     @website = Website.new(admin_website_params)
 
     if @website.save
-      Event.log_event(Event.names[:website_created], 'Website', @website.id,
-                      "Website #{@website.domain} created at #{DateTime.now}", current_user.id)
+      Event.log_event(Event.names[:website_created], "Website", @website.id, "Website #{@website.domain} created at #{DateTime.now}", current_user.id)
       UserMailer.website_created(website: @website).deliver_later
       redirect_to admin_website_url(@website), notice: 'Website was successfully created.'
     else
@@ -214,8 +210,7 @@ class Admin::WebsitesController < AdminController
     ensure_website_admin(website: @website, user: current_user)
     @website.approve
     if @website.save
-      Event.log_event(Event.names[:website_approved], 'Website', @website.id,
-                      "Website #{@website.domain} approved at #{DateTime.now}", current_user.id)
+      Event.log_event(Event.names[:website_approved], "Website", @website.id, "Website #{@website.domain} approved at #{DateTime.now}", current_user.id)
       redirect_to admin_website_url(@website), notice: "Website #{@website.domain} was approved."
     else
       render :edit
@@ -226,8 +221,7 @@ class Admin::WebsitesController < AdminController
     ensure_website_admin(website: @website, user: current_user)
     @website.deny
     if @website.save
-      Event.log_event(Event.names[:website_denied], 'Website', @website.id,
-                      "Website #{@website.domain} denied at #{DateTime.now}", current_user.id)
+      Event.log_event(Event.names[:website_denied], "Website", @website.id, "Website #{@website.domain} denied at #{DateTime.now}", current_user.id)
       redirect_to admin_website_url(@website), notice: "Website #{@website.domain} was denied."
     else
       render :edit
@@ -238,22 +232,21 @@ class Admin::WebsitesController < AdminController
     ensure_admin
 
     @website.destroy
-    Event.log_event(Event.names[:website_deleted], 'Website', @website.id,
-                    "Website #{@website.domain} deleted at #{DateTime.now}", current_user.id)
+    Event.log_event(Event.names[:website_deleted], "Website", @website.id, "Website #{@website.domain} deleted at #{DateTime.now}", current_user.id)
     redirect_to admin_websites_url, notice: 'Website was successfully destroyed.'
   end
 
   def events
-    @events = Event.where(object_type: 'Website', object_id: @website.id).order(:created_at)
+    @events = Event.where(object_type: "Website", object_id: @website.id).order(:created_at)
   end
 
   def add_tag
-    @website.tag_list.add(admin_website_params[:tag_list].split(','))
+    @website.tag_list.add(admin_website_params[:tag_list].split(","))
     @website.save
   end
 
   def remove_tag
-    @website.tag_list.remove(admin_website_params[:tag_list].split(','))
+    @website.tag_list.remove(admin_website_params[:tag_list].split(","))
     @website.save
   end
 
@@ -268,49 +261,48 @@ class Admin::WebsitesController < AdminController
   end
 
   private
+    def set_website_manager_options
+      if admin_permissions?
+        @website_manager_options = User.active.order("email")
+      elsif @website && @website.organization
+        @website_manager_options = @website.organization.users.active.order("email")
+      elsif current_user.organization
+        @website_manager_options = current_user.organization.users.active.order("email")
+      else
+        []
+      end
 
-  def set_website_manager_options
-    if admin_permissions?
-      @website_manager_options = User.active.order('email')
-    elsif @website && @website.organization
-      @website_manager_options = @website.organization.users.active.order('email')
-    elsif current_user.organization
-      @website_manager_options = current_user.organization.users.active.order('email')
-    else
-      []
+      if @website_manager_options && @website
+        @website_manager_options = @website_manager_options - @website.website_managers
+      end
     end
 
-    @website_manager_options -= @website.website_managers if @website_manager_options && @website
-  end
-
-  def log_update(current_state)
-    Event.log_event(Event.names[:website_updated], 'Website', @website.id,
-                    "Website #{@website.domain} updated at #{DateTime.now}", current_user.id)
-    if admin_website_params[:production_status] != current_state
-      Event.log_event(Event.names[:website_state_changed], 'Website', @website.id,
-                      "Website #{@website.domain} state changed to #{admin_website_params[:production_status]} at #{DateTime.now}", current_user.id)
+    def log_update(current_state)
+      Event.log_event(Event.names[:website_updated], "Website", @website.id, "Website #{@website.domain} updated at #{DateTime.now}", current_user.id)
+      if admin_website_params[:production_status] != current_state
+        Event.log_event(Event.names[:website_state_changed], "Website", @website.id, "Website #{@website.domain} state changed to #{admin_website_params[:production_status]} at #{DateTime.now}", current_user.id)
+      end
     end
-  end
 
-  def set_website
-    @website = Website.find_by_id(params[:id])
-  end
+    def set_website
+      @website = Website.find_by_id(params[:id])
+    end
 
-  def admin_website_params
-    params.require(:website).permit(:domain, :office, :office_id, :sub_office, :suboffice_id, :contact_email, :site_owner_email, :production_status, :type_of_site, :digital_brand_category, :redirects_to, :status_code, :cms_platform, :required_by_law_or_policy, :has_dap, :dap_gtm_code, :cost_estimator_url, :modernization_plan_url, :annual_baseline_cost,
-                                    :modernization_cost,
-                                    :modernization_cost_2021,
-                                    :modernization_cost_2022,
-                                    :modernization_cost_2023,
-                                    :analytics_url,
-                                    :https,
-                                    :uswds_version,
-                                    :uses_feedback, :feedback_tool, :sitemap_url, :mobile_friendly, :has_search, :uses_tracking_cookies,
-                                    :hosting_platform,
-                                    :has_authenticated_experience,
-                                    :authentication_tool,
-                                    :repository_url,
-                                    :notes,
-                                    :tag_list)
-  end
+    def admin_website_params
+      params.require(:website).permit(:domain, :office, :office_id, :sub_office, :suboffice_id, :contact_email, :site_owner_email, :production_status, :type_of_site, :digital_brand_category, :redirects_to, :status_code, :cms_platform, :required_by_law_or_policy, :has_dap, :dap_gtm_code, :cost_estimator_url, :modernization_plan_url, :annual_baseline_cost,
+      :modernization_cost,
+      :modernization_cost_2021,
+      :modernization_cost_2022,
+      :modernization_cost_2023,
+      :analytics_url,
+      :https,
+      :uswds_version,
+      :uses_feedback, :feedback_tool, :sitemap_url, :mobile_friendly, :has_search, :uses_tracking_cookies,
+      :hosting_platform,
+      :has_authenticated_experience,
+      :authentication_tool,
+      :repository_url,
+      :notes,
+      :tag_list)
+    end
 end

--- a/app/controllers/admin/websites_controller.rb
+++ b/app/controllers/admin/websites_controller.rb
@@ -1,45 +1,45 @@
 class Admin::WebsitesController < AdminController
-  before_action :ensure_organizational_website_manager, only: [
-    :collection_preview,
-    :collection_request,
-    :export_versions
+  before_action :ensure_organizational_website_manager, only: %i[
+    collection_preview
+    collection_request
+    export_versions
   ]
   before_action :set_paper_trail_whodunnit
 
-  before_action :set_website, only: [
-    :show, :costs, :statuscard, :edit, :update, :destroy, :collection_request,
-    :approve,
-    :deny,
-    :events,
-    :dendrogram,
-    :add_tag,
-    :remove_tag,
-    :versions,
-    :export_versions,
-    :add_website_manager,
-    :remove_website_manager,
+  before_action :set_website, only: %i[
+    show costs statuscard edit update destroy collection_request
+    approve
+    deny
+    events
+    dendrogram
+    add_tag
+    remove_tag
+    versions
+    export_versions
+    add_website_manager
+    remove_website_manager
   ]
 
-  before_action :set_website_manager_options, only: [
-    :new,
-    :create,
-    :edit,
-    :update,
-    :add_website_manager,
-    :remove_website_manager,
+  before_action :set_website_manager_options, only: %i[
+    new
+    create
+    edit
+    update
+    add_website_manager
+    remove_website_manager
   ]
 
   def index
-    if params[:all]
-      @websites = Website.all.order(:production_status, :domain)
-    else
-      @websites = Website.active.order(:production_status, :domain)
-    end
+    @websites = if params[:all]
+                  Website.all.order(:production_status, :domain)
+                else
+                  Website.active.order(:production_status, :domain)
+                end
     @tags = Website.tag_counts_by_name
   end
 
   def versions
-    @versions = @website.versions.limit(500).order("created_at DESC").page params[:page]
+    @versions = @website.versions.limit(500).order('created_at DESC').page params[:page]
   end
 
   def export_versions
@@ -48,22 +48,20 @@ class Admin::WebsitesController < AdminController
     render json: { result: :ok }
   end
 
-  def dendrogram
-  end
+  def dendrogram; end
 
   def dendrogram_json
-
-    if params["office"] == "true"
-       dendrogram_json_by_office
+    if params['office'] == 'true'
+      dendrogram_json_by_office
     else
       # default
       dendrogram_json_by_domain
     end
 
     respond_to do |format|
-      format.json {
-        render "dendrogram_json.js"
-      }
+      format.json do
+        render 'dendrogram_json.js'
+      end
     end
   end
 
@@ -73,27 +71,28 @@ class Admin::WebsitesController < AdminController
     # loop all sites and build a list of top-level domains
     @active_websites = Website.active
     @active_websites.each do |website|
-      if website.tld?
-        @websites << {
-          name: website.domain,
-          children: [
-          ]
-        }
-      end
+      next unless website.tld?
+
+      @websites << {
+        name: website.domain,
+        children: []
+      }
     end
 
     @active_websites.each do |website|
-      selected_website = @websites.select { |w| w[:name] == website[:domain] || w[:name] == website[:parent_domain] }.first
+      selected_website = @websites.select do |w|
+        w[:name] == website[:domain] || w[:name] == website[:parent_domain]
+      end.first
       next unless selected_website.present?
 
-      if !website.tld?
-        selected_website[:children] << {
-          name: website.domain || "N/A",
-          value: 1
-        }
-      end
+      next if website.tld?
+
+      selected_website[:children] << {
+        name: website.domain || 'N/A',
+        value: 1
+      }
     end
-    return @websites
+    @websites
   end
 
   def dendrogram_json_by_office
@@ -110,15 +109,17 @@ class Admin::WebsitesController < AdminController
     end
 
     @active_websites.each do |website|
-      selected_website = @websites.select { |w| w[:office] == website[:office] || w[:sub_office] == website[:sub_office] }.first
+      selected_website = @websites.select do |w|
+        w[:office] == website[:office] || w[:sub_office] == website[:sub_office]
+      end.first
       next unless selected_website.present?
 
       selected_website[:children] << {
-        name: website.domain || "N/A",
+        name: website.domain || 'N/A',
         value: 1
       }
     end
-    return @websites
+    @websites
   end
 
   def export_csv
@@ -128,15 +129,17 @@ class Admin::WebsitesController < AdminController
     send_data @websites.to_csv, filename: "touchpoints-websites-#{Date.today}.csv"
   end
 
-  def statuscard
-  end
+  def statuscard; end
 
   def search
     search_text = params[:search]
     tag_name = params[:tag]
     if search_text.present?
-      search_text = "%" + search_text + "%"
-      @websites = Website.where(" domain ilike ? or office ilike ? or sub_office ilike ? or production_status ilike ? or site_owner_email ilike ? ", search_text, search_text, search_text, search_text, search_text).order(:production_status, :domain)
+      search_text = '%' + search_text + '%'
+      managed_sites = Website.where(id: Website.ids_by_manager_search(search_text))
+      @websites = Website.where(' domain ilike ? or office ilike ? or sub_office ilike ? or production_status ilike ? or site_owner_email ilike ? ', search_text, search_text, search_text, search_text, search_text).or(managed_sites).order(
+        :production_status, :domain
+      )
     elsif tag_name.present?
       @websites = Website.tagged_with(tag_name).order(:production_status, :domain)
     else
@@ -148,8 +151,7 @@ class Admin::WebsitesController < AdminController
     @websites = Website.active.order(:production_status, :domain)
   end
 
-  def show
-  end
+  def show; end
 
   def collection_preview
     ensure_admin
@@ -160,10 +162,14 @@ class Admin::WebsitesController < AdminController
     # fetch all websites for site owner
     @websites = Website.active.where(site_owner_email: @website.site_owner_email)
     # only include websites which are missing data
-    @websites = @websites.select { | ws | ws.requiresDataCollection? }
-    UserMailer.website_data_collection(@website.site_owner_email, @websites).deliver_later if @website.site_owner_email.present?
+    @websites = @websites.select { |ws| ws.requiresDataCollection? }
+    if @website.site_owner_email.present?
+      UserMailer.website_data_collection(@website.site_owner_email,
+                                         @websites).deliver_later
+    end
     UserMailer.website_data_collection(current_user.email, @websites).deliver_later
-    redirect_to admin_websites_url, notice: "Website data collection request was successfully sent for #{@website.domain}"
+    redirect_to admin_websites_url,
+                notice: "Website data collection request was successfully sent for #{@website.domain}"
   end
 
   def new
@@ -184,7 +190,8 @@ class Admin::WebsitesController < AdminController
     @website = Website.new(admin_website_params)
 
     if @website.save
-      Event.log_event(Event.names[:website_created], "Website", @website.id, "Website #{@website.domain} created at #{DateTime.now}", current_user.id)
+      Event.log_event(Event.names[:website_created], 'Website', @website.id,
+                      "Website #{@website.domain} created at #{DateTime.now}", current_user.id)
       UserMailer.website_created(website: @website).deliver_later
       redirect_to admin_website_url(@website), notice: 'Website was successfully created.'
     else
@@ -207,7 +214,8 @@ class Admin::WebsitesController < AdminController
     ensure_website_admin(website: @website, user: current_user)
     @website.approve
     if @website.save
-      Event.log_event(Event.names[:website_approved], "Website", @website.id, "Website #{@website.domain} approved at #{DateTime.now}", current_user.id)
+      Event.log_event(Event.names[:website_approved], 'Website', @website.id,
+                      "Website #{@website.domain} approved at #{DateTime.now}", current_user.id)
       redirect_to admin_website_url(@website), notice: "Website #{@website.domain} was approved."
     else
       render :edit
@@ -218,7 +226,8 @@ class Admin::WebsitesController < AdminController
     ensure_website_admin(website: @website, user: current_user)
     @website.deny
     if @website.save
-      Event.log_event(Event.names[:website_denied], "Website", @website.id, "Website #{@website.domain} denied at #{DateTime.now}", current_user.id)
+      Event.log_event(Event.names[:website_denied], 'Website', @website.id,
+                      "Website #{@website.domain} denied at #{DateTime.now}", current_user.id)
       redirect_to admin_website_url(@website), notice: "Website #{@website.domain} was denied."
     else
       render :edit
@@ -229,21 +238,22 @@ class Admin::WebsitesController < AdminController
     ensure_admin
 
     @website.destroy
-    Event.log_event(Event.names[:website_deleted], "Website", @website.id, "Website #{@website.domain} deleted at #{DateTime.now}", current_user.id)
+    Event.log_event(Event.names[:website_deleted], 'Website', @website.id,
+                    "Website #{@website.domain} deleted at #{DateTime.now}", current_user.id)
     redirect_to admin_websites_url, notice: 'Website was successfully destroyed.'
   end
 
   def events
-    @events = Event.where(object_type: "Website", object_id: @website.id).order(:created_at)
+    @events = Event.where(object_type: 'Website', object_id: @website.id).order(:created_at)
   end
 
   def add_tag
-    @website.tag_list.add(admin_website_params[:tag_list].split(","))
+    @website.tag_list.add(admin_website_params[:tag_list].split(','))
     @website.save
   end
 
   def remove_tag
-    @website.tag_list.remove(admin_website_params[:tag_list].split(","))
+    @website.tag_list.remove(admin_website_params[:tag_list].split(','))
     @website.save
   end
 
@@ -258,48 +268,49 @@ class Admin::WebsitesController < AdminController
   end
 
   private
-    def set_website_manager_options
-      if admin_permissions?
-        @website_manager_options = User.active.order("email")
-      elsif @website && @website.organization
-        @website_manager_options = @website.organization.users.active.order("email")
-      elsif current_user.organization
-        @website_manager_options = current_user.organization.users.active.order("email")
-      else
-        []
-      end
 
-      if @website_manager_options && @website
-        @website_manager_options = @website_manager_options - @website.website_managers
-      end
+  def set_website_manager_options
+    if admin_permissions?
+      @website_manager_options = User.active.order('email')
+    elsif @website && @website.organization
+      @website_manager_options = @website.organization.users.active.order('email')
+    elsif current_user.organization
+      @website_manager_options = current_user.organization.users.active.order('email')
+    else
+      []
     end
 
-    def log_update(current_state)
-      Event.log_event(Event.names[:website_updated], "Website", @website.id, "Website #{@website.domain} updated at #{DateTime.now}", current_user.id)
-      if admin_website_params[:production_status] != current_state
-        Event.log_event(Event.names[:website_state_changed], "Website", @website.id, "Website #{@website.domain} state changed to #{admin_website_params[:production_status]} at #{DateTime.now}", current_user.id)
-      end
-    end
+    @website_manager_options -= @website.website_managers if @website_manager_options && @website
+  end
 
-    def set_website
-      @website = Website.find_by_id(params[:id])
+  def log_update(current_state)
+    Event.log_event(Event.names[:website_updated], 'Website', @website.id,
+                    "Website #{@website.domain} updated at #{DateTime.now}", current_user.id)
+    if admin_website_params[:production_status] != current_state
+      Event.log_event(Event.names[:website_state_changed], 'Website', @website.id,
+                      "Website #{@website.domain} state changed to #{admin_website_params[:production_status]} at #{DateTime.now}", current_user.id)
     end
+  end
 
-    def admin_website_params
-      params.require(:website).permit(:domain, :office, :office_id, :sub_office, :suboffice_id, :contact_email, :site_owner_email, :production_status, :type_of_site, :digital_brand_category, :redirects_to, :status_code, :cms_platform, :required_by_law_or_policy, :has_dap, :dap_gtm_code, :cost_estimator_url, :modernization_plan_url, :annual_baseline_cost,
-      :modernization_cost,
-      :modernization_cost_2021,
-      :modernization_cost_2022,
-      :modernization_cost_2023,
-      :analytics_url,
-      :https,
-      :uswds_version,
-      :uses_feedback, :feedback_tool, :sitemap_url, :mobile_friendly, :has_search, :uses_tracking_cookies,
-      :hosting_platform,
-      :has_authenticated_experience,
-      :authentication_tool,
-      :repository_url,
-      :notes,
-      :tag_list)
-    end
+  def set_website
+    @website = Website.find_by_id(params[:id])
+  end
+
+  def admin_website_params
+    params.require(:website).permit(:domain, :office, :office_id, :sub_office, :suboffice_id, :contact_email, :site_owner_email, :production_status, :type_of_site, :digital_brand_category, :redirects_to, :status_code, :cms_platform, :required_by_law_or_policy, :has_dap, :dap_gtm_code, :cost_estimator_url, :modernization_plan_url, :annual_baseline_cost,
+                                    :modernization_cost,
+                                    :modernization_cost_2021,
+                                    :modernization_cost_2022,
+                                    :modernization_cost_2023,
+                                    :analytics_url,
+                                    :https,
+                                    :uswds_version,
+                                    :uses_feedback, :feedback_tool, :sitemap_url, :mobile_friendly, :has_search, :uses_tracking_cookies,
+                                    :hosting_platform,
+                                    :has_authenticated_experience,
+                                    :authentication_tool,
+                                    :repository_url,
+                                    :notes,
+                                    :tag_list)
+  end
 end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -85,6 +85,23 @@ class Website < ApplicationRecord
     User.with_role(:website_manager, self)
   end
 
+  def website_manager_emails
+    website_managers.collect{ | mgr | mgr.email }.join(", ")
+  end
+
+  # return all website_ids managed by users with email matching search string
+  def self.ids_by_manager_search(search_text)
+    sql = %q(
+      select w.id from websites w, users_roles ur, roles r, users u
+      where u.email ilike :search_text
+        and u.id = ur.user_id
+        and ur.role_id = r.id
+        and r.resource_type = 'Website'
+        and r.resource_id = w.id
+        and r.name = 'website_manager').gsub("\n","")
+    self.find_by_sql([sql,search_text: search_text]).collect{ | ws | ws.id }
+  end
+
   def admin?(user:)
     raise ArgumentException unless user.class == User
 

--- a/app/views/admin/websites/_results.html.erb
+++ b/app/views/admin/websites/_results.html.erb
@@ -26,7 +26,7 @@
         <th data-sortable scope="col" role="columnheader">Status</th>
         <th data-sortable scope="col" role="columnheader">Office</th>
         <th data-sortable scope="col" role="columnheader">Sub-office</th>
-        <th data-sortable scope="col" role="columnheader">Website Manager</th>
+        <th data-sortable scope="col" role="columnheader">Website Managers</th>
         <th data-sortable scope="col" role="columnheader">Website Contact</th>
         <th>Tags</th>
       </tr>
@@ -42,7 +42,7 @@
           </td>
           <td><%= website.office %></td>
           <td><%= website.sub_office %></td>
-          <td><%= website.site_owner_email %></td>
+          <td><%= website.website_manager_emails %></td>
           <td><%= website.contact_email %></td>
           <td><%= website.tag_list %></td>
         </tr>

--- a/app/views/admin/websites/index.html.erb
+++ b/app/views/admin/websites/index.html.erb
@@ -45,7 +45,7 @@
 
 <div class="well">
   <div class="field">
-    <%= label_tag :search_text, "Search by domain, email, office, sub-office, Website Manager email, or Website Contact email" %>
+    <%= label_tag :search_text, "Search by domain, email, office, sub-office, Website Manager emails, or Website Contact email" %>
     <%= text_field_tag :search_text, nil, class: "usa-input" %>
     <% if @tags.first %>
       <p>

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -1,0 +1,9 @@
+namespace :one_offs do
+  task migrate_website_managers: :environment do
+    Website.all.each do | website |
+      next unless website.site_owner_email.present?
+      u = User.where(email: website.site_owner_email).first
+      u.add_role(:website_manager, website) unless u&.has_role?(:website_manager, website)
+    end
+  end
+end


### PR DESCRIPTION
TP-1385 update references to website.site_owner_email in search and views, add migration rake task

Linked story: https://trello.com/c/zyZgZsrY/1385-migrate-website-manager-to-website-managers

- Add migration rake task
- Change website search to search through website managers email addresses
- Change manager references from site_owner_email to website_managers role