### PR TITLE
Removed max-width for survey label

### DIFF
--- a/app/assets/stylesheets/uswds.scss
+++ b/app/assets/stylesheets/uswds.scss
@@ -1203,7 +1203,6 @@ img{
   display:block;
   font-weight:normal;
   margin-top:1.5rem;
-  max-width:30rem;
 }
 
 .usa-label--error{


### PR DESCRIPTION
Survey question labels were limited to max-width of 30 rem resulting in label not taking full div width. Removed max-width to allow label occupy full div width.