### PR TITLE
Make users by day stacked bar chart including inactive users

### DIFF
--- a/app/controllers/admin/site_controller.rb
+++ b/app/controllers/admin/site_controller.rb
@@ -8,6 +8,7 @@ class Admin::SiteController < AdminController
 
     @response_groups = Submission.group("date(created_at)").count.sort.last(@days_since.days)
     @user_groups = User.group("date(created_at)").count.sort.last(@days_since.days)
+    @inactive_user_groups = User.where(inactive: true).group("date(updated_at)").count.sort.last(@days_since.days)
     todays_submissions = Submission.where("created_at > ?", Time.now - @days_since.days)
 
     # Add in 0 count days to fetched analytics

--- a/app/views/admin/site/index.html.erb
+++ b/app/views/admin/site/index.html.erb
@@ -222,7 +222,7 @@
         <%= render 'components/admin/responses_per_day', response_groups: @response_groups %>
       </div>
       <div class="well">
-        <%= render 'components/admin/new_users_over_time', user_groups: @user_groups %>
+        <%= render 'components/admin/new_users_over_time', user_groups: @user_groups, inactive_user_groups: @inactive_user_groups %>
       </div>
       <% else %>
         <h4>

--- a/app/views/components/admin/_new_users_over_time.html.erb
+++ b/app/views/components/admin/_new_users_over_time.html.erb
@@ -20,14 +20,24 @@ $(function() {
       <% end %>
       ],
       datasets: [{
-        label: '# of Users',
+        label: '# of Active Users',
         data: [
         <% user_groups.each do |key, value| %>
           <%= value %>,
         <% end %>
         ],
-        backgroundColor: "#E1F3F8"
-      }]
+        backgroundColor: "#57B63A"
+      },
+      {
+        label: '# of Inactive Users',
+        data: [
+        <% inactive_user_groups.each do |key, value| %>
+          <%= value %>,
+        <% end %>
+        ],
+        backgroundColor: "#AEBCA9"
+      }
+      ]
     },
     options: {
       responsive: true,
@@ -35,11 +45,17 @@ $(function() {
         position: 'bottom',
       },
       scales: {
-        yAxes: [{
-          ticks: {
-            beginAtZero: true
-          }
-        }]
+      x: {
+        stacked: true,
+      },
+      y: {
+        stacked: true
+      },
+      yAxes: [{
+        ticks: {
+          beginAtZero: true
+        }
+      }]
       }
     }
   });


### PR DESCRIPTION
https://trello.com/c/jOu4dh3M/1390-show-0-days-for-daily-users-chart

Made the users_by_day chart a stacked bar chart with inactive users.

<img width="1133" alt="Screen Shot 2022-03-21 at 11 07 31 AM" src="https://user-images.githubusercontent.com/1626505/159290644-cc0f11e1-5fe9-40f2-8096-542e1536f39a.png">

