### PR TITLE
TP-187 Add social_media_account_created_notification email and send on create

### DIFF
--- a/app/controllers/admin/digital_service_accounts_controller.rb
+++ b/app/controllers/admin/digital_service_accounts_controller.rb
@@ -34,6 +34,7 @@ module Admin
 
     if @digital_service_account.save
       Event.log_event(Event.names[:digital_service_account_created], "Digital Service Account", @digital_service_account.id, "Digital Service Account #{@digital_service_account.name} created at #{DateTime.now}", current_user.id)
+      UserMailer.social_media_account_created_notification(digital_service_account: @digital_service_account, link: admin_digital_service_account_path(@digital_service_account)).deliver_later
       redirect_to admin_digital_service_account_path(@digital_service_account), notice: 'Digital service account was successfully created.'
     else
       render :new

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -13,6 +13,14 @@ class UserMailer < ApplicationMailer
       to: emails
   end
 
+  def social_media_account_created_notification(digital_service_account:, link: )
+    set_logo
+    @digital_service_account = digital_service_account
+    @link = link
+    mail subject: "Touchpoints social media account has been created",
+      to: UserMailer.registry_manager_emails
+  end
+
   def service_event_notification(subject:, service:, event:, link: "")
     set_logo
     @subject = subject
@@ -138,6 +146,10 @@ class UserMailer < ApplicationMailer
   end
 
   private
+
+  def self.registry_manager_emails
+    User.registry_managers.collect { |u| u.email }.join(",")
+  end
 
   def self.touchpoints_team
     ENV.fetch('TOUCHPOINTS_TEAM') { 'feedback-analytics@gsa.gov' }

--- a/app/views/user_mailer/social_media_account_created_notification.html.erb
+++ b/app/views/user_mailer/social_media_account_created_notification.html.erb
@@ -1,0 +1,28 @@
+
+Social Media Account has been created
+
+Change made by: <%= @digital_service_account.user.email %>
+
+See this social media account here: <%= @digital_service_account.service_url %>
+
+If you are having trouble with this link, follow this url: <%= @link %>
+
+Social Media Account Details
+
+Social Media Account Name: <%=@digital_service_account.name %>
+
+Agencies: <%= @digital_service_account.organization.name %>
+
+Account Type: <%= @digital_service_account.account %>
+
+Account URL: <%= @digital_service_account.service_url %>
+
+Short Description: <%= @digital_service_account.short_description %>
+
+Long Description: <%= @digital_service_account.long_description %>
+
+Tags: <%= @digital_service_account.tags.to_s %>
+
+Created at: <%= @digital_service_account.created_at.to_s %>
+
+Status: Created

--- a/app/views/user_mailer/social_media_account_created_notification.text.erb
+++ b/app/views/user_mailer/social_media_account_created_notification.text.erb
@@ -1,0 +1,17 @@
+<%= render 'user_mailer/components/header' %>
+<h3>
+  Social Media Account has been created
+</h3>
+<p>Change made by: <%= @digital_service_account.user.email %></p>
+<p><a href="<%= @digital_service_account.service_url %>">See this social media account here</a></p>
+<p>If you are having trouble with this link, follow this url <a href="<%= @link %>"></a></p>
+<h2>Social Media Account Details</h2>
+<p><em>Social Media Account Name:</em> <%=@digital_service_account.name %></p>
+<p><em>Agencies:</em> <%= @digital_service_account.organization.name %></p>
+<p><em>Account Type:</em> <%= @digital_service_account.account %></p>
+<p><em>Account URL:</em> <%= @digital_service_account.service_url %></p>
+<p><em>Short Description:</em> <%= @digital_service_account.short_description %></p>
+<p><em>Long Description:</em> <%= @digital_service_account.long_description %></p>
+<p><em>Tags:</em> <%= @digital_service_account.tags.to_s %></p>
+<p><em>Created at: <%= @digital_service_account.created_at.to_s %></em> </p>
+<p><em>Status:</em> Created</p>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -110,6 +110,23 @@ RSpec.describe UserMailer, type: :mailer do
 
   end
 
+  describe "social_media_account_created_notification" do
+    let!(:user) { FactoryBot.create(:user, registry_manager: true) }
+    let(:digital_service_account) { FactoryBot.create(:digital_service_account)}
+    let(:mail) { UserMailer.social_media_account_created_notification(digital_service_account: digital_service_account, link: admin_digital_service_account_path(digital_service_account)) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Touchpoints social media account has been created")
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq([ENV.fetch("TOUCHPOINTS_EMAIL_SENDER")])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Social Media Account has been created")
+    end
+
+  end
+
   describe "org_user_notification" do
     let(:user) { FactoryBot.create(:user) }
     let(:mail) { UserMailer.org_user_notification(user,user) }


### PR DESCRIPTION
https://trello.com/c/qAb8LUR0/1387-send-email-when-a-social-media-account-is-created

Create email and content
Send email on social_media_account create
Spec