### PR TITLE
TP-1442-refactor-digital-product-and-digital-service-account-users-and-org-relationships-use-taggable

### DIFF
--- a/app/controllers/admin/digital_products_controller.rb
+++ b/app/controllers/admin/digital_products_controller.rb
@@ -61,19 +61,15 @@ class Admin::DigitalProductsController < AdminController
   end
 
   def add_organization
-    @organization = Organization.find_by_id(params[:organization][:id])
-
-    if @organization
-      @organization.add_role(:sponsor, @digital_product)
-    end
+    @digital_product.organization_list.add(params[:organization_id])
+    @digital_product.save
+    set_sponsoring_agency_options
   end
 
   def remove_organization
-    @organization = Organization.find_by_id(params[:organization][:id])
-
-    if @organization
-      @organization.remove_role(:sponsor, @digital_product)
-    end
+    @digital_product.organization_list.remove(params[:organization_id])
+    @digital_product.save
+    set_sponsoring_agency_options
   end
 
   def add_user
@@ -164,8 +160,17 @@ class Admin::DigitalProductsController < AdminController
 
 
   private
+
     def set_digital_product
       @digital_product = DigitalProduct.find(params[:id])
+      set_sponsoring_agency_options
+    end
+
+    def set_sponsoring_agency_options
+      @sponsoring_agency_options = Organization.all.order(:name)
+      if @sponsoring_agency_options && @digital_product
+        @sponsoring_agency_options = @sponsoring_agency_options - @digital_product.sponsoring_agencies
+      end
     end
 
     def digital_product_params
@@ -182,7 +187,8 @@ class Admin::DigitalProductsController < AdminController
         :short_description,
         :long_description,
         :certified_at,
-        :tag_list
+        :tag_list,
+        :organization_list
       )
     end
 end

--- a/app/controllers/admin/digital_service_accounts_controller.rb
+++ b/app/controllers/admin/digital_service_accounts_controller.rb
@@ -34,7 +34,7 @@ module Admin
 
     if @digital_service_account.save
       current_user.add_role(:contact, @digital_service_account)
-      current_user.organization.add_role(:sponsor, @digital_service_account)
+      @digital_service_account.organization_list.add(current_user.organization.id)
 
       Event.log_event(Event.names[:digital_service_account_created], "Digital Service Account", @digital_service_account.id, "Digital Service Account #{@digital_service_account.name} created at #{DateTime.now}", current_user.id)
 

--- a/app/controllers/admin/digital_service_accounts_controller.rb
+++ b/app/controllers/admin/digital_service_accounts_controller.rb
@@ -76,19 +76,15 @@ module Admin
   end
 
   def add_organization
-    @organization = Organization.find_by_id(params[:organization][:id])
-
-    if @organization
-      @organization.add_role(:sponsor, @digital_service_account)
-    end
+    @digital_service_account.organization_list.add(params[:organization_id])
+    @digital_service_account.save
+    set_sponsoring_agency_options
   end
 
   def remove_organization
-    @organization = Organization.find_by_id(params[:organization][:id])
-
-    if @organization
-      @organization.remove_role(:sponsor, @digital_service_account)
-    end
+    @digital_service_account.organization_list.remove(params[:organization_id])
+    @digital_service_account.save
+    set_sponsoring_agency_options
   end
 
   def add_user
@@ -188,6 +184,14 @@ module Admin
 
     def set_digital_service_account
       @digital_service_account = DigitalServiceAccount.find(params[:id])
+      set_sponsoring_agency_options
+    end
+
+    def set_sponsoring_agency_options
+      @sponsoring_agency_options = Organization.all.order(:name)
+      if @sponsoring_agency_options && @digital_service_account
+        @sponsoring_agency_options = @sponsoring_agency_options - @digital_service_account.sponsoring_agencies
+      end
     end
 
     def digital_service_account_params
@@ -203,7 +207,8 @@ module Admin
         :short_description,
         :long_description,
         :tags,
-        :tag_list)
+        :tag_list,
+        :organization_list)
     end
   end
 end

--- a/app/models/digital_product.rb
+++ b/app/models/digital_product.rb
@@ -7,10 +7,11 @@ class DigitalProduct < ApplicationRecord
   validates :name, presence: true
 
   has_paper_trail
+
   resourcify
 
   include AASM
-  acts_as_taggable_on :tags
+  acts_as_taggable_on :tags, :organizations
 
   scope :active, -> { where(aasm_state: :published) }
 
@@ -75,5 +76,9 @@ class DigitalProduct < ApplicationRecord
     end
 
     puts "Loaded DigitalServiceAccounts"
+  end
+
+  def sponsoring_agencies
+    Organization.where(id: self.organization_list)
   end
 end

--- a/app/models/digital_service_account.rb
+++ b/app/models/digital_service_account.rb
@@ -3,9 +3,10 @@ require 'open-uri'
 
 class DigitalServiceAccount < ApplicationRecord
   include AASM
-  acts_as_taggable_on :tags
+  acts_as_taggable_on :tags, :organizations
 
   has_paper_trail
+
   resourcify
 
   scope :active, -> { where(aasm_state: :published) }
@@ -40,6 +41,10 @@ class DigitalServiceAccount < ApplicationRecord
 
   def organization_abbreviation
     self.organization.abbreviation
+  end
+
+  def sponsoring_agencies
+    Organization.where(id: self.organization_list)
   end
 
   def self.load_service_accounts

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -18,11 +18,6 @@ class Organization < ApplicationRecord
   validates :abbreviation, presence: true
   validates :abbreviation, uniqueness: true
 
-  # an Organization can be assigned to the following objects:
-  #  Digital Products
-  #  Digital Service Accounts
-  rolify
-
   def slug
     self.abbreviation.downcase
   end

--- a/app/views/admin/digital_products/_organizations.html.erb
+++ b/app/views/admin/digital_products/_organizations.html.erb
@@ -1,68 +1,56 @@
-<%= form_with(model: digital_product, url: admin_digital_product_path(digital_product), local: true) do |f| %>
-	<div class="grid-row">
-	  <div class="grid-col-12">
-	  	<h3>
-				Sponsoring Agencies
-			</h3>
-	  	<div class="organizations-list">
-				<ul class="usa-list usa-list--unstyled">
-				<% digital_product.roles.sort.each do |role| %>
-					<% role.organizations.sort_by { |u| u.name }.each do |org| %>
-					<li style="margin-bottom: 3px;">
-						<span class="usa-tag">
-							<%= org.name %>
-						</span>
-						<% if digital_product_permissions?(digital_product: digital_product, user: current_user) %>
-						<a href="javascript:void(0);" class="remove-tag-link" data-id="<%= org.id %>">
-							<span class="fa fa-trash"></span>
-						</a>
-						<% end %>
-					</li>
-		  		<% end %>
-	  		<% end %>
-				</ul>
-	  	</div>
+<div id="sponsoring-agencies-div" class="grid-row" data-value="<%= admin_digital_product_path(@digital_product) %>">
+  <div class="grid-col-12">
+    <h3>
+      Sponsoring Agencies
+    </h3>
+    <small>
+      Optionally, this digital product may be associated with one or more
+      <%= link_to "Agencies", admin_organizations_path %>.
+    </small>
+    <p class="sponsoring-agencies-list">
+      <ul class="usa-list usa-list--unstyled">
+        <% @digital_product.sponsoring_agencies.each do |agency| %>
+        <li style="margin-bottom: 3px;">
+          <span class="usa-tag">
+            <%= agency.name %>
+          </span>
+          &nbsp;
+          <a href="javascript:void(0);" class="remove-agency-link" data-value="<%= agency.id %>">
+            <span class="fa fa-trash"></span>
+          </a>
+        </li>
+          <% end %>
+      </ul>
+    </p>
+  </div>
+  <%= select_tag :organization_id, options_for_select(@sponsoring_agency_options.map { |p| [p.name, p.id] }), prompt: "Choose an Agency", class: "usa-select add-agency" %>
+</div>
 
-			<% if digital_product_permissions?(digital_product: digital_product, user: current_user) %>
-				<% if digital_product.roles.present? %>
-					<% @unselected_organizations = Organization.all.select { |org| !digital_product.roles.last.organizations.collect(&:id).include?(org.id) }  %>
-				<% else %>
-					<% @unselected_organizations = Organization.all  %>
-				<% end %>
-
-				<% if @unselected_organizations.present? %>
-		    	<%= f.select :organization_id, options_for_select(@unselected_organizations.sort_by(&:abbreviation).map { |organization| ["#{organization.abbreviation} - #{organization.name}", organization.id] }), { prompt: "Which Organization?", include_blank: true }, { class: "usa-select" } %>
-				<% end %>
-			<% end %>
-
-	  </div>
-	</div>
-<% end %>
-
-<% if digital_product_permissions?(digital_product: digital_product, user: current_user) %>
 <script>
-	$(function() {
-		$("#digital_product_organization_id").on("change", function(event) {
-			event.preventDefault();
+  $(function() {
 
-			var thisForm = $(this).closest("form");
-			$.ajax({
-				url: thisForm.attr("action") + "/add_organization",
-				type: 'post',
-				data: "organization[id]=" + $("#digital_product_organization_id").val()
-			});
-		});
-		$
-		$(".organizations-list .remove-tag-link").on("click", function(e) {
-			event.preventDefault();
+    $(".add-agency").on("change", function(e) {
 
-			var thisForm = $(this).closest("form");
-			$.ajax({
-				url: thisForm.attr("action") + "/remove_organization",
-				type: 'post',
-				data: "organization[id]=" + $(this).attr("data-id")
-			});
-		})
-	})
+      event.preventDefault();
+
+      var container = $('#sponsoring-agencies-div');
+      $.ajax({
+        url: container.attr("data-value") + "/add_organization",
+        type: 'post',
+        data: "organization_id=" + $(this).val()
+      });
+    });
+
+    $(".remove-agency-link").on("click", function(e) {
+      event.preventDefault();
+
+      var container = $('#sponsoring-agencies-div');
+      $.ajax({
+        url: container.attr("data-value") + "/remove_organization",
+        type: 'post',
+        data: "organization_id=" + $(this).attr("data-value")
+      });
+    });
+
+  })
 </script>
-<% end %>

--- a/app/views/admin/digital_products/add_organization.js.erb
+++ b/app/views/admin/digital_products/add_organization.js.erb
@@ -1,5 +1,1 @@
-<% if @organization %>
-$(".organizations").html("<%= escape_javascript render(partial: 'admin/digital_products/organizations', locals: { digital_product: @digital_product }) %>");
-<% else %>
-alert("Organization <%= params[:organization][:name] %> does not exist.")
-<% end %>
+$("#sponsoring-agencies-div").html("<%= escape_javascript render(partial: 'admin/digital_products/organizations', locals: { digital_product: @digital_product }) %>");

--- a/app/views/admin/digital_products/remove_organization.js.erb
+++ b/app/views/admin/digital_products/remove_organization.js.erb
@@ -1,5 +1,2 @@
-<% if @organization %>
-$(".organizations").html("<%= escape_javascript render(partial: 'admin/digital_products/organizations', locals: { digital_product: @digital_product }) %>");
-<% else %>
-alert("User <%= params[:organization][:id] %> does not exist.")
-<% end %>
+$("#sponsoring-agencies-div").html("<%= escape_javascript render(partial: 'admin/digital_products/organizations', locals: { digital_product: @digital_product }) %>");
+

--- a/app/views/admin/digital_service_accounts/_organizations.html.erb
+++ b/app/views/admin/digital_service_accounts/_organizations.html.erb
@@ -1,68 +1,56 @@
-<%= form_with(model: digital_service_account, url: admin_digital_service_account_path(digital_service_account), local: true) do |f| %>
-	<div class="grid-row">
-	  <div class="grid-col-12">
-	  	<h3>
-				Sponsoring Agencies
-			</h3>
-	  	<div class="organizations-list">
-				<ul class="usa-list usa-list--unstyled">
-				<% digital_service_account.roles.sort.each do |role| %>
-					<% role.organizations.sort_by { |u| u.name }.each do |org| %>
-					<li style="margin-bottom: 3px;">
-						<span class="usa-tag">
-							<%= org.name %>
-						</span>
-						<% if digital_service_account_permissions?(digital_service_account: digital_service_account, user: current_user) %>
-						<a href="javascript:void(0);" class="remove-tag-link" data-id="<%= org.id %>">
-							<span class="fa fa-trash"></span>
-						</a>
-						<% end %>
-					</li>
-		  		<% end %>
-	  		<% end %>
-				</ul>
-	  	</div>
+<div id="sponsoring-agencies-div" class="grid-row" data-value="<%= admin_digital_service_account_path(@digital_service_account) %>">
+  <div class="grid-col-12">
+    <h3>
+      Sponsoring Agencies
+    </h3>
+    <small>
+      Optionally, this account may be associated with one or more
+      <%= link_to "Agencies", admin_organizations_path %>.
+    </small>
+    <p class="sponsoring-agencies-list">
+      <ul class="usa-list usa-list--unstyled">
+        <% @digital_service_account.sponsoring_agencies.each do |agency| %>
+        <li style="margin-bottom: 3px;">
+          <span class="usa-tag">
+            <%= agency.name %>
+          </span>
+          &nbsp;
+          <a href="javascript:void(0);" class="remove-agency-link" data-value="<%= agency.id %>">
+            <span class="fa fa-trash"></span>
+          </a>
+        </li>
+          <% end %>
+      </ul>
+    </p>
+  </div>
+  <%= select_tag :organization_id, options_for_select(@sponsoring_agency_options.map { |p| [p.name, p.id] }), prompt: "Choose an Agency", class: "usa-select add-agency" %>
+</div>
 
-			<% if digital_service_account_permissions?(digital_service_account: digital_service_account, user: current_user) %>
-				<% if digital_service_account.roles.present? %>
-					<% @unselected_organizations = Organization.all.select { |org| !digital_service_account.roles.last.organizations.collect(&:id).include?(org.id) }  %>
-				<% else %>
-					<% @unselected_organizations = Organization.all  %>
-				<% end %>
-
-				<% if @unselected_organizations.present? %>
-		    	<%= f.select :organization_id, options_for_select(@unselected_organizations.sort_by(&:abbreviation).map { |organization| ["#{organization.abbreviation} - #{organization.name}", organization.id] }), { prompt: "Which Organization?" }, { class: "usa-select" } %>
-				<% end %>
-			<% end %>
-
-	  </div>
-	</div>
-<% end %>
-
-<% if digital_service_account_permissions?(digital_service_account: digital_service_account, user: current_user) %>
 <script>
-	$(function() {
-		$("#digital_service_account_organization_id").on("change", function(event) {
-			event.preventDefault();
+  $(function() {
 
-			var thisForm = $(this).closest("form");
-			$.ajax({
-				url: thisForm.attr("action") + "/add_organization",
-				type: 'post',
-				data: "organization[id]=" + $("#digital_service_account_organization_id").val()
-			});
-		});
-		$
-		$(".organizations-list .remove-tag-link").on("click", function(e) {
-			event.preventDefault();
+    $(".add-agency").on("change", function(e) {
 
-			var thisForm = $(this).closest("form");
-			$.ajax({
-				url: thisForm.attr("action") + "/remove_organization",
-				type: 'post',
-				data: "organization[id]=" + $(this).attr("data-id")
-			});
-		})
-	})
+      event.preventDefault();
+
+      var container = $('#sponsoring-agencies-div');
+      $.ajax({
+        url: container.attr("data-value") + "/add_organization",
+        type: 'post',
+        data: "organization_id=" + $(this).val()
+      });
+    });
+
+    $(".remove-agency-link").on("click", function(e) {
+      event.preventDefault();
+
+      var container = $('#sponsoring-agencies-div');
+      $.ajax({
+        url: container.attr("data-value") + "/remove_organization",
+        type: 'post',
+        data: "organization_id=" + $(this).attr("data-value")
+      });
+    });
+
+  })
 </script>
-<% end %>

--- a/app/views/admin/digital_service_accounts/add_organization.js.erb
+++ b/app/views/admin/digital_service_accounts/add_organization.js.erb
@@ -1,5 +1,1 @@
-<% if @organization %>
-$(".organizations").html("<%= escape_javascript render(partial: 'admin/digital_service_accounts/organizations', locals: { digital_service_account: @digital_service_account }) %>");
-<% else %>
-alert("Organization <%= params[:organization][:name] %> does not exist.")
-<% end %>
+$("#sponsoring-agencies-div").html("<%= escape_javascript render(partial: 'admin/digital_service_accounts/organizations', locals: { digital_service_account: @digital_service_account }) %>");

--- a/app/views/admin/digital_service_accounts/remove_organization.js.erb
+++ b/app/views/admin/digital_service_accounts/remove_organization.js.erb
@@ -1,5 +1,1 @@
-<% if @organization %>
-$(".organizations").html("<%= escape_javascript render(partial: 'admin/digital_service_accounts/organizations', locals: { digital_service_account: @digital_service_account }) %>");
-<% else %>
-alert("User <%= params[:organization][:id] %> does not exist.")
-<% end %>
+$("#sponsoring-agencies-div").html("<%= escape_javascript render(partial: 'admin/digital_service_accounts/organizations', locals: { digital_service_account: @digital_service_account }) %>");

--- a/spec/features/admin/collections_spec.rb
+++ b/spec/features/admin/collections_spec.rb
@@ -109,7 +109,7 @@ feature "Data Collections", js: true do
           expect(page.current_path).to eq(admin_collection_path(Collection.last))
           expect(page).to have_link("Add a Service to report on")
           # TODO:  Sometimes content in the notice area isn't visible
-          #expect(page).to have_content("Collection was successfully created.")
+          # expect(page).to have_content("Collection was successfully created.")
         end
       end
     end

--- a/spec/features/admin/collections_spec.rb
+++ b/spec/features/admin/collections_spec.rb
@@ -108,7 +108,8 @@ feature "Data Collections", js: true do
           expect(page).to have_content("CX Quarterly Reporting")
           expect(page.current_path).to eq(admin_collection_path(Collection.last))
           expect(page).to have_link("Add a Service to report on")
-          expect(page).to have_content("Collection was successfully created.", wait: 4)
+          # TODO:  Sometimes content in the notice area isn't visible
+          #expect(page).to have_content("Collection was successfully created.")
         end
       end
     end

--- a/spec/features/admin/digital_service_accounts_spec.rb
+++ b/spec/features/admin/digital_service_accounts_spec.rb
@@ -111,7 +111,7 @@ feature "Digital Service Accounts", js: true do
       before 'fill-in the form' do
         visit admin_digital_service_account_path(digital_service_account)
 
-        select(organization.name, from: "digital_service_account_organization_id")
+        select(organization.name, from: "organization_id")
         find(".organizations").click # just to lose focus
       end
 
@@ -122,13 +122,13 @@ feature "Digital Service Accounts", js: true do
 
     describe 'remove organization' do
       let(:digital_service_account) { FactoryBot.create(:digital_service_account) }
-      let!(:role) { organization.add_role(:sponsor, digital_service_account) }
 
       before 'fill-in the form' do
+        digital_service_account.organization_list.add(organization.id)
         visit admin_digital_service_account_path(digital_service_account)
+        select(organization.name, from: "organization_id")
         expect(page).to have_content(organization.name.upcase)
-        find(".organizations-list .remove-tag-link").click
-
+        find(".remove-agency-link").click
       end
 
       it 'removes the organization' do


### PR DESCRIPTION
https://trello.com/c/1wXhtqcd/1442-refactor-digital-product-and-digital-service-account-users-and-org-relationships-use-taggable

Replaced organizations modeled as roles with organizations modeled as an organizations tag context

@afomi Outstanding Questions:

- Are there any organizational role mappings to DigitalProducts and DigitalServiceAccounts that need to be migrated to the organizations tag_lists?
- Shall I create a migration to remove the OrganizationRole association table?
