### PR TITLE
TP-1448 allow DigitalServiceAccount contacts to manage the DigitalSer…

### DIFF
--- a/app/controllers/admin/digital_service_accounts_controller.rb
+++ b/app/controllers/admin/digital_service_accounts_controller.rb
@@ -16,20 +16,25 @@ module Admin
   end
 
   def review
+    eensure_admin_or_contact(@digital_service_account)
     @digital_service_accounts = DigitalServiceAccount.where("aasm_state = 'created' OR aasm_state = 'edited'").order(:organization_id, :name).page(params[:page])
   end
 
   def show
+    ensure_admin_or_contact(@digital_service_account)
   end
 
   def new
+    ensure_admin
     @digital_service_account = DigitalServiceAccount.new
   end
 
   def edit
+    ensure_admin_or_contact(@digital_service_account)
   end
 
   def create
+    ensure_admin
     @digital_service_account = DigitalServiceAccount.new(digital_service_account_params)
     @digital_service_account.organization_list.add(current_user.organization_id)
 
@@ -47,6 +52,7 @@ module Admin
   end
 
   def update
+    ensure_admin_or_contact(@digital_service_account)
     if @digital_service_account.update(digital_service_account_params)
       Event.log_event(Event.names[:digital_service_account_updated], 'DigitalServiceAccount',
         @digital_service_account.id, "updated by #{current_user.email} on #{Date.today}", current_user.id)
@@ -59,6 +65,7 @@ module Admin
   end
 
   def destroy
+    ensure_admin_or_contact(@digital_service_account)
     @digital_service_account.destroy
     Event.log_event(Event.names[:digital_service_account_deleted], 'DigitalServiceAccount',
       @digital_service_account.id, "deleted by #{current_user.email} on #{Date.today}", current_user.id)
@@ -66,28 +73,33 @@ module Admin
   end
 
   def add_tag
+    ensure_admin_or_contact(@digital_service_account)
     @digital_service_account.tag_list.add(digital_service_account_params[:tag_list].split(','))
     @digital_service_account.save
   end
 
   def remove_tag
+    ensure_admin_or_contact(@digital_service_account)
     @digital_service_account.tag_list.remove(digital_service_account_params[:tag_list].split(','))
     @digital_service_account.save
   end
 
   def add_organization
+    ensure_admin_or_contact(@digital_service_account)
     @digital_service_account.organization_list.add(params[:organization_id])
     @digital_service_account.save
     set_sponsoring_agency_options
   end
 
   def remove_organization
+    ensure_admin_or_contact(@digital_service_account)
     @digital_service_account.organization_list.remove(params[:organization_id])
     @digital_service_account.save
     set_sponsoring_agency_options
   end
 
   def add_user
+    ensure_admin_or_contact(@digital_service_account)
     @user = User.find_by_email(params[:user][:email])
 
     if @user
@@ -96,6 +108,7 @@ module Admin
   end
 
   def remove_user
+    ensure_admin_or_contact(@digital_service_account)
     @user = User.find_by_id(params[:user][:id])
 
     if @user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,14 @@ class ApplicationController < ActionController::Base
     redirect_to(index_path, notice: "Authorization is Required")
   end
 
+  def ensure_admin_or_contact(obj)
+    return true if admin_permissions?
+    if current_user.present?
+      return true if current_user.has_role?(:contact, obj)
+    end
+    redirect_to(index_path, notice: "Authorization is Required")
+  end
+
   def ensure_performance_manager_permissions
     return true if performance_manager_permissions?
 
@@ -156,7 +164,7 @@ class ApplicationController < ActionController::Base
   def registry_manager_permissions?(user:)
     return false unless user.present?
     return true if admin_permissions?
-    user.registry_manager?(user: user)
+    user.registry_manager?
   end
 
   helper_method :digital_service_account_permissions?

--- a/spec/features/admin/digital_service_accounts_spec.rb
+++ b/spec/features/admin/digital_service_accounts_spec.rb
@@ -184,6 +184,29 @@ feature "Digital Service Accounts", js: true do
         expect(page).to_not have_content(user.email.upcase)
       end
     end
+  end
 
+  context "as Contact" do
+    let(:digital_service_account) { FactoryBot.create(:digital_service_account) }
+
+    before do
+      user.add_role(:contact, digital_service_account)
+      login_as user
+      visit admin_digital_service_account_path(digital_service_account)
+    end
+
+    it 'contact can edit digital service account' do
+      click_on "Edit"
+      expect(page).to have_content("Editing Social Media Account")
+    end
+
+    it 'contact can delete digital service account' do
+      click_on "Edit"
+      expect(page).to have_content("Editing Social Media Account")
+      accept_confirm do
+        click_link "Delete"
+      end
+      expect(page).to have_content("Digital service account was deleted.")
+    end
   end
 end


### PR DESCRIPTION
TP-1448 allow DigitalServiceAccount contacts to manage the DigitalServiceAccount

https://trello.com/c/f0BlgJ8i/1448-limit-the-editing-of-a-digital-service-account-by-the-user-contacts