### PR TITLE
TP-1450 Ensure search works for digital products

### DIFF
--- a/app/controllers/admin/digital_products_controller.rb
+++ b/app/controllers/admin/digital_products_controller.rb
@@ -149,13 +149,12 @@ class Admin::DigitalProductsController < AdminController
     search_text = params[:search]
     organization_id = params[:organization_id]
 
-    if search_text && search_text.length >= 3
-      @digital_products = DigitalProduct.where("name ilike '%#{search_text}%'")
-    elsif organization_id
-      @digital_products = DigitalProduct.where("organization_id = ?", organization_id)
-    else
-      @digital_products = DigitalProduct.all
-    end
+    @digital_products = DigitalProduct.all
+    @digital_products = @digital_products.where("name ilike '%#{search_text}%'") if search_text && search_text.length >= 3
+    @digital_products = @digital_products.where("organization_id = ?", organization_id) if organization_id.present? && organization_id != ''
+    @digital_products = @digital_products.where("service = ?", params[:service]) if params[:service].present? && params[:service] != 'All'
+    @digital_products = @digital_products.where("aasm_state = ?", params[:aasm_state].downcase) if params[:aasm_state].present? && params[:aasm_state] != 'All'
+    @digital_producs
   end
 
 

--- a/app/controllers/admin/digital_products_controller.rb
+++ b/app/controllers/admin/digital_products_controller.rb
@@ -151,7 +151,7 @@ class Admin::DigitalProductsController < AdminController
 
     @digital_products = DigitalProduct.all
     @digital_products = @digital_products.where("name ilike '%#{search_text}%'") if search_text && search_text.length >= 3
-    @digital_products = @digital_products.where("organization_id = ?", organization_id) if organization_id.present? && organization_id != ''
+    @digital_products = @digital_products.tagged_with(organization_id, context: "organizations") if organization_id.present? && organization_id != ''
     @digital_products = @digital_products.where("service = ?", params[:service]) if params[:service].present? && params[:service] != 'All'
     @digital_products = @digital_products.where("aasm_state = ?", params[:aasm_state].downcase) if params[:aasm_state].present? && params[:aasm_state] != 'All'
     @digital_producs

--- a/app/controllers/admin/digital_products_controller.rb
+++ b/app/controllers/admin/digital_products_controller.rb
@@ -154,7 +154,7 @@ class Admin::DigitalProductsController < AdminController
     @digital_products = @digital_products.tagged_with(organization_id, context: "organizations") if organization_id.present? && organization_id != ''
     @digital_products = @digital_products.where("service = ?", params[:service]) if params[:service].present? && params[:service] != 'All'
     @digital_products = @digital_products.where("aasm_state = ?", params[:aasm_state].downcase) if params[:aasm_state].present? && params[:aasm_state] != 'All'
-    @digital_producs
+    @digital_products
   end
 
 

--- a/app/controllers/admin/digital_service_accounts_controller.rb
+++ b/app/controllers/admin/digital_service_accounts_controller.rb
@@ -12,7 +12,7 @@ module Admin
   ]
 
   def index
-    @digital_service_accounts = DigitalServiceAccount.order(:organization_id, :name).page(params[:page])
+    @digital_service_accounts = DigitalServiceAccount.order(:name).page(params[:page])
   end
 
   def review
@@ -176,20 +176,16 @@ module Admin
     end
   end
 
-  def search
+ def search
     search_text = params[:search]
     organization_id = params[:organization_id]
-    service_text = params[:service]
 
-    if search_text && search_text.length >= 3
-      @digital_products = DigitalServiceAccount.where("name ilike '%#{search_text}%'")
-    elsif organization_id
-      @digital_products = DigitalServiceAccount.where("organization_id = ?", organization_id)
-    elsif service_text
-      @digital_products = DigitalServiceAccount.where("service ilike '%#{search_text}%'")
-    else
-      @digital_products = DigitalServiceAccount.all
-    end
+    @digital_service_accounts = DigitalServiceAccount.all
+    @digital_service_accounts = @digital_service_accounts.where("name ilike '%#{search_text}%'") if search_text && search_text.length >= 3
+    @digital_service_accounts = @digital_service_accounts.tagged_with(organization_id, context: "organizations") if organization_id.present? && organization_id != ''
+    @digital_service_accounts = @digital_service_accounts.where("service = ?", params[:service]) if params[:service].present? && params[:service] != 'All'
+    @digital_service_accounts = @digital_service_accounts.where("aasm_state = ?", params[:aasm_state].downcase) if params[:aasm_state].present? && params[:aasm_state] != 'All'
+    @digital_service_accounts
   end
 
 

--- a/app/models/digital_service_account.rb
+++ b/app/models/digital_service_account.rb
@@ -35,14 +35,6 @@ class DigitalServiceAccount < ApplicationRecord
     end
   end
 
-  def organization_name
-    self.organization.name
-  end
-
-  def organization_abbreviation
-    self.organization.abbreviation
-  end
-
   def sponsoring_agencies
     Organization.where(id: self.organization_list)
   end

--- a/app/views/admin/digital_products/index.html.erb
+++ b/app/views/admin/digital_products/index.html.erb
@@ -109,9 +109,6 @@
     $('#organization_id').on("change", function(event) {
       event.preventDefault();
 
-      // $('.usa-hint.goal-parent-id').show();
-      // $('.usa-hint.goal-parent-id').fadeOut(2000);
-      debugger
       $.ajax({
         url: '/admin/digital_products/search',
         data: {

--- a/app/views/admin/digital_products/index.html.erb
+++ b/app/views/admin/digital_products/index.html.erb
@@ -123,8 +123,6 @@
     $('#aasm_state').on("change", function(event) {
       event.preventDefault();
 
-      // $('.usa-hint.goal-parent-id').show();
-      // $('.usa-hint.goal-parent-id').fadeOut(2000);
       $.ajax({
         url: '/admin/digital_products/search',
         data: {

--- a/app/views/admin/digital_products/index.html.erb
+++ b/app/views/admin/digital_products/index.html.erb
@@ -70,7 +70,7 @@
   </div>
   <div class="grid-col-6">
     <%= label_tag "Status selector", nil, class: "usa-label" %>
-    <%= select_tag :hi, options_for_select(["All", "Published", "Archive"]), class: "usa-select" %>
+    <%= select_tag :aasm_state, options_for_select(["All", "Published", "Archive"]), class: "usa-select" %>
   </div>
 </div>
 
@@ -119,6 +119,21 @@
         }
       });
     });
+
+    $('#aasm_state').on("change", function(event) {
+      event.preventDefault();
+
+      // $('.usa-hint.goal-parent-id').show();
+      // $('.usa-hint.goal-parent-id').fadeOut(2000);
+      debugger
+      $.ajax({
+        url: '/admin/digital_products/search',
+        data: {
+          aasm_state: event.target.value
+        }
+      });
+    });
+
 
     $('#service').on("change", function(event) {
       event.preventDefault();

--- a/app/views/admin/digital_products/index.html.erb
+++ b/app/views/admin/digital_products/index.html.erb
@@ -125,7 +125,6 @@
 
       // $('.usa-hint.goal-parent-id').show();
       // $('.usa-hint.goal-parent-id').fadeOut(2000);
-      debugger
       $.ajax({
         url: '/admin/digital_products/search',
         data: {

--- a/app/views/admin/digital_service_accounts/_results.html.erb
+++ b/app/views/admin/digital_service_accounts/_results.html.erb
@@ -26,4 +26,3 @@
   </tbody>
 </table>
 
-<%= paginate digital_service_accounts %>

--- a/app/views/admin/digital_service_accounts/index.html.erb
+++ b/app/views/admin/digital_service_accounts/index.html.erb
@@ -71,7 +71,7 @@
   </div>
   <div class="grid-col-6">
     <%= label_tag "Status selector", nil, class: "usa-label" %>
-    <%= select_tag :hi, options_for_select(["All", "Published", "Archive"]), class: "usa-select" %>
+    <%= select_tag :aasm_state, options_for_select(["All", "Published", "Archive"]), class: "usa-select" %>
   </div>
 </div>
 
@@ -128,6 +128,17 @@
         url: '/admin/digital_service_accounts/search',
         data: {
           service: event.target.value
+        }
+      });
+    });
+
+    $('#aasm_state').on("change", function(event) {
+      event.preventDefault();
+
+      $.ajax({
+        url: '/admin/digital_service_accounts/search',
+        data: {
+          aasm_state: event.target.value
         }
       });
     });

--- a/app/views/admin/digital_service_accounts/index.html.erb
+++ b/app/views/admin/digital_service_accounts/index.html.erb
@@ -110,9 +110,6 @@
     $('#organization_id').on("change", function(event) {
       event.preventDefault();
 
-      // $('.usa-hint.goal-parent-id').show();
-      // $('.usa-hint.goal-parent-id').fadeOut(2000);
-      debugger
       $.ajax({
         url: '/admin/digital_service_accounts/search',
         data: {

--- a/app/views/admin/digital_service_accounts/search.js.erb
+++ b/app/views/admin/digital_service_accounts/search.js.erb
@@ -1,1 +1,1 @@
-$(".search-results").html("<%= escape_javascript render(partial: 'admin/digital_products/results', locals: { digital_products: @digital_products }) %>");
+$(".search-results").html("<%= escape_javascript render(partial: 'admin/digital_service_accounts/results', locals: { digital_service_accounts: @digital_service_accounts }) %>");

--- a/app/views/admin/forms/show.html.erb
+++ b/app/views/admin/forms/show.html.erb
@@ -296,7 +296,7 @@
 </div>
 <script type="text/javascript">
   $(function() {
-    $("#integrity-hashed-url-checkbox").on("click", function(i, b) {
+    $("#integrity-hashed-url-checkbox").on("click", function() {
       if ($(this).is(':checked')) {
         $("#integrity-hashed-url").show();
       } else {

--- a/app/views/admin/forms/show.html.erb
+++ b/app/views/admin/forms/show.html.erb
@@ -297,7 +297,6 @@
 <script type="text/javascript">
   $(function() {
     $("#integrity-hashed-url-checkbox").on("click", function(i, b) {
-      debugger
       if ($(this).is(':checked')) {
         $("#integrity-hashed-url").show();
       } else {

--- a/db/migrate/20220621210703_remove_digital_products_org.rb
+++ b/db/migrate/20220621210703_remove_digital_products_org.rb
@@ -1,0 +1,6 @@
+class RemoveDigitalProductsOrg < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :digital_products, :organization_id
+    remove_column :digital_service_accounts, :organization_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_15_113910) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_21_210703) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,7 +88,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_15_113910) do
   end
 
   create_table "digital_products", force: :cascade do |t|
-    t.integer "organization_id"
     t.integer "user_id"
     t.string "service"
     t.string "url"
@@ -107,7 +106,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_15_113910) do
   end
 
   create_table "digital_service_accounts", force: :cascade do |t|
-    t.integer "organization_id"
     t.integer "user_id"
     t.string "service"
     t.string "service_url"

--- a/spec/features/admin/digital_products_spec.rb
+++ b/spec/features/admin/digital_products_spec.rb
@@ -9,8 +9,8 @@ feature "Digital Products", js: true do
   let!(:service_provider) { FactoryBot.create(:service_provider, organization: organization ) }
   let!(:service) { FactoryBot.create(:service, organization: organization, service_provider: service_provider, service_owner_id: admin.id) }
 
-  let!(:digital_product) { FactoryBot.create(:digital_product) }
-  let!(:digital_product_2) { FactoryBot.create(:digital_product) }
+  let!(:digital_product) { FactoryBot.create(:digital_product, name: "Test1", service: "Facebook", organization_id: organization.id, aasm_state: 'published') }
+  let!(:digital_product_2) { FactoryBot.create(:digital_product, aasm_state: "created") }
 
   context "as Admin" do
     before do
@@ -28,8 +28,34 @@ feature "Digital Products", js: true do
         expect(page.current_path).to eq(admin_digital_products_path)
         expect(page).to have_css("tbody tr", count: 2)
       end
-
     end
 
+    describe "#search" do
+      before do
+        visit admin_digital_products_path
+      end
+
+      it "can search by keyword" do
+        fill_in :tags, with: digital_product.name
+        find("#tags").native.send_key :tab
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+
+      it "can search by organization" do
+
+        select(organization.name, from: 'organization_id')
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+
+      it "can search by service" do
+        select("Facebook", from: 'service')
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+
+      it "can search by aasm_state" do
+        select('Published', from: 'aasm_state')
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+    end
   end
 end

--- a/spec/features/admin/digital_products_spec.rb
+++ b/spec/features/admin/digital_products_spec.rb
@@ -9,7 +9,7 @@ feature "Digital Products", js: true do
   let!(:service_provider) { FactoryBot.create(:service_provider, organization: organization ) }
   let!(:service) { FactoryBot.create(:service, organization: organization, service_provider: service_provider, service_owner_id: admin.id) }
 
-  let!(:digital_product) { FactoryBot.create(:digital_product, name: "Test1", service: "Facebook", organization_id: organization.id, aasm_state: 'published') }
+  let!(:digital_product) { FactoryBot.create(:digital_product, name: "Test1", service: "Facebook", aasm_state: 'published') }
   let!(:digital_product_2) { FactoryBot.create(:digital_product, aasm_state: "created") }
 
   context "as Admin" do
@@ -42,7 +42,8 @@ feature "Digital Products", js: true do
       end
 
       it "can search by organization" do
-
+        digital_product.organization_list.add(organization.id)
+        digital_product.save
         select(organization.name, from: 'organization_id')
         expect(page).to have_css("tbody tr", count: 1)
       end

--- a/spec/features/admin/digital_service_accounts_spec.rb
+++ b/spec/features/admin/digital_service_accounts_spec.rb
@@ -184,6 +184,38 @@ feature "Digital Service Accounts", js: true do
         expect(page).to_not have_content(user.email.upcase)
       end
     end
+
+    describe "#search" do
+      let!(:digital_service_account) { FactoryBot.create(:digital_service_account, name: "Test1", service: "Facebook", aasm_state: 'published') }
+      let!(:digital_service_account_2) { FactoryBot.create(:digital_service_account, aasm_state: "created") }
+
+      before do
+        visit admin_digital_service_accounts_path
+      end
+
+      it "can search by keyword" do
+        fill_in :tags, with: digital_service_account.name
+        find("#tags").native.send_key :tab
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+
+      it "can search by organization" do
+        digital_service_account.organization_list.add(organization.id)
+        digital_service_account.save
+        select(organization.name, from: 'organization_id')
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+
+      it "can search by service" do
+        select("Facebook", from: 'service')
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+
+      it "can search by aasm_state" do
+        select('Published', from: 'aasm_state')
+        expect(page).to have_css("tbody tr", count: 1)
+      end
+    end
   end
 
   context "as Contact" do


### PR DESCRIPTION
https://trello.com/c/9DGvJmra/1450-ensuring-the-search-filters-work-on-digital-service-accounts

- Fixed org, service, keyword searches
- Added aasm filter
- Added specs

@ryanwoldatwork  What do you think about adding search by sponsoring agencies here?   Or is that more for reporting?