### PR TITLE
TP-1463 Add email notification on form published / archived

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class EventsController < AdminController
     before_action :ensure_admin
-    
+
     def index
       @events = Event.limit(500).order('created_at DESC').page params[:page]
     end

--- a/app/controllers/admin/forms_controller.rb
+++ b/app/controllers/admin/forms_controller.rb
@@ -79,6 +79,7 @@ module Admin
       Event.log_event(Event.names[:form_published], 'Form', @form.uuid, "Form #{@form.name} published at #{DateTime.now}", current_user.id)
 
       @form.publish!
+      UserMailer.form_status_changed(form: @form, action: 'published').deliver_later
       redirect_to admin_form_path(@form), notice: 'Published'
     end
 
@@ -86,6 +87,7 @@ module Admin
       Event.log_event(Event.names[:form_archived], 'Form', @form.uuid, "Form #{@form.name} archived at #{DateTime.now}", current_user.id)
 
       @form.archive!
+      UserMailer.form_status_changed(form: @form, action: 'archived').deliver_later
       redirect_to admin_form_path(@form), notice: 'Archived'
     end
 

--- a/app/controllers/admin/site_controller.rb
+++ b/app/controllers/admin/site_controller.rb
@@ -26,7 +26,7 @@ module Admin
 
       form_ids = todays_submissions.collect(&:form_id).uniq
       @recent_forms = Form.find(form_ids)
-    end  
+    end
 
     def a11; end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -24,6 +24,14 @@ class UserMailer < ApplicationMailer
          to: emails
   end
 
+  def form_status_changed(form:, action:)
+    set_logo
+    @form = form
+    @action = action
+    mail subject: "Touchpoints form #{@form.name} #{@action}",
+         to: ENV.fetch('TOUCHPOINTS_ADMIN_EMAILS').split(',')
+  end
+
   def social_media_account_created_notification(digital_service_account:, link:)
     set_logo
     @digital_service_account = digital_service_account

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -60,6 +60,7 @@ class Goal < ApplicationRecord
   # default a new goals position to the max position + 1 for the organization
   def set_position
     return if position.present?
+
     self.position = Goal.where(organization:).maximum(:position) + 1
   end
 end

--- a/app/views/user_mailer/form_status_changed.html.erb
+++ b/app/views/user_mailer/form_status_changed.html.erb
@@ -1,0 +1,11 @@
+<%= render 'user_mailer/components/header' %>
+<h3>
+  Form status changed.
+</h3>
+<p>
+  Form <%= link_to @form.name, admin_form_url(@form) %>
+  status changed to <%= @action %>.
+</p>
+<p>
+  Visit <%= link_to admin_form_url(@form), admin_form_url(@form) %> to view.
+</p>

--- a/app/views/user_mailer/form_status_changed.text.erb
+++ b/app/views/user_mailer/form_status_changed.text.erb
@@ -1,0 +1,5 @@
+Form status changed.
+
+Form <%= @form.name %> status changed to <%= @action %>.
+
+Visit <%= admin_form_url(@form) %> to view.

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -109,7 +109,6 @@ FactoryBot.define do
       name { 'Open-ended Test form' }
       kind { 'custom' }
       after(:create) do |f, _evaluator|
-
         FactoryBot.create(:question,
                           form: f,
                           answer_field: :answer_01,

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -327,8 +327,8 @@ feature 'Touchpoints', js: true do
         end
 
         it 'does not display character count messaging' do
-          expect(page).to_not have_content("characters")
-          expect(page).to_not have_content("allowed")
+          expect(page).to_not have_content('characters')
+          expect(page).to_not have_content('allowed')
         end
       end
 
@@ -347,7 +347,7 @@ feature 'Touchpoints', js: true do
           expect(page).to have_content('5 characters left')
         end
       end
-    end # context
+    end
 
     describe '/touchpoints?location_code=' do
       before do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -46,6 +46,28 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
+  describe 'form_status_changed' do
+    let!(:organization) { FactoryBot.create(:organization) }
+    let(:user) { FactoryBot.create(:user, organization:) }
+    let(:form) { FactoryBot.create(:form, organization:, user:) }
+    let(:mail) { UserMailer.form_status_changed(form:, action: 'published') }
+
+    before do
+      ENV['ENABLE_EMAIL_NOTIFICATIONS'] = 'true'
+    end
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq("Touchpoints form #{form.name} published")
+      expect(mail.to).to eq(ENV.fetch('TOUCHPOINTS_ADMIN_EMAILS').split(','))
+      expect(mail.from).to eq([ENV.fetch('TOUCHPOINTS_EMAIL_SENDER')])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('Form status changed')
+      expect(mail.body.encoded).to match('status changed to published')
+    end
+  end
+
   describe 'account_deactivation_scheduled_notification' do
     let!(:organization) { FactoryBot.create(:organization) }
     let(:user) { FactoryBot.create(:user, organization:) }


### PR DESCRIPTION
https://trello.com/c/pC9QFaW0/1463-touchpoint-admins-receive-an-email-when-a-form-is-published-and-archived

