### PR TITLE
forms task bar

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -1,7 +1,7 @@
 .code {
   font-family: monospace;
-  padding: 3px;
   border-radius: 3px;
+  overflow-wrap: break-word;
 }
 footer {
   margin-top: 16px;

--- a/app/controllers/admin/digital_service_accounts_controller.rb
+++ b/app/controllers/admin/digital_service_accounts_controller.rb
@@ -143,7 +143,7 @@ module Admin
           title: 'Digital Service Account was published',
           body: "Digital Service Account #{@digital_service_account.name} published at #{DateTime.now} by #{current_user.email}",
           path: admin_digital_service_account_url(@digital_service_account),
-          emails: (User.admins.collect(&:email) + User.registry_managers.collect(&:email) + @digital_service_account.roles.first.users.collect(&:email)).uniq
+          emails: (User.admins.collect(&:email) + User.registry_managers.collect(&:email) + @digital_service_account.roles.first.users.collect(&:email)).uniq,
         ).deliver_later
 
         redirect_to admin_digital_service_account_path(@digital_service_account), notice: "Digital Service Account #{@digital_service_account.name} was published."

--- a/app/controllers/admin/performance_controller.rb
+++ b/app/controllers/admin/performance_controller.rb
@@ -19,13 +19,13 @@ module Admin
     def quarterly_performance_notification
       year = params[:year]
       quarter = params[:quarter]
-      
-      Collection.where(aasm_state: 'draft', year: year, quarter: quarter).each do |collection|
+
+      Collection.where(aasm_state: 'draft', year:, quarter:).each do |collection|
         UserMailer.quarterly_performance_notification(collection_id: collection.id).deliver_later
       end
 
       redirect_to admin_performance_path,
-        notice: 'Quarterly performance email notication sent successfully.'
+                  notice: 'Quarterly performance email notication sent successfully.'
     end
 
     private

--- a/app/controllers/admin/reporting_controller.rb
+++ b/app/controllers/admin/reporting_controller.rb
@@ -2,8 +2,7 @@
 
 module Admin
   class ReportingController < AdminController
-    def index
-    end
+    def index; end
 
     def hisps
       row = []

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,6 +4,9 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   def self.tag_counts_by_name
-    ActsAsTaggableOn::Tag.joins(:taggings).select('tags.id, tags.name, COUNT(taggings.id) as taggings_count').group('tags.id, tags.name').where('taggings.taggable_type = ? and taggings.context = ? ', name, 'tags')
+    ActsAsTaggableOn::Tag.joins(:taggings)
+      .select('tags.id, tags.name, COUNT(taggings.id) as taggings_count')
+      .group('tags.id, tags.name')
+      .where('taggings.taggable_type = ? and taggings.context = ? ', name, 'tags')
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -9,8 +9,8 @@ class Form < ApplicationRecord
   belongs_to :organization
   belongs_to :service, optional: true
 
-  has_many :form_sections, dependent: :delete_all
-  has_many :questions, dependent: :destroy
+  has_many :form_sections, dependent: :destroy
+  has_many :questions, dependent: :destroy, counter_cache: :questions_count
   has_many :submissions
 
   has_many :user_roles, dependent: :destroy
@@ -30,6 +30,8 @@ class Form < ApplicationRecord
 
   scope :non_templates, -> { where(template: false) }
   scope :templates, -> { where(template: true) }
+
+  scope :non_archived, -> { where("aasm_state != 'archived'") }
 
   mount_uploader :logo, LogoUploader
 
@@ -138,6 +140,7 @@ class Form < ApplicationRecord
     new_form.title = new_form.name
     new_form.survey_form_activations = 0
     new_form.response_count = 0
+    new_form.questions_count = 0
     new_form.last_response_created_at = nil
     new_form.aasm_state = :in_development
     new_form.uuid = nil
@@ -404,6 +407,10 @@ class Form < ApplicationRecord
                     ip_address: 'IP Address',
                   })
     end
+
+    hash.merge!({
+                  tag_list: 'Tags',
+                })
 
     hash
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Question < ApplicationRecord
-  belongs_to :form, optional: false, counter_cache: true
-  belongs_to :form_section, optional: false
+  belongs_to :form, counter_cache: true
+  belongs_to :form_section
   has_many :question_options, dependent: :destroy
 
   validates :question_type, presence: true
@@ -38,7 +38,7 @@ class Question < ApplicationRecord
   validates :character_limit, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: MAX_CHARACTERS, allow_nil: true }
 
   after_commit do |question|
-    FormCache.invalidate(question.form.short_uuid)
+    FormCache.invalidate(question.form.short_uuid) if question.persisted?
   end
 
   def max_length

--- a/app/views/admin/collections/index.html.erb
+++ b/app/views/admin/collections/index.html.erb
@@ -46,7 +46,12 @@
   <div class="grid-row">
     <div class="grid-col-12">
       <div class="ui-filter">
-        Filter by fiscal year and quarter, or view <%= link_to "All Collections", admin_collections_path %>
+        Filter by fiscal year and quarter
+        <% if params[:year] || params[:quarter] %>
+          <small>
+            <%= link_to "View All Collections", admin_collections_path %>
+          </small>
+        <% end %>
 
         <div class="year" data-id="2022">
           <h4>
@@ -82,6 +87,7 @@
       <th data-sortable scope="col" role="columnheader">Organization</th>
       <th data-sortable scope="col" role="columnheader">Service Provider (HISP)</th>
       <th data-sortable scope="col" role="columnheader">Collection name</th>
+      <th data-sortable scope="col" role="columnheader">Detail report count</th>
       <th data-sortable scope="col" role="columnheader">Year</th>
       <th data-sortable scope="col" role="columnheader">Quarter</th>
       <th data-sortable scope="col" role="columnheader">Status</th>
@@ -95,6 +101,7 @@
         <td><%= collection.organization.name %></td>
         <td><%= collection.service_provider ? collection.service_provider.name : "SPECIFY THIS COLLECTION'S SERVICE PROVIDER" %></td>
         <td><%= link_to collection.name, admin_collection_path(collection) %></td>
+        <td><%= collection.omb_cx_reporting_collections.size %></td>
         <td><%= collection.year %></td>
         <td><%= collection.quarter %></td>
         <td>

--- a/app/views/admin/forms/_logo_display.html.erb
+++ b/app/views/admin/forms/_logo_display.html.erb
@@ -27,14 +27,14 @@
           <legend class="usa-sr-only">Display Organization Tag Logo</legend>
           <div class="usa-checkbox">
             <%= f.check_box :display_header_logo, class: "usa-checkbox__input" %>
-            <%= f.label :display_header_logo, "Display (320px wide by 80px tall) Organization logo before the title in the Form header?", class: "usa-checkbox__label" %>
+            <%= f.label :display_header_logo, "Display small banner (320px wide by 80px tall) logo?", class: "usa-checkbox__label" %>
           </div>
         </fieldset>
         <fieldset class="usa-fieldset">
           <legend class="usa-sr-only">Display Organization Tag Logo</legend>
           <div class="usa-checkbox">
             <%= f.check_box :display_header_square_logo, class: "usa-checkbox__input" %>
-            <%= f.label :display_header_square_logo, "Display Square (80px wide by 80px tall) Organization logo before the title in the Form header?", class: "usa-checkbox__label" %>
+            <%= f.label :display_header_square_logo, "Display square (80px wide by 80px tall) logo?", class: "usa-checkbox__label" %>
           </div>
         </fieldset>
       </div>

--- a/app/views/admin/forms/_nav.html.erb
+++ b/app/views/admin/forms/_nav.html.erb
@@ -1,7 +1,7 @@
 <ul class="usa-button-group usa-button-group--segmented">
   <li class="usa-button-group__item">
     <%= link_to admin_form_path(form), class: "usa-button #{current_path == admin_form_path(form) ? nil : 'usa-button--outline'}" do %>
-      Survey overview
+      Overview
     <% end %>
   </li>
   <li class="usa-button-group__item">
@@ -10,8 +10,8 @@
     <% end %>
   </li>
   <li class="usa-button-group__item">
-    <%= link_to delivery_method_admin_form_path(form), class: "usa-button #{current_path == delivery_method_admin_form_path(form) ? nil : 'usa-button--outline'}" do %>
-      Delivery method
+    <%= link_to delivery_admin_form_path(form), class: "usa-button #{current_path == delivery_admin_form_path(form) ? nil : 'usa-button--outline'}" do %>
+      Delivery
     <% end %>
   </li>
   <li class="usa-button-group__item">

--- a/app/views/admin/forms/_preview.html.erb
+++ b/app/views/admin/forms/_preview.html.erb
@@ -1,6 +1,0 @@
-<p>
-  <%= link_to example_admin_form_path(form), class: "usa-button usa-button--outline width-full", target: "_blank", rel: "noopener" do %>
-    <i class="fa fa-eye"></i>
-    Preview this survey
-  <% end %>
-</p>

--- a/app/views/admin/forms/_task_bar.html.erb
+++ b/app/views/admin/forms/_task_bar.html.erb
@@ -1,0 +1,168 @@
+<%= render 'admin/forms/step_indicator', form: form %>
+
+<div class="well">
+  <% if form.deployable_form? %>
+  <strong>
+   Touchpoints-hosted URL
+  </strong>
+  <br>
+  <p>
+    Every form gets a touchpoints-hosted URL.
+    <br>
+    This form can be publicly accessed from the following URL.
+    You can choose to share this URL with users, or not.
+  </p>
+
+  <p>
+    <%= link_to submit_touchpoint_uuid_url(form), submit_touchpoint_uuid_url(form), target: "_blank" %>
+  </p>
+
+  <% if form.delivery_method == "touchpoints-hosted-only" %>
+  <p>
+    A form can also be embedded into a website using
+    <%= link_to "Delivery Options", delivery_admin_form_path(form) %>.
+  </p>
+  <% end %>
+
+    <% if form.delivery_method == "modal" || form.delivery_method == "inline" || form.delivery_method == "custom-button-modal" %>
+      <strong>
+        Delivery options
+      </strong>
+      <br>
+
+      <% if form.deployable_form? %>
+        <% if form.delivery_method == "inline" || "custom-button-modal" %>
+        <p>
+          Add the following markup to your site
+          as a place to display the Touchpoint
+          <i><%= form.delivery_method %></i>.
+        </p>
+        <span class="code minh-10 bg-base-lighter padding-1">
+          <%= h("<div id=\"#{form.element_selector}\"></div>") %>
+        </span>
+        <% end %>
+      <p>
+        Add the following script to your site to embed your form.
+      </p>
+      <div>
+        <div class="code minh-10 bg-base-lighter padding-1">
+          <%= h("<script src=\"#{touchpoint_url(form.short_uuid, format: :js)}\" async></script>") %>
+        </div>
+      </div>
+      <br>
+      <div class="usa-checkbox">
+        <input class="usa-checkbox__input" type="checkbox" value="1" name="form[integrity-hashed-url]" id="integrity-hashed-url-checkbox">
+        <label class="usa-checkbox__label" for="integrity-hashed-url-checkbox">with integrity hash</label>
+      </div>
+      <div id="integrity-hashed-url" hidden class="margin-top-2">
+        <div class="usa-alert usa-alert--warning">
+          <div class="usa-alert__body">
+            <p class="usa-alert__text font-sans-3xs">
+              This alternative version of embed script includes an integrity attribute.
+              Using this version offers more security.
+              Changing any aspect of the Form's display will change this checksum,
+              and if deployed, could become invalid.
+            </p>
+          </div>
+        </div>
+        <br>
+        <div class="code minh-10 bg-base-lighter padding-1">
+          <%= h("<script src=\"#{touchpoint_url(form.short_uuid, format: :js)}\" integrity=\"sha256-#{form_integrity_checksum(form: form)}\" async></script>") %>
+        </div>
+      </div>
+      <% end %>
+
+      <% if form.delivery_method == "modal" || form.delivery_method == "custom-button-modal" || form.delivery_method == "inline" %>
+      <p>
+        <%= link_to example_admin_form_path(form), class: "usa-button bg-base width-full", target: "_blank", rel: "noopener" do %>
+          <i class="fa fa-eye"></i>
+          Preview
+          <br>
+          <small>
+            (<%= form.delivery_method %>)
+          </small>
+        <% end %>
+      </p>
+      <p>
+        <%= link_to copy_admin_form_path(form), class: "usa-button usa-button--outline width-full", method: :post, data: { confirm: 'Are you sure?' } do %>
+          <i class="fa fa-copy"></i>
+          Copy
+        <% end %>
+      </p>
+      <% end %>
+
+    <% end %>
+  <% else %>
+    <div class="usa-alert usa-alert--error">
+      <div class="usa-alert__body">
+        <p class="usa-alert__text">
+          Form is not published
+        </p>
+      </div>
+    </div>
+
+    <p>
+      <%= link_to example_admin_form_path(form), class: "usa-button bg-base width-full", target: "_blank", rel: "noopener" do %>
+        <i class="fa fa-eye"></i>
+        Preview
+        <small>
+          <%= form.delivery_method %>
+        </small>
+      <% end %>
+    </p>
+
+    <p>
+      <%= link_to publish_admin_form_path(form), method: :post, data: { confirm: 'Are you sure?' }, class: "usa-button width-full" do %>
+      <i class="far fa-check-circle"></i>
+      Publish
+      <% end %>
+    </p>
+
+    <p>
+      <%= link_to copy_admin_form_path(form), class: "usa-button usa-button--outline width-full", method: :post, data: { confirm: 'Are you sure?' } do %>
+        <i class="fa fa-copy"></i>
+        Copy
+      <% end %>
+    </p>
+
+  <% end %>
+
+  <% unless form.archived? %>
+    <p>
+      <%= link_to archive_admin_form_path(form), class: "usa-button usa-button--accent-cool width-full", method: :post, data: { confirm: 'Are you sure?' } do %>
+        <span class="fa fa-archive"></span>
+        Archive
+      <% end %>
+    </p>
+  <% end %>
+
+  <% unless form.in_development? %>
+    <p>
+      <%= link_to reset_admin_form_path(form), class: "usa-button usa-button--secondary width-full", method: :post, data: { confirm: 'Are you sure?' } do %>
+        <span class="fa fa-backward"></span>
+        Reset form
+      <% end %>
+    </p>
+  <% end %>
+
+  <% if form.archived? || !form.deployable_form? %>
+    <% if form.persisted? %>
+      <%= link_to admin_form_path(form), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary width-full" do %>
+        <i class="fas fa-trash"></i>
+        Delete
+      <% end %>
+    <% end %>
+  <% end %>
+</div>
+
+<script>
+  $(function() {
+    $("#integrity-hashed-url-checkbox").on("click", function() {
+      if ($(this).is(':checked')) {
+        $("#integrity-hashed-url").show();
+      } else {
+        $("#integrity-hashed-url").hide();
+      }
+    })
+  })
+</script>

--- a/app/views/admin/forms/delivery.html.erb
+++ b/app/views/admin/forms/delivery.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation_title do %>
-  Editing Delivery Method for: <%= @form.name %>
+  Editing Delivery method for: <%= @form.name %>
 <% end %>
 <p>
   <%= link_to admin_forms_path do %>
@@ -26,8 +26,9 @@
       <% end %>
     </div>
   <% end %>
-  <div class="grid-row">
-    <div class="grid-col">
+
+  <div class="grid-row grid-gap-lg">
+    <div class="desktop:grid-col-8">
       <div>
         <div class="usa-alert usa-alert--info">
           <div class="usa-alert__body">
@@ -92,46 +93,33 @@
         <p>
           <%= f.submit (@form.persisted? ? "Update Survey" : "Create Survey"), class: "usa-button" %>
         </p>
-        </div>
-        <div class="grid-row">
-          <div class="grid-col">
-            <div class="well">
-              <div class="usa-alert usa-alert--info">
-                  <div class="usa-alert__body">
-                    <p class="usa-alert__text">
-                      After the delivery method has been saved you can preview this survey.
-                    </p>
-                  </div>
-              </div>
-              <br>
-              <%= link_to example_admin_form_path(@form), class: "usa-button usa-button--outline full-width", target: "_blank", rel: "noopener" do %>
-                <i class="fa fa-eye"></i>
-                Preview
-              <% end %>
-            </div>
-          </div>
+      </div>
     </div>
-</div>
+    <div class="desktop:grid-col-4">
+      <%= render 'admin/forms/task_bar', form: @form %>
+    </div>
+
+  </div>
 <% end %>
 
 <script>
   $(function() {
-    $("#form_delivery_method_touchpoints-hosted-only").click(function() {
+    $("#form_delivery_method_touchpoints-hosted-only").on("click", function() {
       $('#delivery-method-text').hide();
       $('#delivery-method-html-id').hide();
       $('#allowlist-options').hide();
     });
-    $("#form_delivery_method_modal").click(function() {
+    $("#form_delivery_method_modal").on("click", function() {
       $('#delivery-method-text').show();
       $('#delivery-method-html-id').hide();
       $('#allowlist-options').show();
     });
-    $("#form_delivery_method_custom-button-modal").click(function() {
+    $("#form_delivery_method_custom-button-modal").on("click", function() {
       $('#delivery-method-text').hide();
       $('#delivery-method-html-id').show();
       $('#allowlist-options').show();
     });
-    $("#form_delivery_method_inline").click(function() {
+    $("#form_delivery_method_inline").on("click", function() {
       $('#delivery-method-text').hide();
       $('#delivery-method-html-id').show();
       $('#allowlist-options').show();

--- a/app/views/admin/forms/example.html.erb
+++ b/app/views/admin/forms/example.html.erb
@@ -41,9 +41,11 @@
     <br>
     <div class="grid-container">
       <div class="grid-col-12">
-        <a id="<%= @form.element_selector %>">
-          Custom button
-        </a>
+        <div style="padding-left: 5rem; padding-top: 5rem;">
+          <a id="<%= @form.element_selector %>" style="color: DeepPink; font-family: sans-serif; font-size: 2rem; border: 7px solid DeepPink; border-radius: 1rem; padding: 1rem; background-color: LightPink;">
+            This is a custom button
+          </a>
+        </div>
       </div>
     </div>
     <br>

--- a/app/views/admin/forms/index.html.erb
+++ b/app/views/admin/forms/index.html.erb
@@ -7,6 +7,22 @@
 <% end %>
 
 <% if @forms.present? %>
+  <p class="font-sans-3xs">
+  <% if !params[:all] %>
+    <%= link_to all_admin_forms_path do %>
+      Also show archived forms
+    <% end %>
+  <% end %>
+
+  <% if params[:all] %>
+    <%= link_to admin_forms_path do %>
+      Show active forms only
+    <% end %>
+  <% end %>
+  </p>
+<% end %>
+
+<% if @forms.present? %>
 <table class="usa-table">
   <thead class="font-sans-3xs">
     <tr>
@@ -44,7 +60,7 @@
         <%= link_to form.name, admin_form_path(form) %>
       </td>
       <td>
-        <%= form.questions.size %>
+        <%= form.questions_count %>
       </td>
       <td>
         <%= form.survey_form_activations %>

--- a/app/views/admin/forms/questions.html.erb
+++ b/app/views/admin/forms/questions.html.erb
@@ -9,15 +9,15 @@
 </p>
 <%= render 'admin/forms/nav', form: @form %>
 <br>
-<div class="grid-row">
-  <div class="grid-col">
+<div class="grid-row grid-gap-lg">
+  <div class="desktop:grid-col-8">
     <% if @form.questions.size > 12 %>
     <div class="usa-alert usa-alert--warning">
       <div class="usa-alert__body">
         <p class="usa-alert__text">
           Touchpoints supports a maximum of 20 questions.
           There are currently
-          <%= @form.questions.size %> questions.
+          <%= @form.questions_count %> questions.
           <br>
           Fewer questions tend to get better engagement.
         </p>
@@ -31,7 +31,8 @@
       </div>
       <%= render partial: 'components/forms/footer_banner', locals: { form: @form } %>
     </div>
-
-    <%= render "admin/forms/preview", { form: @form } %>
+  </div>
+  <div class="desktop:grid-col-4 ">
+    <%= render 'admin/forms/task_bar', form: @form %>
   </div>
 </div>

--- a/app/views/admin/forms/show.html.erb
+++ b/app/views/admin/forms/show.html.erb
@@ -26,9 +26,8 @@
 <% end %>
 
 <% if is_at_least_form_manager?(user: current_user, form: @form) %>
-<div class="grid-row grid-gap-md">
-  <div class="tablet:grid-col-6">
-    <%= render 'admin/forms/step_indicator', form: @form %>
+<div class="grid-row grid-gap-lg">
+  <div class="desktop:grid-col-8">
     <p>
       <strong class="font-sans-3xl">
         <%= @form.response_count %> responses
@@ -46,177 +45,8 @@
       <% end %>
     <p>
   </div>
-  <div class="tablet:grid-col-6 bg-gray-5">
-    <div class="padding-1">
-      <% if !@form.deployable_form? %>
-        <h2>
-          <i class="far fa-check-circle"></i>
-          Publish your form
-        </h2>
-      <% end %>
-
-      <% if @form.deployable_form? %>
-        <strong>
-         Touchpoints-hosted URL
-        </strong>
-        <br>
-        <p>
-          This form can be publicly accessed from the following URL.
-        </p>
-        <p>
-          <%= link_to submit_touchpoint_uuid_url(@form), submit_touchpoint_uuid_url(@form), target: "_blank" %>
-        </p>
-        <% if @form.delivery_method == "modal" || @form.delivery_method == "inline" || @form.delivery_method == "custom-button-modal" %>
-          <strong>
-            Javascript embed code
-          </strong>
-          <br>
-          <p>
-            <% if @form.deployable_form? %>
-              <% if @form.delivery_method == "custom-button-modal" %>
-              <p>
-                Add the following markup to your site
-                as a place to display the Touchpoint
-                <i>inline</i>.
-              </p>
-
-              <p>
-                <span class="code">
-                  <%= h("<a id=\"#{@form.element_selector}\"></a>") %>
-                </span>
-              </p>
-              <% end %>
-              <% if @form.delivery_method == "inline" %>
-              <p>
-                Add the following markup to your site
-                as a place to display the Touchpoint
-                <i>inline</i>.
-              </p>
-              <p>
-                <span class="code">
-                  <%= h("<div id=\"#{@form.element_selector}\"></div>") %>
-                </span>
-              </p>
-              <% end %>
-            <p>
-              Add the following script to your site to embed your form.
-            </p>
-            <div>
-              <div class="code minh-10 bg-base-lighter">
-                <%= h("<script src=\"#{touchpoint_url(@form.short_uuid, format: :js)}\" async></script>") %>
-              </div>
-            </div>
-            <br>
-            <div class="usa-checkbox">
-              <input class="usa-checkbox__input" type="checkbox" value="1" name="form[integrity-hashed-url]" id="integrity-hashed-url-checkbox">
-              <label class="usa-checkbox__label" for="integrity-hashed-url-checkbox">with integrity hash</label>
-            </div>
-            <div id="integrity-hashed-url" hidden>
-              <div class="usa-alert usa-alert--warning">
-                <div class="usa-alert__body">
-                  <p class="usa-alert__text">
-                    This alternative version of embed script includes an integrity attribute.
-                    Using this version offers more security.
-                    Changing any aspect of the Form's display will change this checksum,
-                    and if deployed, could become invalid.
-                  </p>
-                </div>
-              </div>
-              <br>
-              <div class="code minh-10 bg-base-lighter">
-                <%= h("<script src=\"#{touchpoint_url(@form.short_uuid, format: :js)}\" integrity=\"sha256-#{form_integrity_checksum(form: @form)}\" async></script>") %>
-              </div>
-            </div>
-            <% end %>
-            <% if @form.delivery_method == "inline" %>
-            <h4>
-              Preview an example:
-            </h4>
-            <p>
-              <%= link_to 'Inline', example_admin_form_path(@form), class: "usa-button", target: "_blank", rel: "noopener" %>
-            </p>
-            <% end %>
-            <% if @form.delivery_method == "custom-button-modal" %>
-            <h4>
-              Preview an example:
-            </h4>
-            <p>
-              <%= link_to 'Custom button modal', example_admin_form_path(@form), class: "usa-button", target: "_blank", rel: "noopener" %>
-            </p>
-            <% end %>
-            <% if @form.delivery_method == "modal" %>
-            <h4>
-              Preview your form:
-            </h4>
-            <p>
-              Delivery method: <%= @form.delivery_method %>
-            </p>
-            <p>
-              <%= link_to example_admin_form_path(@form), class: "usa-button usa-button--outline width-full", target: "_blank", rel: "noopener" do %>
-                <i class="fa fa-eye"></i>
-                Preview
-              <% end %>
-            </p>
-            <p>
-              <%= link_to copy_admin_form_path(@form), class: "usa-button usa-button--outline width-full", method: :post, data: { confirm: 'Are you sure?' } do %>
-                <i class="fa fa-copy"></i>
-                Copy
-              <% end %>
-            </p>
-            <% end %>
-          </p>
-        <% end %>
-      <% else %>
-        <div class="usa-alert usa-alert--error">
-          <div class="usa-alert__body">
-            <h3 class="usa-alert__heading">Survey is not published</h3>
-            <p>
-              <%= link_to example_admin_form_path(@form), class: "usa-button usa-button--outline", target: "_blank", rel: "noopener" do %>
-                <i class="fa fa-eye"></i>
-                Preview
-              <% end %>
-              <%= link_to copy_admin_form_path(@form), class: "usa-button usa-button--outline", method: :post, data: { confirm: 'Are you sure?' } do %>
-                <i class="fa fa-copy"></i>
-                Copy
-              <% end %>
-            </p>
-            <p class="usa-alert__text">
-              Publish to make it "live."
-            </p>
-          </div>
-        </div>
-        <p>
-          <%= link_to publish_admin_form_path(@form), method: :post, data: { confirm: 'Are you sure?' }, class: "usa-button width-full" do %>
-            <i class="far fa-check-circle"></i>
-            Publish
-          <% end %>
-        </p>
-      <% end %>
-
-    <% unless @form.archived? %>
-      <p>
-        <%= link_to archive_admin_form_path(@form), class: "usa-button usa-button--accent-cool width-full", method: :post, data: { confirm: 'Are you sure?' } do %>
-          <span class="fa fa-archive"></span>
-          Archive this form
-        <% end %>
-      </p>
-    <% end %>
-    <% unless @form.in_development? %>
-      <p>
-        <%= link_to reset_admin_form_path(@form), class: "usa-button usa-button--base width-full", method: :post, data: { confirm: 'Are you sure?' } do %>
-          Reset form
-        <% end %>
-      </p>
-    <% end %>
-    <% if @form.archived? || !@form.deployable_form? %>
-      <% if @form.persisted? %>
-        <%= link_to admin_form_path(@form), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary width-full" do %>
-          <i class="fas fa-trash"></i>
-          Delete Survey
-        <% end %>
-      <% end %>
-    <% end %>
-    </div>
+  <div class="desktop:grid-col-4 ">
+    <%= render 'admin/forms/task_bar', form: @form %>
   </div>
 </div>
 <br>
@@ -306,14 +136,3 @@
 <div class="form-manager-options">
   <%= render 'admin/forms/form_manager_options', form: @form %>
 </div>
-<script type="text/javascript">
-  $(function() {
-    $("#integrity-hashed-url-checkbox").on("click", function() {
-      if ($(this).is(':checked')) {
-        $("#integrity-hashed-url").show();
-      } else {
-        $("#integrity-hashed-url").hide();
-      }
-    })
-  })
-</script>

--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -136,7 +136,7 @@
       <%= link_to archive_admin_service_path(@service), class: "usa-button full-width", method: :post do %>
         <i class="fa fa-archive"></i>
         &nbsp;
-        Archive this form
+        Archive
       <% end %>
     </div>
     <% end %>

--- a/app/views/admin/websites/_tags.html.erb
+++ b/app/views/admin/websites/_tags.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: website, url: admin_website_path(website), local: true) do |f| %>
   <div class="grid-row">
-    <div class="grid-col-6">
+    <div class="grid-col-12">
       <label class="usa-label" for="tags">
         Tags
       </label>

--- a/app/views/components/_roles_and_permissions.html.erb
+++ b/app/views/components/_roles_and_permissions.html.erb
@@ -135,7 +135,7 @@
         <div class="grid-row grid-gap-md">
           <div class="tablet:grid-col-12">
             <p>
-              Don't see a user to add in a dropdown?
+              Don't see a user in the dropdown?
             </p>
 
             <div class="field">
@@ -146,10 +146,22 @@
         </div>
         <div class="field">
           <br>
-          <%= f.submit "Invite User", class: "usa-button" %>
+          <%= f.submit "Invite User", class: "usa-button", id: "invite-button", disabled: true %>
           <br>
         </div>
       <% end %>
     </div>
   </div>
 </div>
+
+<script>
+  $(function(){
+    $("#user_refer_user").on("keyup", function(event) {
+      if(event.target.value != '' && event.target.value.length > 5) {
+        $("#invite-button").attr('disabled', false);
+      } else {
+        $("#invite-button").attr('disabled', true);
+      }
+    });
+  });
+</script>

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -1,7 +1,9 @@
 <% @instruction_text_limit = 1500 %>
 <% @disclaimer_text_limit = 500 %>
 <% @tabindex = 0 %>
-<%= render 'admin/forms/logo_display', { form: form } %>
+<div class="well">
+  <%= render 'admin/forms/logo_display', { form: form } %>
+</div>
 <br>
 <div class="form-title-edit">
   <div class="text-uppercase font-body-3xs">
@@ -35,7 +37,7 @@
 <br>
 <div class="sorting-div">
   <% multi_section_question_number = 0 %>
-  <% form.form_sections.each_with_index do |section, i| %>
+  <% form.form_sections.includes(:questions).each_with_index do |section, i| %>
     <%= render 'admin/form_sections/view', { form: form, section: section, multi_section_question_number: multi_section_question_number, form_section_page: i + 1, tabindex: @tabindex } %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -255,7 +255,7 @@ Rails.application.routes.draw do
         get 'compliance', to: 'forms#compliance', as: :compliance
         get 'questions', to: 'forms#questions', as: :questions
         get 'responses', to: 'forms#responses', as: :responses
-        get 'delivery_method', to: 'forms#delivery_method', as: :delivery_method
+        get 'delivery', to: 'forms#delivery', as: :delivery
         post 'add_user', to: 'forms#add_user', as: :add_user
         post 'copy', to: 'forms#copy', as: :copy
         post 'publish', to: 'forms#publish', as: :publish
@@ -273,6 +273,7 @@ Rails.application.routes.draw do
         get 'events', to: 'forms#events', as: :events
       end
       collection do
+        get 'all', to: 'forms#index', as: :all, all: true
         post 'copy', to: 'forms#copy', as: :copy_id
       end
       resources :form_sections, except: %i[index show edit] do

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -113,7 +113,7 @@ feature 'Forms', js: true do
         end
 
         it 'redirect to /form/:uuid/questions with a success flash message' do
-          expect(find('.usa-alert.usa-alert--info')).to have_content('Survey was successfully created.')
+          expect(find('.usa-alert.usa-alert--info')).to have_content('Form was successfully created.')
           @form = Form.last
           expect(page).to have_content('Editing Questions for')
           expect(page).to have_content(@form.name)
@@ -131,7 +131,7 @@ feature 'Forms', js: true do
         end
 
         it 'redirect to /form/:uuid/questions with a success flash message' do
-          expect(find('.usa-alert.usa-alert--info')).to have_content('Survey was successfully created.')
+          expect(find('.usa-alert.usa-alert--info')).to have_content('Form was successfully created.')
           @form = Form.last
           expect(page.current_path).to eq(questions_admin_form_path(@form))
         end
@@ -140,12 +140,12 @@ feature 'Forms', js: true do
           within('.usa-file-input') do
             attach_file('form_logo', 'spec/fixtures/touchpoints-logo.png')
           end
-          find('label', text: 'Display Square (80px wide by 80px tall) Organization logo before the title in the Form header?').click
+          find('label', text: 'Display square (80px wide by 80px tall) logo?').click
           click_on 'Update logo'
-          click_on 'Delivery method'
+          click_on 'Delivery'
           find('label', text: 'Hosted only on the touchpoints site').click
           click_on 'Update Survey'
-          expect(page).to have_content('Survey was successfully updated.')
+          expect(page).to have_content('Form was successfully updated.')
           visit example_admin_form_path(Form.last)
           expect(page).to have_css('.form-header-logo-square')
         end
@@ -163,13 +163,13 @@ feature 'Forms', js: true do
           within('.usa-file-input') do
             attach_file('form_logo', 'spec/fixtures/touchpoints-logo.png')
           end
-          find('label', text: 'Display Square (80px wide by 80px tall) Organization logo before the title in the Form header?').click
+          find('label', text: 'Display square (80px wide by 80px tall) logo?').click
           click_on 'Update logo'
-          click_on 'Delivery method'
+          click_on 'Delivery'
           find('label', text: 'Embedded inline on your site').click
           fill_in('form_element_selector', with: 'test_selector')
           click_on 'Update Survey'
-          expect(page).to have_content('Survey was successfully updated.')
+          expect(page).to have_content('Form was successfully updated.')
           visit example_admin_form_path(Form.last)
           within('.fba-modal-dialog') do
             expect(page).to have_css('.form-header-logo-square')
@@ -251,13 +251,13 @@ feature 'Forms', js: true do
             before do
               form.update(aasm_state: :in_development)
               visit admin_form_path(form)
-              click_on 'Archive this form'
+              click_on 'Archive'
               page.driver.browser.switch_to.alert.accept
             end
 
             it "display 'Archived' flash message" do
               expect(page).to have_content('Archived')
-              expect(page).to have_content('Survey is not published')
+              expect(page).to have_content('Form is not published')
             end
           end
         end
@@ -272,7 +272,7 @@ feature 'Forms', js: true do
 
           it "display 'Reset' flash message" do
             expect(page).to have_content('Form has been reset')
-            expect(page).to have_content('Survey is not published')
+            expect(page).to have_content('Form is not published')
           end
         end
 
@@ -280,7 +280,7 @@ feature 'Forms', js: true do
           it 'can copy a form' do
             click_on 'Copy'
             page.driver.browser.switch_to.alert.accept
-            expect(page).to have_content('Survey was successfully copied')
+            expect(page).to have_content('Form was successfully copied')
           end
         end
 
@@ -451,7 +451,7 @@ feature 'Forms', js: true do
         end
 
         it 'updates successfully' do
-          expect(page).to have_content('Survey was successfully updated.')
+          expect(page).to have_content('Form was successfully updated.')
           visit notifications_admin_form_path(form)
           expect(find("input[type='text']").value).to eq('new@email.gov')
         end
@@ -463,7 +463,7 @@ feature 'Forms', js: true do
 
         before do
           login_as(admin)
-          visit delivery_method_admin_form_path(form)
+          visit delivery_admin_form_path(form)
         end
 
         describe 'editing the whitelist url' do
@@ -473,8 +473,8 @@ feature 'Forms', js: true do
           end
 
           it 'can edit existing Form' do
-            expect(page).to have_content('Survey was successfully updated.')
-            expect(page.current_path).to eq(delivery_method_admin_form_path(form))
+            expect(page).to have_content('Form was successfully updated.')
+            expect(page.current_path).to eq(delivery_admin_form_path(form))
             expect(find('#form_whitelist_url').value).to eq('example.com')
           end
         end
@@ -504,12 +504,12 @@ feature 'Forms', js: true do
         describe 'delete a Form' do
           context 'with no responses' do
             before do
-              click_on 'Delete Survey'
+              click_on 'Delete'
               page.driver.browser.switch_to.alert.accept
             end
 
             it 'can delete existing Form' do
-              expect(page).to have_content('Survey was successfully destroyed.')
+              expect(page).to have_content('Form was successfully destroyed.')
             end
           end
 
@@ -517,7 +517,7 @@ feature 'Forms', js: true do
             let!(:submission) { FactoryBot.create(:submission, form:) }
 
             before do
-              click_on 'Delete Survey'
+              click_on 'Delete'
               page.driver.browser.switch_to.alert.accept
             end
 
@@ -1133,12 +1133,12 @@ feature 'Forms', js: true do
     describe 'can delete a Form' do
       context 'with no responses' do
         before do
-          click_on 'Delete Survey'
+          click_on 'Delete'
           page.driver.browser.switch_to.alert.accept
         end
 
         it 'can delete existing Form' do
-          expect(page).to have_content('Survey was successfully destroyed.')
+          expect(page).to have_content('Form was successfully destroyed.')
         end
       end
 
@@ -1146,7 +1146,7 @@ feature 'Forms', js: true do
         let!(:submission) { FactoryBot.create(:submission, form:) }
 
         before do
-          click_on 'Delete Survey'
+          click_on 'Delete'
           page.driver.browser.switch_to.alert.accept
         end
 
@@ -1276,10 +1276,15 @@ feature 'Forms', js: true do
       end
 
       it 'arrives at /admin/forms/:uuid/questions' do
-        within('.usa-alert__body') do
-          expect(page).to have_content('Survey was successfully created')
+        within('.usa-alert--info .usa-alert__body') do
+          expect(page).to have_content('Form was successfully created')
         end
         expect(page).to have_content('Editing Questions for:')
+        expect(page).to have_content('Form is not published')
+        expect(page).to have_link('Publish')
+        expect(page).to have_link('Copy')
+        expect(page).to have_link('Archive')
+        expect(page).to have_link('Delete')
       end
 
       context 'notification settings' do
@@ -1294,7 +1299,7 @@ feature 'Forms', js: true do
         it 'can be updated' do
           fill_in 'form_notification_emails', with: 'user@example.gov'
           click_on 'Update Survey'
-          expect(page).to have_content('Survey was successfully updated.')
+          expect(page).to have_content('Form was successfully updated.')
 
           click_on 'Notifications'
           expect(find_field('form_notification_emails').value).to eq('user@example.gov')
@@ -1316,8 +1321,8 @@ feature 'Forms', js: true do
         page.driver.browser.switch_to.alert.accept
       end
 
-      it 'conveys the survey was successfully copied' do
-        expect(page).to have_content('Survey was successfully copied.')
+      it 'conveys the form was successfully copied' do
+        expect(page).to have_content('Form was successfully copied.')
         expect(page.current_path).to eq(admin_form_path(Form.last.short_uuid))
         expect(page).to have_content('Viewing Survey')
         expect(page).to have_content("Copy of #{form.name}")
@@ -1549,8 +1554,14 @@ feature 'Forms', js: true do
         visit permissions_admin_form_path(form)
       end
 
-      it 'shows an alert when the email address is not provided' do
-        fill_in('user[refer_user]', with: '')
+      it 'initially disabled button shows an alert when at least 6 characters of an invalid email address is provided' do
+        expect(find("#invite-button").disabled?).to be(true)
+        fill_in('user[refer_user]', with: 'some')
+        expect(find("#invite-button").disabled?).to be(true)
+
+        # add more than 6 characters, to activate the submit button
+        find('#user_refer_user').send_keys('some@address.com')
+        expect(find("#invite-button").disabled?).to be(false)
         click_on 'Invite User'
         expect(page).to have_content('Please enter a valid .gov or .mil email address')
         expect(page.current_path).to eq(permissions_admin_form_path(form))
@@ -1568,9 +1579,9 @@ feature 'Forms', js: true do
           ENV['GITHUB_CLIENT_ID'] = 'something'
         end
 
-        it 'shows an HTML valiation user alert when the email address is not valid' do
+        it 'shows an HTML validation user alert when the email address is not valid' do
           expect(page).to have_content('Invite a colleague')
-          fill_in('user[refer_user]', with: 'test')
+          fill_in('user[refer_user]', with: 'testing')
           click_on 'Invite User'
           message = page.find('#user_refer_user').native.attribute('validationMessage')
           expect(message).to have_content "Please include an '@' in the email address."

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Form, type: :model do
           :referer,
           :created_at,
           :ip_address,
+          :tag_list
                                                          ])
       end
     end
@@ -176,6 +177,7 @@ RSpec.describe Form, type: :model do
 
     before do
       form.submissions.destroy_all # manually remove the Form's seeded submission
+      form.form_sections.first.questions.delete_all
 
       expect(UserRole.count).to eq(1)
       form.destroy
@@ -256,31 +258,25 @@ RSpec.describe Form, type: :model do
     let(:form_without_responses) { FactoryBot.create(:form, :open_ended_form, organization:, user:) }
     let!(:user_role) { FactoryBot.create(:user_role, user:, form: form_without_responses, role: UserRole::Role::FormManager) }
 
-    describe "delete the Form's Form Sections" do
-      before do
-        expect(form_without_responses.form_sections.count).to eq 1
-      end
+    before do
+      expect(form_without_responses.form_sections.count).to eq 1
+      expect(form_without_responses.user_roles.count).to eq 1
+      form_without_responses.form_sections.first.questions.delete_all
+    end
 
+    describe "delete the Form's Form Sections" do
       it 'destroys dependent Form Section' do
         expect { form_without_responses.destroy }.to change { FormSection.count }.by(-1)
       end
     end
 
     describe "delete the Form's Questions" do
-      before do
-        expect(form_without_responses.questions.count).to eq 1
-      end
-
       it 'destroys dependent Questions' do
         expect { form_without_responses.destroy }.to change { Question.count }.by(-1)
       end
     end
 
     describe "delete the Form's UserRoles" do
-      before do
-        expect(form_without_responses.user_roles.count).to eq 1
-      end
-
       it 'destroys dependent UserRole' do
         expect { form_without_responses.destroy }.to change { UserRole.count }.by(-1)
       end


### PR DESCRIPTION
* uses ensure_no_questions
* add tags to csv export
* update inline example page
* force wrap on code blocks (the embed .js was overflowing)