### PR TITLE
Improve compatibility of FBA style insertion

### DIFF
--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -59,7 +59,9 @@ function FBAform(d, N) {
 		<%- if form.load_css %>
 		loadCss: function()
 		{
-			d.head.innerHTML += '<style>' + this.css + '</style>';
+			var style = document.createElement('style');
+			d.head.appendChild(style);
+			style.innerHTML = this.css;
 		},
 		<% end %>
 		loadHtml: function()


### PR DESCRIPTION
Modifying innerHTML of the head tag will reset styles added programmatically using [CSSStyleSheet#insertRule](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule) to any other style tags within the head, thus creating unintended side-effects. Instead, avoid those side-effects by assigning FBA's own styles to a newly-created style tag.

Proof of concept of issue being fixed: https://codepen.io/aduth/pen/rNZjqWq

Related TTS Slack thread: https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1677618486262159