### PR TITLE
Rename Submission.submission_tags to tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "sprockets-rails"
 gem "pg", "~> 1.3"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 5.6"
+gem "puma"
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails", ">= 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/omniauth_login_dot_gov.git
-  revision: 73843e3742dbd595b2d081e33c04a65eb89d9cde
+  revision: a9a8b1c2e8000762c39fc68f172dc82f1481debb
   branch: main
   specs:
-    omniauth_login_dot_gov (1.0.0)
+    omniauth_login_dot_gov (2.0.0)
       faraday (~> 0.17)
       json-jwt (~> 1.11)
       jwt (~> 2.2)
@@ -96,15 +96,15 @@ GEM
     aes_key_wrap (1.1.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.835.0)
-    aws-record (2.12.0)
+    aws-partitions (1.838.0)
+    aws-record (2.13.0)
       aws-sdk-dynamodb (~> 1, >= 1.85.0)
     aws-sdk-core (3.185.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-dynamodb (1.95.0)
+    aws-sdk-dynamodb (1.96.0)
       aws-sdk-core (~> 3, >= 3.184.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-rails (3.9.0)
@@ -118,10 +118,10 @@ GEM
     aws-sdk-ses (1.56.0)
       aws-sdk-core (~> 3, >= 3.184.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sesv2 (1.40.0)
+    aws-sdk-sesv2 (1.41.0)
       aws-sdk-core (~> 3, >= 3.184.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.63.0)
+    aws-sdk-sqs (1.64.0)
       aws-sdk-core (~> 3, >= 3.184.0)
       aws-sigv4 (~> 1.1)
     aws-sessionstore-dynamodb (2.1.0)
@@ -276,7 +276,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0808)
+    mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -285,7 +285,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
-    net-imap (0.4.0)
+    net-imap (0.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -331,11 +331,11 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.3)
-    puma (5.6.7)
+    puma (6.4.0)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
-    rack-cors (1.1.1)
+    rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
@@ -442,7 +442,7 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
-    ruby-vips (2.1.4)
+    ruby-vips (2.2.0)
       ffi (~> 1.12)
     rubyzip (1.3.0)
     sass-rails (6.0.0)
@@ -482,7 +482,7 @@ GEM
     ssrf_filter (1.1.2)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
-    thor (1.2.2)
+    thor (1.3.0)
     tilt (2.3.0)
     timeout (0.4.0)
     turbo-rails (1.5.0)
@@ -556,7 +556,7 @@ DEPENDENCIES
   paper_trail
   pg (~> 1.3)
   pry
-  puma (~> 5.6)
+  puma
   rack-cors (>= 1.1.1)
   rails (~> 7.0.6)
   rails-controller-testing

--- a/app/controllers/admin/forms_controller.rb
+++ b/app/controllers/admin/forms_controller.rb
@@ -365,7 +365,7 @@ module Admin
           send_data csv_content
         end
         format.json do
-          ExportJob.perform_later(params[:uuid], @form.short_uuid, start_date.to_s, end_date.to_s, "touchpoints-form-responses-#{timestamp_string}.csv")
+          ExportJob.perform_later(params[:uuid], @form.short_uuid, start_date.to_s, end_date.to_s, "touchpoints-form-#{@form.short_uuid}-responses-#{timestamp_string}.csv")
           render json: { result: :ok }
         end
       end

--- a/app/controllers/admin/service_providers_controller.rb
+++ b/app/controllers/admin/service_providers_controller.rb
@@ -119,6 +119,7 @@ module Admin
         :tag_list,
         :cx_maturity_mapping_value,
         :impact_mapping_value,
+        :year_designated
       )
     end
   end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -257,6 +257,7 @@ module Admin
         :description,
         :short_description,
         :year_designated,
+        :previously_reported,
         :digital_service,
         :estimated_annual_volume_of_customers,
         :hisp,

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -44,7 +44,7 @@ module Admin
 
     def search
       @all_submissions = @form.submissions
-      @all_submissions = @all_submissions.where(":tags = ANY (submission_tags)", tags: params[:tag]) if params[:tag]
+      @all_submissions = @all_submissions.where(":tags = ANY (tags)", tags: params[:tag]) if params[:tag]
       if params[:archived]
         @submissions = @all_submissions.order('submissions.created_at DESC').page params[:page]
       else
@@ -65,18 +65,18 @@ module Admin
     def add_tag
       tag = tag_params[:tag]
 
-      if !tag.strip.empty? && !@submission.submission_tags.include?(tag)
-        @submission.submission_tags << tag.strip.downcase
+      if !tag.strip.empty? && !@submission.tags.include?(tag)
+        @submission.tags << tag.strip.downcase
         @submission.save!
-        @submission.form.update_submission_tags!(@submission.submission_tags)
+        @submission.form.update_submission_tags!(@submission.tags)
       end
     end
 
     def remove_tag
       tag = tag_params[:tag]
 
-      if @submission.submission_tags.include?(tag)
-        @submission.submission_tags -= [tag]
+      if @submission.tags.include?(tag)
+        @submission.tags -= [tag]
         @submission.save!
       end
     end
@@ -108,7 +108,7 @@ module Admin
     def submissions_table
       @show_archived = true if params[:archived]
       all_submissions = @form.submissions
-      all_submissions = all_submissions.where(":tags = ANY (submission_tags)", tags: params[:tag]) if params[:tag]
+      all_submissions = all_submissions.where(":tags = ANY (tags)", tags: params[:tag]) if params[:tag]
       if params[:archived]
         @submissions = all_submissions.order('submissions.created_at DESC').page params[:page]
       else

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -502,7 +502,7 @@ class Form < ApplicationRecord
     end
 
     ordered_hash.merge!({
-      tag_list: 'Tags',
+      tags: 'Tags',
     })
 
     ordered_hash

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class Submission < ApplicationRecord
-  # TODO: remove acts-as-taggable, in favor of .submission_tags
-  # TODO: then, rename submission_tags to tags
-  acts_as_taggable_on :tags
   include AASM
 
   belongs_to :form, counter_cache: :response_count

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -7,6 +7,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
              :organization_name,
              :name,
              :slug,
+             :year_designated,
              :description,
              :notes,
              :department,

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -13,6 +13,7 @@ class ServiceSerializer < ActiveModel::Serializer
              :short_description,
              :justification_text,
              :year_designated,
+             :previously_reported,
              :contact_center,
              :kind,
              :transactional,

--- a/app/serializers/submission_serializer.rb
+++ b/app/serializers/submission_serializer.rb
@@ -36,11 +36,5 @@ class SubmissionSerializer < ActiveModel::Serializer
              :aasm_state,
              :language,
              :uuid,
-             :tag_list
-
-  # override tag_list provided by acts-as-taggable
-  # but keep an array of tags
-  def tag_list
-    object.submission_tags
-  end
+             :tags
 end

--- a/app/views/admin/cx_collections/_form.html.erb
+++ b/app/views/admin/cx_collections/_form.html.erb
@@ -125,8 +125,8 @@
   </div>
 
   <div class="field">
-    <%= form.label :reflection, class: "usa-label" %>
-    <%= form.text_field :reflection, class: "usa-input" %>
+    <%= form.label :reflection, 'Reflection text', class: "usa-label" %>
+    <%= form.text_area :reflection, class: "usa-textarea" %>
   </div>
 
   <% if performance_manager_permissions? && cx_collection.persisted? %>

--- a/app/views/admin/questions/_form.html.erb
+++ b/app/views/admin/questions/_form.html.erb
@@ -105,7 +105,7 @@
         var questionType = $("#question_question_type option:selected").text();
       <% end %>
 
-      <% if admin_permissions? %>
+      <% if admin_permissions? || service_manager_permissions? %>
       var questionType = $("input[name='question[question_type]']").val();
       <% end %>
 

--- a/app/views/admin/service_providers/_form.html.erb
+++ b/app/views/admin/service_providers/_form.html.erb
@@ -24,6 +24,11 @@
       </div>
 
       <div class="field">
+        <%= form.label :year_designated, "Year designated", class: "usa-label" %>
+        <%= form.number_field :year_designated, class: "usa-input", placeholder: 2023 %>
+      </div>
+
+      <div class="field">
         <%= form.label :description, class: "usa-label" %>
         <%= form.text_area :description, class: "usa-textarea" %>
       </div>

--- a/app/views/admin/service_providers/show.html.erb
+++ b/app/views/admin/service_providers/show.html.erb
@@ -52,6 +52,12 @@
       <br>
       <%= to_markdown(@service_provider.description) %>
     </p>
+
+     <p>
+      <strong>Year designated</strong>
+      <br>
+      <%= @service_provider.year_designated %>
+    </p>
     <p>
       <strong>Service provider managers</strong>
       <br>
@@ -181,4 +187,3 @@
         <% end %>
     </p>
 </div>
-

--- a/app/views/admin/services/_form.html.erb
+++ b/app/views/admin/services/_form.html.erb
@@ -31,6 +31,18 @@
       <%= form.label :year_designated, "Year designated", class: "usa-label" %>
       <%= form.text_field :year_designated, class: "usa-input", placeholder: 2023 %>
     </div>
+
+     <br>
+    <fieldset class="usa-fieldset margin-bottom-3">
+      <legend class="usa-sr-only">Previously reported?</legend>
+      <div class="usa-checkbox">
+        <%= form.check_box :previously_reported, class: "usa-checkbox__input" %>
+        <%= form.label :previously_reported, "Previously reported?", class: "usa-checkbox__label" %>
+        <span class="usa-hint font-sans-3xs">
+        Not a currently designated HISP
+      </span>
+      </div>
+    </fieldset>
     <% end %>
 
     <div class="field">

--- a/app/views/admin/submissions/_tags.html.erb
+++ b/app/views/admin/submissions/_tags.html.erb
@@ -9,7 +9,7 @@
       </h3>
       <div class="tag-list">
         <ul class="usa-list usa-list--unstyled">
-          <% submission.submission_tags.sort.each do |tag| %>
+          <% submission.tags.sort.each do |tag| %>
           <li>
             <span class="usa-tag">
               <%= tag %>

--- a/app/views/components/forms/_footer_banner.html.erb
+++ b/app/views/components/forms/_footer_banner.html.erb
@@ -2,7 +2,8 @@
   <footer class="usa-banner__header touchpoints-footer-banner">
     <div class="usa-banner__inner">
       <div class="grid-col-auto">
-        <img class="usa-banner__header-flag" src="<%= image_url("us_flag_small.png") %>" alt="U.S. flag">
+        <img class="usa-banner__header-flag" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAALCAMAAABBPP0LAAAAG1BMVEUdM7EeNLIeM7HgQCDaPh/bPh/bPx/////bPyBEby41AAAAUElEQVQI123MNw4CABDEwD3jC/9/MQ1BQrgeOSkIqYe2o2FZtthXgQLgbHVMZdlsfUQFQnHtjP1+8BUhBDKOqtmfot6ojqPzR7TjdU+f6vkED+IDPhTBcMAAAAAASUVORK5CYII=
+" alt="U.S. flag">
       </div>
       <div class="grid-col-fill tablet:grid-col-auto">
         <p class="usa-banner__header-text">

--- a/db/migrate/20231017015030_rename_submission_tags.rb
+++ b/db/migrate/20231017015030_rename_submission_tags.rb
@@ -1,0 +1,5 @@
+class RenameSubmissionTags < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :submissions, :submission_tags, :tags
+  end
+end

--- a/db/migrate/20231017203550_add_previously_reported_to_services.rb
+++ b/db/migrate/20231017203550_add_previously_reported_to_services.rb
@@ -1,0 +1,6 @@
+class AddPreviouslyReportedToServices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :services, :previously_reported, :boolean, default: false
+    add_column :service_providers, :year_designated, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_16_190706) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_17_203550) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -657,6 +657,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_190706) do
     t.integer "services_count", default: 0
     t.integer "impact_mapping_value", default: 0
     t.string "portfolio_manager_email"
+    t.integer "year_designated"
     t.index ["organization_id"], name: "index_service_providers_on_organization_id"
   end
 
@@ -723,6 +724,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_190706) do
     t.boolean "contact_center", default: false, comment: "True or False for whether the service involves a contact center and/or an interaction with a contact center"
     t.integer "year_designated"
     t.text "short_description"
+    t.boolean "previously_reported", default: false
     t.index ["organization_id"], name: "index_services_on_organization_id"
   end
 
@@ -761,7 +763,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_190706) do
     t.string "uuid"
     t.string "aasm_state", default: "received"
     t.string "hostname"
-    t.string "submission_tags", default: [], array: true
+    t.string "tags", default: [], array: true
     t.index ["created_at"], name: "index_submissions_on_created_at"
     t.index ["flagged"], name: "index_submissions_on_flagged"
     t.index ["form_id"], name: "index_submissions_on_form_id"

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Form, type: :model do
           :referer,
           :created_at,
           :ip_address,
-          :tag_list
+          :tags
         ])
       end
     end


### PR DESCRIPTION
* update gems
* add services.previously_reported and service_providers.year_designated
* add short_uuid to form export
* allow service_managers to see the same form components as an admin
* embed the U.S. flag image, rather than loading an image asset