### PR TITLE
Show required fields label only if form includes required fields

### DIFF
--- a/app/views/components/forms/_custom_layout.html.erb
+++ b/app/views/components/forms/_custom_layout.html.erb
@@ -15,9 +15,11 @@
           <%= sanitize(form.instructions) %>
         </p>
       <% end %>
-      <p>
-        <%= t('form.required_field_html') %>
-      </p>
+      <% if form.questions.any?(&:is_required?) %>
+        <p>
+          <%= t('form.required_field_html') %>
+        </p>
+      <% end %>
       <%= render 'components/forms/flash', form: form %>
       <%= render partial: "components/forms/custom", locals: { form: form, questions: form.questions } %>
     </div>

--- a/spec/views/components/forms/_custom_layout.html.erb_spec.rb
+++ b/spec/views/components/forms/_custom_layout.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'components/forms/_custom_layout.html.erb' do
+  let(:form) { create(:form) }
+
+  subject(:rendered) do
+    render partial: 'components/forms/custom_layout', locals: { form: }
+  end
+
+  context 'with required fields' do
+    let(:form) { create(:form, :a11) }
+
+    it 'displays required field label' do
+      expect(rendered).to have_content(strip_tags(t('form.required_field_html')))
+    end
+  end
+
+  context 'without required fields' do
+    let(:form) { create(:form, :star_ratings) }
+
+    it 'does not display required field label' do
+      expect(rendered).not_to have_content(strip_tags(t('form.required_field_html')))
+    end
+  end
+end


### PR DESCRIPTION
We have a simple Yes/No optional questionnaire on our website ([example](https://login.gov/help/trouble-signing-in/overview/)), and I noticed recently the addition of a "required field" label since #1231. The label feels rather out of place for our simple form, which doesn't include any required fields.

The changes proposed here would only display this label on a form which includes required fields.