### PR TITLE
Add aria label to feedback modal dialog

### DIFF
--- a/app/views/components/widget/_modal.html.erb
+++ b/app/views/components/widget/_modal.html.erb
@@ -1,6 +1,7 @@
 <div id="fba-modal-dialog"
   class="fba-modal-dialog"
   role="dialog"
+  aria-label="Feedback modal dialog"
   aria-modal="<%= ['modal', 'custom-button-modal'].include?(form.delivery_method) ? 'true' : 'false' %>">
   <%= render "components/widget/no_modal", form: form do %>
     <%= render partial: 'components/forms/footer', locals: { form: form } %>


### PR DESCRIPTION
We are using a Touchpoints survey on https//:www.ada.gov. Currently [Google Lighthouse](https://googlechrome.github.io/lighthouse/viewer/?psiurl=https%3A%2F%2Fwww.ada.gov%2F&strategy=mobile&category=performance&category=accessibility&category=best-practices&category=seo&category=pwa&utm_source=lh-chrome-ext) is reporting an accessibility with the survey:
![image](https://github.com/GSA/touchpoints/assets/18104884/a0b6b86b-a28e-420c-bca0-a46b73e70495)
This PR corrects the error [as recommended](https://dequeuniversity.com/rules/axe/4.7/aria-dialog-name) by adding an aria-label to the dialog.