### PR TITLE
don't reset the form after it is submitted

### DIFF
--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -434,7 +434,6 @@ function FBAform(d, N) {
 		closeDialog: function() {
 			document.dispatchEvent(new Event('onTouchpointsModalClose'));
 			d.querySelector('.fba-modal').setAttribute("hidden", true);
-			this.resetFormDisplay();
 			this.activatedButton.focus();
 			this.dialogOpen = false;
 		},

--- a/spec/features/embedded_touchpoints_spec.rb
+++ b/spec/features/embedded_touchpoints_spec.rb
@@ -46,6 +46,11 @@ feature 'Touchpoints', js: true do
           # shows success flash message
           expect(page).to have_content('Success')
           expect(page).to have_content('Thank you. Your feedback has been received.')
+
+          # doesn't reset form; leave the flash message
+          find(".fba-modal-close").click
+          find("#fba-button").click
+          expect(page).to have_content('Thank you. Your feedback has been received.')
         end
 
         it 'renders success flash message' do


### PR DESCRIPTION
currently, when a form is submitted, the "Success" message shows,
and when a form's modal is closed, the form resets to a state as if to receive another response, which is not an intention.