### PR TITLE
Improve client-side handling of failed websocket downloads.

### DIFF
--- a/app/assets/javascripts/channels/export.js
+++ b/app/assets/javascripts/channels/export.js
@@ -1,15 +1,19 @@
-function subscribeExportChannel(uuid, startExportJobFtn, completionCallback) {
+function subscribeExportChannel(uuid, url, completionCallback) {
   App.cable.subscriptions.create(
     { channel: "ExportChannel", uuid: uuid },
     {
       connected: function() {
-        startExportJobFtn();
+        $.get(url);
       },
 
       // Called when the WebSocket connection is closed, either by server or by client-side stale connection monitor.
       // If the connection closes before we receive a response, count that as a failed export and unsubscribe.
       // Reconnecting is not useful because we can't tell whether the response was sent while we were disconnected.
       disconnected: function() {
+        if (newrelic) {
+          newrelic.noticeError(new Error("Export channel disconnected."), { requestedUrl: url});
+        }
+
         const errorText = "We're sorry, your download has failed. That happens sometimes for response sets over several MB's in size.\n\n" +
           "We're working on fixing this problem. You can monitor our progress at https://github.com/GSA/touchpoints/issues/1446. " +
           "In the meantime, you can use our API to download large response sets. View API documentation at https://github.com/GSA/touchpoints/wiki/API.";

--- a/app/assets/javascripts/channels/export.js
+++ b/app/assets/javascripts/channels/export.js
@@ -1,37 +1,42 @@
-function subscribeExportChannel(uuid, callback) {
-  App.download = App.cable.subscriptions.create(
+function subscribeExportChannel(uuid, startExportJobFtn, completionCallback) {
+  App.cable.subscriptions.create(
     { channel: "ExportChannel", uuid: uuid },
     {
       connected: function() {
-        callback();
+        startExportJobFtn();
       },
 
-      disconnected: function() {},
+      // Called when the WebSocket connection is closed, either by server or by client-side stale connection monitor.
+      // If the connection closes before we receive a response, count that as a failed export and unsubscribe.
+      // Reconnecting is not useful because we can't tell whether the response was sent while we were disconnected.
+      disconnected: function() {
+        const errorText = "We're sorry, your download has failed. That happens sometimes for response sets over several MB's in size.\n\n" +
+          "We're working on fixing this problem. You can monitor our progress at https://github.com/GSA/touchpoints/issues/1446. " +
+          "In the meantime, you can use our API to download large response sets. View API documentation at https://github.com/GSA/touchpoints/wiki/API.";
+
+        const blob = new Blob([errorText], {
+          type: "text/plain;charset=utf-8"
+        });
+
+        saveAs(blob, `touchpoints-failed-export-${(new Date().toISOString().slice(0, 19))}`);
+
+        // 'this' is the subscription object
+        this.unsubscribe();
+        completionCallback();
+      },
 
       received: function(data) {
 
-        var blob = new Blob([data.csv], {
+        const blob = new Blob([data.csv], {
           type: "text/csv;charset=utf-8"
         });
 
         saveAs(blob, data.filename);
 
-        $(".export-btn.cursor-not-allowed")
-          .html("Export FY Responses")
-          .removeClass('cursor-not-allowed');
-
-        $(".export-all-btn.cursor-not-allowed")
-          .html("Export Responses to CSV")
-          .removeClass('cursor-not-allowed');
-
-        $(".export-a11-v2-btn.cursor-not-allowed")
-          .html("Export A11v2 Responses to CSV")
-          .removeClass('cursor-not-allowed');
-
-        App.download.unsubscribe();
-        App.cable.disconnect();
-        delete App.download;
-      }
+        // 'this' is the subscription object
+        this.unsubscribe();
+        completionCallback();
+      },
     }
   );
 }

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -53,9 +53,7 @@
       const url = $(this).attr('href') + '?uuid=' + uuid + '';
       subscribeExportChannel(
         uuid,
-        function() {
-          $.get(url);
-        },
+        url,
         () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
       );
 

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -41,18 +41,23 @@
     $('.export-btn').on("click", function(e) {
       e.preventDefault();
 
-      if ($(this).text() == "Exporting...") {
+      if ($(this).text() === "Exporting...") {
         console.log("Click disabled while exporting");
         return false;
       }
 
-      var uuid = generateUUID();
+      const uuid = generateUUID();
+      const buttonHtml = $(this).html();
       $(this).html('Exporting...').addClass('cursor-not-allowed');
 
-      var url = $(this).attr('href') + '?uuid=' + uuid + '';
-      subscribeExportChannel(uuid, function() {
-        $.get(url);
-      });
+      const url = $(this).attr('href') + '?uuid=' + uuid + '';
+      subscribeExportChannel(
+        uuid,
+        function() {
+          $.get(url);
+        },
+        () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
+      );
 
       return false;
     });

--- a/app/views/admin/submissions/_performance_gov.html.erb
+++ b/app/views/admin/submissions/_performance_gov.html.erb
@@ -50,9 +50,7 @@
       const url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
       subscribeExportChannel(
         uuid,
-        function() {
-          $.get(url);
-        },
+        url,
         () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
       );
       return false;

--- a/app/views/admin/submissions/_performance_gov.html.erb
+++ b/app/views/admin/submissions/_performance_gov.html.erb
@@ -40,16 +40,21 @@
   $(function() {
     $('.export-cx-summary-button').click(function(e) {
       e.preventDefault();
-      if ($(this).text() == "Exporting...") {
+      if ($(this).text() === "Exporting...") {
         console.log("Click disabled while exporting");
         return false;
       }
-      var uuid = generateUUID();
+      const uuid = generateUUID();
+      const buttonHtml = $(this).html();
       $(this).html('Exporting...').addClass('cursor-not-allowed');
-      var url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
-      subscribeExportChannel(uuid, function() {
-        $.get(url);
-      });
+      const url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
+      subscribeExportChannel(
+        uuid,
+        function() {
+          $.get(url);
+        },
+        () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
+      );
       return false;
     })
   });

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -51,46 +51,61 @@
 
     $('.export-all-btn').on("click", function(e) {
       e.preventDefault();
-      if ($(this).text() == "Exporting...") {
+      if ($(this).text() === "Exporting...") {
         console.log("Click disabled while exporting");
         return false;
       }
-      var uuid = generateUUID();
+      const uuid = generateUUID();
+      const buttonHtml = $(this).html();
       $(this).html('Exporting...').addClass('cursor-not-allowed');
-      var url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
-      subscribeExportChannel(uuid, function() {
-        $.get(url);
-      });
+      const url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
+      subscribeExportChannel(
+        uuid,
+        function() {
+          $.get(url);
+        },
+        () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
+      );
       return false;
     });
 
     // for the FY 2020-2024 buttons
     $('.export-btn').on("click", function(e) {
       e.preventDefault();
-      if ($(this).text() == "Exporting...") {
+      if ($(this).text() === "Exporting...") {
         console.log("Click disabled while exporting");
         return false;
       }
-      var uuid = generateUUID();
+      const uuid = generateUUID();
+      const buttonHtml = $(this).html();
       $(this).html('Exporting...').addClass('cursor-not-allowed');
-      var url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
-      subscribeExportChannel(uuid, function() {
-        $.get(url);
-      });
+      const url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
+      subscribeExportChannel(
+        uuid,
+        function() {
+          $.get(url);
+        },
+        () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
+      );
       return false;
     });
 
     $('.export-a11-v2-btn').on("click", function(e) {
       e.preventDefault();
-      if ($(this).text() == "Exporting...") {
+      if ($(this).text() === "Exporting...") {
         return false;
       }
-      var uuid = generateUUID();
+      const uuid = generateUUID();
+      const buttonHtml = $(this).html();
       $(this).html('Exporting...').addClass('cursor-not-allowed');
-      var url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
-      subscribeExportChannel(uuid, function() {
-        $.get(url);
-      });
+      const url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
+      subscribeExportChannel(
+        uuid,
+        function() {
+          $.get(url);
+        },
+        () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
+      );
       return false;
     });
   });

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -61,9 +61,7 @@
       const url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
       subscribeExportChannel(
         uuid,
-        function() {
-          $.get(url);
-        },
+        url,
         () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
       );
       return false;
@@ -82,9 +80,7 @@
       const url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
       subscribeExportChannel(
         uuid,
-        function() {
-          $.get(url);
-        },
+        url,
         () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
       );
       return false;
@@ -101,9 +97,7 @@
       const url = $(this).attr('href') + '&uuid=' + uuid + '&touchpoint_id=<%= form.short_uuid %>';
       subscribeExportChannel(
         uuid,
-        function() {
-          $.get(url);
-        },
+        url,
         () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
       );
       return false;

--- a/app/views/components/admin/_versions.html.erb
+++ b/app/views/components/admin/_versions.html.erb
@@ -44,18 +44,23 @@
     $('.export-btn').on("click", function(e) {
       e.preventDefault();
 
-      if ($(this).text() == "Exporting...") {
+      if ($(this).text() === "Exporting...") {
         console.log("Click disabled while exporting");
         return false;
       }
 
-      var uuid = generateUUID();
+      const uuid = generateUUID();
+      const buttonHtml = $(this).html();
       $(this).html('Exporting...').addClass('cursor-not-allowed');
 
-      var url = $(this).attr('href') + '?uuid=' + uuid + '';
-      subscribeExportChannel(uuid, function() {
-        $.get(url);
-      });
+      const url = $(this).attr('href') + '?uuid=' + uuid + '';
+      subscribeExportChannel(
+        uuid,
+        function() {
+          $.get(url);
+        },
+        () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
+      );
 
       return false;
     });

--- a/app/views/components/admin/_versions.html.erb
+++ b/app/views/components/admin/_versions.html.erb
@@ -56,9 +56,7 @@
       const url = $(this).attr('href') + '?uuid=' + uuid + '';
       subscribeExportChannel(
         uuid,
-        function() {
-          $.get(url);
-        },
+        url,
         () => $(this).html(buttonHtml).removeClass('cursor-not-allowed')
       );
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  config.active_job.queue_adapter = :async
+  config.active_job.queue_adapter = :sidekiq
 
   config.action_mailer.perform_deliveries = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  config.active_job.queue_adapter = :sidekiq
+  config.active_job.queue_adapter = :async
 
   config.action_mailer.perform_deliveries = true
 
@@ -78,6 +78,9 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+
+  # Turn on source maps
+  config.assets.debug = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -418,8 +418,8 @@ Rails.application.routes.draw do
     get 'performance/apg', to: 'performance#apgs', as: :apgs
     get 'management', to: 'site#management', as: :management
     get 'events', to: 'events#index', as: :events
-    get 'events/:id', to: 'events#show', as: :event
     get 'events/export', to: 'site#events_export', as: :export_events
+    get 'events/:id', to: 'events#show', as: :event
     root to: 'forms#index'
     get 'feed', to: 'submissions#feed', as: :feed
     get 'export_feed', to: 'submissions#export_feed', as: :export_feed


### PR DESCRIPTION
The main change here is in what happens if the websocket gets disconnected after the download has been requested but before the response has been received.

Previously, the code would try to reconnect the websocket and, once connected, it would re-request the data. The second download would probably fail too, and the third, and so forth. During all of this, the UI would give no indication of what was happening - it would just continue to display the "Exporting..." label on the export button.

Now, the code gives up after the first disconnect. It then resets the export button and, in place of the data file it was supposed to return, it returns a file with the following text:

> We're sorry, your download has failed. That happens sometimes for response sets over several MB's in size.
>
> We're working on fixing this problem. You can monitor our progress at `https://github.com/GSA/touchpoints/issues/1446`. In the meantime, you can use our API to download large response sets. View API documentation at `https://github.com/GSA/touchpoints/wiki/API`.

This was the easiest way to signal an error but it's probably not the best user experience. I'm happy to consider a different approach. I'm also happy to change the text.

The PR also fixes some minor problems where the code didn't always restore the original text to the export buttons once exports were complete (i.e., the button read as "Export FY2022" on page load, transitioned to "Exporting..." during export and then transitioned to "Export FY Responses".)
