### PR TITLE
Performance improvements for responses page

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -53,7 +53,9 @@ S3_AWS_SECRET_ACCESS_KEY=
 S3_AWS_BUCKET_NAME=
 S3_AWS_REGION=
 
-# S3 Private Bucket for Collection uploads
+# S3 Private Bucket
+# Must be configured in order to upload collection data
+# Must be configured in order to export response data
 S3_UPLOADS_AWS_ACCESS_KEY_ID=
 S3_UPLOADS_AWS_BUCKET_NAME=
 S3_UPLOADS_AWS_REGION=

--- a/app/assets/javascripts/channels/export.js
+++ b/app/assets/javascripts/channels/export.js
@@ -3,26 +3,23 @@ function subscribeExportChannel(uuid, url, completionCallback) {
     { channel: "ExportChannel", uuid: uuid },
     {
       connected: function() {
-        $.get(url);
+        $.ajax(url)
+          .fail(response => {
+            this.unsubscribe();
+            if (response.status === 400 && response.responseText) {
+              this.downloadError(response.responseText);
+            } else {
+              this.downloadError();
+            }
+            completionCallback();
+          });
       },
 
       // Called when the WebSocket connection is closed, either by server or by client-side stale connection monitor.
       // If the connection closes before we receive a response, count that as a failed export and unsubscribe.
       // Reconnecting is not useful because we can't tell whether the response was sent while we were disconnected.
       disconnected: function() {
-        if (newrelic) {
-          newrelic.noticeError(new Error("Export channel disconnected."), { requestedUrl: url});
-        }
-
-        const errorText = "We're sorry, your download has failed. That happens sometimes for response sets over several MB's in size.\n\n" +
-          "We're working on fixing this problem. You can monitor our progress at https://github.com/GSA/touchpoints/issues/1446. " +
-          "In the meantime, you can use our API to download large response sets. View API documentation at https://github.com/GSA/touchpoints/wiki/API.";
-
-        const blob = new Blob([errorText], {
-          type: "text/plain;charset=utf-8"
-        });
-
-        saveAs(blob, `touchpoints-failed-export-${(new Date().toISOString().slice(0, 19))}`);
+        this.downloadError('Websocket disconnected unexpectedly.');
 
         // 'this' is the subscription object
         this.unsubscribe();
@@ -30,17 +27,31 @@ function subscribeExportChannel(uuid, url, completionCallback) {
       },
 
       received: function(data) {
-
-        const blob = new Blob([data.csv], {
-          type: "text/csv;charset=utf-8"
-        });
-
-        saveAs(blob, data.filename);
+        const dataUrl = data.url;
+        const filename = data.filename;
+        $.ajax(dataUrl)
+          .done(function(data) {
+            const blob = new Blob([data], {
+              type: "text/csv;charset=utf-8"
+            });
+            saveAs(blob, filename);
+          })
+          .fail(() => this.downloadError(`Invalid download link: ${dataUrl}`))
+          .always(() => completionCallback());
 
         // 'this' is the subscription object
         this.unsubscribe();
-        completionCallback();
       },
+
+      downloadError: function(errorExplanation = '') {
+        const errorText = `Your export failed.\n\n${errorExplanation}`
+
+        const blob = new Blob([errorText], {
+          type: "text/plain;charset=utf-8"
+        });
+
+        saveAs(blob, `touchpoints-failed-export-${(new Date().toISOString().slice(0, 19))}`);
+      }
     }
   );
 }

--- a/app/controllers/admin/forms_controller.rb
+++ b/app/controllers/admin/forms_controller.rb
@@ -369,6 +369,13 @@ module Admin
       start_date = params[:start_date] ? Date.parse(params[:start_date]).to_date : Time.zone.now.beginning_of_quarter
       end_date = params[:end_date] ? Date.parse(params[:end_date]).to_date : Time.zone.now.end_of_quarter
 
+      max_export_rows = 300_000 # max number of rows that may be exported to csv
+      count = Form.find_by_short_uuid(@form.short_uuid).non_flagged_submissions(start_date:, end_date:).count
+      if count > max_export_rows
+        render status: :bad_request, plain: "Your response set contains #{helpers.number_with_delimiter count} responses and is too big to be exported from the Touchpoints app. Consider using the Touchpoints API to download large response sets (over #{helpers.number_with_delimiter max_export_rows} responses)."
+        return
+      end
+
       respond_to do |format|
         format.csv do
           csv_content = Form.find_by_short_uuid(@form.short_uuid).to_csv(start_date:, end_date:)

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -99,7 +99,12 @@ module Admin
       @response_groups = @response_groups.sort
     end
 
-    def responses_by_status; end
+    def responses_by_status
+      responses_by_aasm = @form.submissions.group(:aasm_state).count
+      flagged_count = @form.submissions.where(flagged: true).size
+      @responses_by_status = { **responses_by_aasm, 'flagged' => flagged_count, 'total' => responses_by_aasm.values.sum }
+      @responses_by_status.default = 0
+    end
 
     def performance_gov
       @report = FormCache.fetch_performance_gov_analysis(@form.short_uuid)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -198,12 +198,31 @@ module ApplicationHelper
     Aws::S3::Presigner.new(client: s3_client)
   end
 
+  def s3_bucket
+    bucket_name = ENV.fetch('S3_UPLOADS_AWS_BUCKET_NAME')
+    s3_service.bucket(bucket_name)
+  end
+
   def s3_presigned_url(key)
     s3_presigner.presigned_url(
       :get_object,
       bucket: ENV.fetch("S3_UPLOADS_AWS_BUCKET_NAME"),
       key: key,
       expires_in: 15.minutes.to_i
+    ).to_s
+  end
+
+  def store_temporarily(data)
+    key = "temporary_files/#{SecureRandom.uuid}"
+    s3_bucket.put_object({
+                           body: data,
+                           key:,
+                         })
+    s3_presigner.presigned_url(
+      :get_object,
+      bucket: s3_bucket.name,
+      key:,
+      expires_in: 5.minutes.to_i,
     ).to_s
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
+  include ApplicationHelper
 end

--- a/app/jobs/export_a11_v2_job.rb
+++ b/app/jobs/export_a11_v2_job.rb
@@ -5,8 +5,9 @@ class ExportA11V2Job < ApplicationJob
 
   def perform(session_uuid, form_short_uuid, start_date, end_date, filename = "export-#{Time.zone.now}.csv")
     csv_content = Form.find_by_short_uuid(form_short_uuid).to_a11_v2_csv(start_date:, end_date:)
+    temporary_url = store_temporarily(csv_content)
     ActionCable.server.broadcast(
-      "exports_channel_#{session_uuid}", { csv: csv_content, filename: }
+      "exports_channel_#{session_uuid}", { url: temporary_url, filename: }
     )
   end
 end

--- a/app/jobs/export_digital_service_accounts.rb
+++ b/app/jobs/export_digital_service_accounts.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ExportDigitalServiceAccounts < ApplicationJob
-  include ApplicationHelper
-
   queue_as :default
 
   def perform(session_uuid, include_all_accounts: false, filename: "touchpoints-digital-service-accounts-#{Time.now.to_i}.csv")
@@ -11,19 +9,10 @@ class ExportDigitalServiceAccounts < ApplicationJob
     else
       csv_content = DigitalServiceAccount.to_csv
     end
-
-    write_to_private_s3(filename: filename, content: csv_content)
-  end
-
-
-  private
-
-  def write_to_private_s3(filename:, content:)
-    bucket = ENV.fetch("S3_UPLOADS_AWS_BUCKET_NAME")
-    key = "reports/#{filename}"
-
-    obj = s3_service.bucket(bucket).object(key)
-    response = obj.put(body: content)
-    s3_presigned_url(key)
+    temporary_url = store_temporarily(csv_content)
+    ActionCable.server.broadcast(
+      "exports_channel_#{session_uuid}", { url: temporary_url, filename: }
+    )
+    temporary_url
   end
 end

--- a/app/jobs/export_events_job.rb
+++ b/app/jobs/export_events_job.rb
@@ -5,8 +5,9 @@ class ExportEventsJob < ApplicationJob
 
   def perform(session_uuid, filename = "touchpoints-system-events-#{Time.zone.now}.csv")
     csv_content = Event.to_csv
+    temporary_url = store_temporarily(csv_content)
     ActionCable.server.broadcast(
-      "exports_channel_#{session_uuid}", { csv: csv_content, filename: }
+      "exports_channel_#{session_uuid}", { url: temporary_url, filename: }
     )
   end
 end

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -5,8 +5,9 @@ class ExportJob < ApplicationJob
 
   def perform(session_uuid, form_short_uuid, start_date, end_date, filename = "export-#{Time.zone.now}.csv")
     csv_content = Form.find_by_short_uuid(form_short_uuid).to_csv(start_date:, end_date:)
+    temporary_url = store_temporarily(csv_content)
     ActionCable.server.broadcast(
-      "exports_channel_#{session_uuid}", { csv: csv_content, filename: }
+      "exports_channel_#{session_uuid}", { url: temporary_url, filename: }
     )
   end
 end

--- a/app/jobs/export_versions_job.rb
+++ b/app/jobs/export_versions_job.rb
@@ -5,8 +5,9 @@ class ExportVersionsJob < ApplicationJob
 
   def perform(session_uuid, versionable, filename = "touchpoints-versions-#{Time.zone.now}.csv")
     csv_content = Version.to_csv(versionable)
+    temporary_url = store_temporarily(csv_content)
     ActionCable.server.broadcast(
-      "exports_channel_#{session_uuid}", { csv: csv_content, filename: }
+      "exports_channel_#{session_uuid}", { url: temporary_url, filename: }
     )
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -239,11 +239,15 @@ class Form < ApplicationRecord
     ApplicationController.new.render_to_string(partial: 'components/widget/fba', formats: :js, locals: { touchpoint: self })
   end
 
-  def to_csv(start_date: nil, end_date: nil)
-    non_flagged_submissions = submissions
+  def non_flagged_submissions(start_date: nil, end_date: nil)
+    submissions
       .non_flagged
-      .where('created_at >= ?', start_date)
-      .where('created_at <= ?', end_date)
+      .where(created_at: start_date..)
+      .where(created_at: ..end_date)
+  end
+
+  def to_csv(start_date: nil, end_date: nil)
+    non_flagged_submissions = non_flagged_submissions(start_date:, end_date:)
       .order('created_at')
     return nil if non_flagged_submissions.blank?
 

--- a/app/views/admin/submissions/_responses_by_status.html.erb
+++ b/app/views/admin/submissions/_responses_by_status.html.erb
@@ -1,1 +1,1 @@
-<%= render 'components/responses_by_status', submissions: form.submissions %>
+<%= render 'components/responses_by_status', responses_by_status: @responses_by_status %>

--- a/app/views/components/_responses_by_status.html.erb
+++ b/app/views/components/_responses_by_status.html.erb
@@ -30,25 +30,25 @@
   <tbody>
     <tr>
       <td>
-        <%= submissions.select { |s| s.aasm_state == "received" }.size %>
+        <%= number_with_delimiter(responses_by_status["received"]) %>
       </td>
       <td>
-        <%= submissions.select { |s| s.acknowledged? }.size %>
+        <%= number_with_delimiter(responses_by_status["acknowledged"]) %>
       </td>
       <td>
-        <%= submissions.select { |s| s.dispatched? }.size %>
+        <%= number_with_delimiter(responses_by_status["dispatched"]) %>
       </td>
       <td>
-        <%= submissions.select { |s| s.responded? }.size %>
+        <%= number_with_delimiter(responses_by_status["responded"]) %>
       </td>
       <td>
-        <%= submissions.archived.size %>
+        <%= number_with_delimiter(responses_by_status["archived"]) %>
       </td>
       <td>
-        <%= submissions.where(flagged: true).size %>
+        <%= number_with_delimiter(responses_by_status["flagged"]) %>
       </td>
       <td>
-        <%= submissions.size %>
+        <%= number_with_delimiter(responses_by_status["total"]) %>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
This PR does 2 things:

1. The first commit improves the loading performance of the "Responses by Status" table on the form responses page. Login.gov mentioned that it wasn't loading for their giant "Login.gov yes/no survey", now it loads in less than 1 second.
2. The second commit provides support for exporting large response sets to csv. The old implementation tried to pass the exported csv file back over a websocket (which often failed when the file was too big), the new implementation saves the exported csv file to S3 and passes a link to the file back over a websocket. I've tested this locally and got the following results:

- On our 3rd largest response set (NPSgov CX, 35K responses), the export succeeds in ~20 seconds.
- For exports over 300K responses, the export request fails immediately. Tested successfully with our 2nd largest response set (Login.gov yes/no survey, over 2M responses).
- For the 'Login.gov yes/no survey', the FY2022 response set is less than 300K (I don't have the exact number, ~150K responses). This response set downloaded successfully in ~2 minutes.

We need additional S3 configuration to go along with this PR:

- (Required) [Set a CORS policy](https://cloud.gov/docs/services/s3/#allowing-client-side-web-access-from-external-applications) on our private bucket
- (Recommended) [Set a lifecycle configuration policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html) to expire objects with the `temporary_files` prefix in our private bucket. 