### PR TITLE
Add arm64 platform to Gemfile.lock.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     fog-aws (3.24.0)
       fog-core (~> 2.1)
@@ -328,6 +329,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.6-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.6-x86_64-darwin)
       racc (~> 1.4)
@@ -567,6 +570,7 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
+  arm64-darwin-23
   ruby
   x86_64-darwin-19
   x86_64-darwin-20


### PR DESCRIPTION
Solves a problem I was having installing `nokogiri` on my Apple M1 Pro.