### PR TITLE
match the user's original (sub)domain, then top-level domain

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,7 +178,9 @@ class User < ApplicationRecord
     email_address_domain = Mail::Address.new(email).domain
     parsed_domain = parse_host_from_domain(email_address_domain)
 
-    if org = Organization.find_by_domain(parsed_domain)
+    if org = Organization.find_by_domain(email_address_domain)
+      self.organization_id = org.id
+    elsif org = Organization.find_by_domain(parsed_domain)
       self.organization_id = org.id
     else
       UserMailer.no_org_notification(self).deliver_later if id

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -45,7 +45,7 @@
       <%- if @organization.parent %>
       <div class="grid-col-12">
         <%= label_tag "Parent Organization name", nil, class: "usa-label" %>
-        <%= link_to @organization.parent.name, admin_organization_path(@organization.parent) %>
+        <%= render "admin/organizations/badge", organization: @organization %>
       </div>
       <% end -%>
 

--- a/app/views/admin/service_providers/index.html.erb
+++ b/app/views/admin/service_providers/index.html.erb
@@ -9,9 +9,8 @@
   <% end %>
 <% end %>
 
-<br>
 <div
-  class="usa-summary-box"
+  class="usa-summary-box margin-top-1"
   role="region"
   aria-labelledby="summary-box-key-information"
 >
@@ -42,7 +41,7 @@
   </div>
 </div>
 
-<div class="well">
+<div class="well margin-top-1">
   <div class="field">
     <%= label_tag :search_text, "Search by organization or name" %>
     <%= text_field_tag :search_text, nil, class: "usa-input" %>
@@ -69,7 +68,7 @@
 <p>
   <%= link_to admin_hisps_path(format: :csv), class: "usa-button usa-button--outline" do %>
     <i class="fa fa-download"></i>
-    Download hisps.csv
+    Export CSV
   <% end %> - used on <a href="https://performance.gov/cx/" target="_blank" rel="noopener">performance.gov/cx</a>
 </p>
 

--- a/app/views/components/_question_title.html.erb
+++ b/app/views/components/_question_title.html.erb
@@ -5,12 +5,14 @@
   <abbr title="required" class="usa-hint--required">*</abbr>
   <% end -%>
   <%- if question.help_text? %>
-  <p id="question-id-#{question.id}-help-text"
-    class="help-text">
+  <div
+    id="question-id-<%= question.id %>-help-text"
+    class="help-text margin-top-1"
+  >
     <small>
       <%= question.help_text %>
     </small>
-  </p>
+  </div>
   <% end %>
   <%- if local_assigns[:form_builder] && form_builder %>
   <span class="display-block">

--- a/app/views/components/_question_title_label.html.erb
+++ b/app/views/components/_question_title_label.html.erb
@@ -4,11 +4,14 @@
   <abbr title="required" class="usa-hint--required">*</abbr>
   <% end -%>
   <%- if question.help_text? %>
-  <p id="question-id-<%= question.id %>-help-text">
+  <div
+    id="question-id-<%= question.id %>-help-text"
+    class="help-text margin-top-1"
+  >
     <small>
       <%= question.help_text %>
     </small>
-  </p>
+  </div>
   <% end -%>
   <%- if local_assigns[:form_builder] && form_builder %>
   <span class="display-block">

--- a/app/views/components/_question_title_legend.html.erb
+++ b/app/views/components/_question_title_legend.html.erb
@@ -4,12 +4,14 @@
   <abbr title="required" class="usa-hint--required">*</abbr>
   <% end %>
   <%- if question.help_text? %>
-  <p id="question-id-#{question.id}-help-text"
-    class="help-text">
+  <div
+    id="question-id-<%= question.id %>-help-text"
+    class="help-text margin-top-1"
+  >
     <small>
       <%= question.help_text %>
     </small>
-  </p>
+  </div>
   <% end %>
   <%- if local_assigns[:form_builder] && form_builder %>
   <span class="display-block">

--- a/app/views/components/forms/question_types/_star_radio_buttons.html.erb
+++ b/app/views/components/forms/question_types/_star_radio_buttons.html.erb
@@ -10,7 +10,7 @@
     aria-describedby="<%= "question-id-#{question.id}-help-text" %>"
     <% end -%>
   >
-    <input value="0" id="<%= question.ui_selector %>_star0" checked type="radio" name="rating" hidden style="display: none;" hidden>
+    <input value="0" id="<%= question.ui_selector %>_star0" checked type="radio" name="rating" hidden style="display: none;">
     <label for="<%= question.ui_selector %>_star0"
       style="display: none;">
       <span hidden>0 Stars</span>

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -114,6 +114,7 @@ function FBAform(d, N) {
 		<%- if form.delivery_method == "modal" || form.delivery_method == "custom-button-modal" %>
 			this.dialogEl = document.createElement('div');
 			this.dialogEl.setAttribute("hidden", true);
+			this.dialogEl.setAttribute("aria-hidden", true);
 			this.dialogEl.setAttribute('class', 'fba-modal');
 
 			this.dialogEl.innerHTML = "<%= escape_javascript render(partial: 'components/widget/modal', locals: { form: form }) %>";

--- a/app/views/components/widget/_fba2.js.erb
+++ b/app/views/components/widget/_fba2.js.erb
@@ -650,18 +650,18 @@ function FBAform(d, N) {
 	};
 };
 
-// Create unique Touchpoints form object
-const touchpointForm<%= form.short_uuid %> = new FBAform(document, window).init({
-	'modalButtonText': "<%= form.modal_button_text %>",
+// Specify the options for your form
+const touchpointFormOptions<%= form.short_uuid %> = {
 	'formId': "<%= form.short_uuid %>",
+	'modalButtonText': "<%= form.modal_button_text %>",
 	'elementSelector': "<%= form.element_selector %>",
 	'css' : "<%= escape_javascript(render partial: 'components/widget/widget', formats: :css, locals: { form: form }) %>",
 	'loadCSS' : <%= form.load_css %>,
-	<%- if ["a11_v2", "a11_yes_no"].include?(form.kind) %>
 	'formSpecificScript' : function() {
+		<%- if ["a11_v2", "a11_yes_no"].include?(form.kind) %>
 		<%= render "components/form_#{form.kind}_script", form: form %>
+		<% end %>
 	},
-	<% end %>
 	'deliveryMethod' : "<%= form.delivery_method %>",
 	'successTextHeading' : "<%= escape_javascript(form.success_text_heading) %>",
 	'successText' : "<%= escape_javascript(sanitize(form.success_text)) %>",
@@ -670,8 +670,7 @@ const touchpointForm<%= form.short_uuid %> = new FBAform(document, window).init(
 		return {
 		<% form.questions.each do |question| %>
 			<% next unless question_type_javascript_params(question).present? %>
-			<%= question.answer_field %>:
-			<%= raw question_type_javascript_params(question) %>,
+			<%= question.answer_field %> : <%= raw question_type_javascript_params(question) %>,
 		<% end %>
 		}
 	},
@@ -690,5 +689,8 @@ const touchpointForm<%= form.short_uuid %> = new FBAform(document, window).init(
 		<% else %>
 		return null;
 		<% end %>
-	},
-});
+	}
+}
+
+// Create an instance of a Touchpoints form object
+const touchpointForm<%= form.short_uuid %> = new FBAform(document, window).init(touchpointFormOptions<%= form.short_uuid %>);

--- a/app/views/components/widget/_fba2.js.erb
+++ b/app/views/components/widget/_fba2.js.erb
@@ -101,6 +101,7 @@ function FBAform(d, N) {
 		if (this.options.deliveryMethod && (this.options.deliveryMethod === 'modal' || this.options.deliveryMethod === 'custom-button-modal')) {
 			this.dialogEl = d.createElement('div');
 			this.dialogEl.setAttribute("hidden", true);
+			this.dialogEl.setAttribute("aria-hidden", true);
 			this.dialogEl.setAttribute('class', 'fba-modal');
 			this.dialogEl.setAttribute('data-touchpoints-form-id', this.options.formId);
 

--- a/app/views/user_mailer/user_reactivation_email.html.erb
+++ b/app/views/user_mailer/user_reactivation_email.html.erb
@@ -5,7 +5,9 @@
 <p>
 Touchpoints accounts are automatically inactivated
 after 30 days without login, per security policy.
-But, your Touchpoints account has now been reactivated.
+But, your
+<a href="https://touchpoints.digital.gov/">Touchpoints</a>
+account has now been reactivated.
 </p>
 <p>
 Any questions, please us know,
@@ -14,9 +16,8 @@ Any questions, please us know,
 --
 <br>
 
-<a href="https://touchpoints.digital.gov/">
-  Touchpoints Team
-</a>
+
+Touchpoints Team
 <br>
 Feedback Analytics Program
 <br>

--- a/app/views/user_mailer/user_reactivation_email.text.erb
+++ b/app/views/user_mailer/user_reactivation_email.text.erb
@@ -4,6 +4,8 @@ Touchpoints accounts are automatically inactivated
 after 30 days without login, per security policy.
 But, your Touchpoints account has now been reactivated.
 
+Login at: https://touchpoints.digital.gov
+
 Any questions, please us know,
 
 --

--- a/spec/controllers/touchpoints_controller_spec.rb
+++ b/spec/controllers/touchpoints_controller_spec.rb
@@ -57,7 +57,7 @@ describe TouchpointsController, type: :controller do
     it 'returns a success response' do
       get :js, params: { id: form.short_uuid }, session: valid_session
       expect(response.body).to include('use strict')
-      expect(response.body).to include('Create unique Touchpoints form object')
+      expect(response.body).to include('// Create an instance of a Touchpoints form object')
     end
   end
 
@@ -74,7 +74,7 @@ describe TouchpointsController, type: :controller do
     it 'returns a success response' do
       get :show, params: { id: form.short_uuid }, session: valid_session, format: :js
       expect(response.body).to include('use strict')
-      expect(response.body).to include('Create unique Touchpoints form object')
+      expect(response.body).to include('// Create an instance of a Touchpoints form object')
     end
   end
 

--- a/spec/features/admin/service_providers_spec.rb
+++ b/spec/features/admin/service_providers_spec.rb
@@ -25,7 +25,7 @@ feature 'Service Provider', js: true do
         expect(page).to have_content('Service Providers')
         expect(page.current_path).to eq(admin_service_providers_path)
         expect(page).to have_content(service_provider.name)
-        expect(page).to have_content('Download hisps.csv')
+        expect(page).to have_content('Export CSV')
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -164,4 +164,38 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#ensure_organization" do
+    before do
+      @org2 = Organization.create(name: "Subdomain Example", domain: "sub.example.gov", abbreviation: "SUB")
+    end
+
+    it 'handles top-level domains' do
+      @user.email = "user@example.gov"
+      @user.save!
+      expect(@user.organization).to eq(organization)
+    end
+
+    it 'respects subdomains' do
+      @user2 = User.new
+      @user2.email = "user@sub.example.gov"
+      @user2.save!
+      expect(@user2.organization).to eq(@org2)
+    end
+
+    it 'matches by top-level domain if subdomain does not exist' do
+      @user3 = User.new
+      @user3.email = "user@another.example.gov"
+      expect(@user3.save!).to eq(true)
+      expect(@user3.organization).to eq(organization)
+    end
+
+    it 'throws error if an org does not exist with the email' do
+      @user4 = User.new
+      @user4.email = "user@nonexistent.gov"
+      expect do
+        @user4.save!
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end


### PR DESCRIPTION
* define form options as an object, then pass it to the function
  * makes it easier for users to learn how to create and modify their own forms
* make export button consistent