### PR TITLE
Match original modal styling better

### DIFF
--- a/app/views/components/widget/_modal.html.erb
+++ b/app/views/components/widget/_modal.html.erb
@@ -12,10 +12,11 @@
 <% else %>
   <div
     class="<%= form.prefix "usa-modal__content" %> fba-modal-dialog">
-    <div class="<%= form.prefix "usa-modal__main" %>">
-      <%= render "components/widget/no_modal", form: form do %>
-        <%= render partial: 'components/forms/footer', locals: { form: form } %>
-      <% end %>
+    <div>
+      <div class="<%= form.prefix "usa-modal__main" %> padding-bottom-0">
+        <%= render "components/widget/no_modal", form: form %>
+      </div>
+      <%= render partial: 'components/forms/footer', locals: { form: form } %>
     </div>
     <%- unless form.delivery_method == "inline" %>
       <button class="<%= form.prefix "usa-modal__close" %> fba-modal-close"

--- a/app/views/components/widget/_modal.html.erb
+++ b/app/views/components/widget/_modal.html.erb
@@ -19,11 +19,16 @@
       <%= render partial: 'components/forms/footer', locals: { form: form } %>
     </div>
     <%- unless form.delivery_method == "inline" %>
-      <button class="<%= form.prefix "usa-modal__close" %> fba-modal-close"
+      <button class="<%= form.prefix "usa-modal__close" %> usa-button fba-modal-close"
               type="button"
               aria-label="Close this window"
               data-close-modal
-      >×</button>
+      >
+        <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+          <%# close icon %>
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
+        </svg>
+      </button>
     <% end -%>
   </div>
 <% end %>

--- a/app/views/components/widget/_modal.html.erb
+++ b/app/views/components/widget/_modal.html.erb
@@ -13,7 +13,7 @@
   <div
     class="<%= form.prefix "usa-modal__content" %> fba-modal-dialog">
     <div>
-      <div class="<%= form.prefix "usa-modal__main" %> padding-bottom-0">
+      <div class="<%= form.prefix "usa-modal__main" %> padding-bottom-0 padding-top-0">
         <%= render "components/widget/no_modal", form: form %>
       </div>
       <%= render partial: 'components/forms/footer', locals: { form: form } %>

--- a/app/views/components/widget/_widget-uswds-styles.css.erb
+++ b/app/views/components/widget/_widget-uswds-styles.css.erb
@@ -106,7 +106,7 @@
   pointer-events:none !important;
 }
 
-.fba-usa-modal__close{
+.fba-modal .fba-usa-modal__content .fba-usa-modal__close{
   align-items:center;
   align-self:flex-end;
   background-color:transparent;
@@ -118,14 +118,14 @@
   padding:0.25rem 0.25rem;
   width:auto;
 }
-.fba-usa-modal__close:hover, .fba-usa-modal__close:active{
+.fba-modal .fba-usa-modal__content .fba-usa-modal__close:hover, .fba-modal .fba-usa-modal__content .fba-usa-modal__close:active{
   background-color:transparent;
   color:#1b1b1b;
 }
-.fba-usa-modal__close:focus{
+.fba-modal .fba-usa-modal__content .fba-usa-modal__close:focus{
   outline-offset:0;
 }
-.fba-usa-modal__close .usa-icon{
+.fba-modal .fba-usa-modal__content .fba-usa-modal__close .usa-icon{
   height:2rem;
   margin:2px 2px 0 0;
   width:2rem;

--- a/app/views/components/widget/_widget-uswds-styles.css.erb
+++ b/app/views/components/widget/_widget-uswds-styles.css.erb
@@ -79,7 +79,7 @@
   color:#1b1b1b;
   display:inline-block;
   margin:1.25rem auto;
-  max-width:30rem;
+  max-width:35rem;
   position:relative;
   text-align:left;
   vertical-align:middle;
@@ -183,7 +183,7 @@
   display:block;
   height:2.5rem;
   margin-top:0.5rem;
-  max-width:30rem;
+  max-width:none;
   padding:0.5rem;
   width:100%;
 }
@@ -1820,7 +1820,7 @@
   background-size:1.5rem;
 }
 .fba-modal-dialog .usa-combo-box{
-  max-width:30rem;
+  max-width:none;
   position:relative;
 }
 .fba-modal-dialog .usa-combo-box--pristine .usa-combo-box__input{
@@ -2037,7 +2037,7 @@
 .fba-modal-dialog .usa-date-picker__wrapper{
   display:none;
   position:relative;
-  max-width:30rem;
+  max-width:none;
 }
 .fba-modal-dialog .usa-date-picker__wrapper:focus{
   outline:0;
@@ -4041,7 +4041,7 @@
   display:block;
   font-weight:normal;
   margin-top:1.5rem;
-  max-width:30rem;
+  max-width:none;
 }
 .fba-modal-dialog .usa-label--error{
   font-weight:700;
@@ -4057,7 +4057,7 @@
   display:block;
   font-weight:normal;
   margin-top:1.5rem;
-  max-width:30rem;
+  max-width:none;
 }
 .fba-modal-dialog .usa-legend--large{
   font-size:2.13rem;

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -1155,5 +1155,13 @@
 }
 
 .fba-modal-dialog .padding-bottom-0 {
-    padding-bottom:0;
+  padding-bottom:0;
+}
+
+.fba-modal-dialog .padding-top-0 {
+  padding-top:0;
+}
+
+.fba-modal-dialog .touchpoints-form-wrapper .usa-form {
+  max-width: 100%;
 }

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -1153,3 +1153,7 @@
 .fba-modal-dialog .display-none{
   display:none;
 }
+
+.fba-modal-dialog .padding-bottom-0 {
+    padding-bottom:0;
+}

--- a/uswds/widget-uswds-styles.scss
+++ b/uswds/widget-uswds-styles.scss
@@ -4,6 +4,8 @@
   // True means set box-sizing on the html element, false means set it per element as necessary.
   // Set to false since the embedded widget does not control the html element.
   $theme-global-border-box-sizing: false,
+  // Let input elements take the full width of the form.
+  $theme-input-max-width: "none"
 );
 @use "sass:meta";
 

--- a/uswds/widget-uswds-styles/_prefixed-usa-modal.scss
+++ b/uswds/widget-uswds-styles/_prefixed-usa-modal.scss
@@ -87,7 +87,7 @@
   @include set-text-from-bg("white");
   display: inline-block;
   margin: units(2.5) auto;
-  max-width: units($theme-modal-default-max-width);
+  max-width: 35rem;
   position: relative;
   text-align: left;
   vertical-align: middle;

--- a/uswds/widget-uswds-styles/_prefixed-usa-modal.scss
+++ b/uswds/widget-uswds-styles/_prefixed-usa-modal.scss
@@ -116,32 +116,36 @@
   pointer-events: none !important;
 }
 
-.fba-usa-modal__close {
-  align-items: center;
-  align-self: flex-end;
-  background-color: transparent;
-  color: color("base");
-  display: flex;
-  flex-shrink: 0;
-  font-size: size("ui", "2xs");
-  margin: units(-4) 0 0 auto;
-  padding: units(0.5) units(0.5);
-  width: auto;
+.fba-modal {
+  .fba-usa-modal__content {
+    .fba-usa-modal__close {
+      align-items: center;
+      align-self: flex-end;
+      background-color: transparent;
+      color: color("base");
+      display: flex;
+      flex-shrink: 0;
+      font-size: size("ui", "2xs");
+      margin: units(-4) 0 0 auto;
+      padding: units(0.5) units(0.5);
+      width: auto;
 
-  &:hover,
-  &:active {
-    background-color: transparent;
-    color: color("ink");
-  }
+      &:hover,
+      &:active {
+        background-color: transparent;
+        color: color("ink");
+      }
 
-  &:focus {
-    outline-offset: 0;
-  }
+      &:focus {
+        outline-offset: 0;
+      }
 
-  .usa-icon {
-    height: units(4);
-    margin: units(2px) units(2px) 0 0;
-    width: units(4);
+      .usa-icon {
+        height: units(4);
+        margin: units(2px) units(2px) 0 0;
+        width: units(4);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Three styling changes in this PR:

Modal close button now looks like the close button in the USWDS modal examples.
<img width="719" alt="Screenshot 2024-08-14 at 10 44 06 AM" src="https://github.com/user-attachments/assets/9147fd40-4ecf-4ea9-b46d-32f894121bad">

The modal footer has no padding.
<img width="675" alt="Screenshot 2024-08-14 at 10 45 04 AM" src="https://github.com/user-attachments/assets/4a536a8f-88aa-4888-af5a-d2ec780f702f">

The max-width of the modal increased from size 'mobile-lg' (30 rem) to a manually hard-coded 35rem (not a USWDS spacing unit), to match the original modal.
<img width="676" alt="Screenshot 2024-08-14 at 11 39 58 AM" src="https://github.com/user-attachments/assets/e73b365f-d0d8-477b-bb03-268806daa4f0">

