### PR TITLE
Disable USWDS-based version of embedded modal for all forms.

### DIFF
--- a/db/migrate/20240815183449_enable_legacy_form_embed_for_all_forms.rb
+++ b/db/migrate/20240815183449_enable_legacy_form_embed_for_all_forms.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Feature flag migration to accompany release of USWDS-based modal
+class EnableLegacyFormEmbedForAllForms < ActiveRecord::Migration[7.1]
+  def up
+    execute 'UPDATE forms SET legacy_form_embed = TRUE'
+  end
+
+  def down
+    execute 'UPDATE forms SET legacy_form_embed = FALSE'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_23_192756) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_15_183449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Start the roll-out of the USWDS embedded modal by setting all forms to _not_ use the USWDS-based version, until I've done some testing of the new code on existing forms in production.