### PR TITLE
update all remove tag links with a partial

### DIFF
--- a/app/views/admin/digital_products/_organizations.html.erb
+++ b/app/views/admin/digital_products/_organizations.html.erb
@@ -20,13 +20,10 @@
         </span>
 
         <%- if digital_product_permissions?(digital_product: digital_product, user: current_user) %>
-        <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= agency.id %>">
-          <span class="fa fa-trash">
-            <span class="usa-sr-only">
-              Delete
-            </span>
-          </span>
-        </a>
+          <%= render "components/remove_tag_link",
+            klass: "remove-tag-link",
+            value: agency.id %>
+          <% end %>
         <% end %>
       </li>
       <% end %>

--- a/app/views/admin/digital_products/_organizations.html.erb
+++ b/app/views/admin/digital_products/_organizations.html.erb
@@ -52,7 +52,7 @@
       var container = $('#sponsoring-agencies-div');
       $.ajax({
         url: container.attr("data-value") + "/remove_organization",
-        type: 'post',
+        type: 'delete',
         data: "organization_id=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/digital_products/_organizations.html.erb
+++ b/app/views/admin/digital_products/_organizations.html.erb
@@ -20,10 +20,9 @@
         </span>
 
         <%- if digital_product_permissions?(digital_product: digital_product, user: current_user) %>
-          <%= render "components/remove_tag_link",
-            klass: "remove-tag-link",
-            value: agency.id %>
-          <% end %>
+        <%= render "components/remove_tag_link",
+          klass: "remove-tag-link",
+          value: agency.id %>
         <% end %>
       </li>
       <% end %>

--- a/app/views/admin/digital_products/_tags.html.erb
+++ b/app/views/admin/digital_products/_tags.html.erb
@@ -24,13 +24,10 @@
               <%= tag %>
             </span>
             <%- if digital_product_permissions?(digital_product: digital_product, user: current_user) %>
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+              <%= render "components/remove_tag_link",
+                klass: "remove-tag-link",
+                value: tag %>
+              <% end %>
             <% end %>
           </li>
           <% end %>

--- a/app/views/admin/digital_products/_tags.html.erb
+++ b/app/views/admin/digital_products/_tags.html.erb
@@ -68,7 +68,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "digital_product[tag_list]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/digital_products/_tags.html.erb
+++ b/app/views/admin/digital_products/_tags.html.erb
@@ -24,10 +24,9 @@
               <%= tag %>
             </span>
             <%- if digital_product_permissions?(digital_product: digital_product, user: current_user) %>
-              <%= render "components/remove_tag_link",
-                klass: "remove-tag-link",
-                value: tag %>
-              <% end %>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: tag %>
             <% end %>
           </li>
           <% end %>

--- a/app/views/admin/digital_products/_users.html.erb
+++ b/app/views/admin/digital_products/_users.html.erb
@@ -21,7 +21,6 @@
           klass: "remove-tag-link",
           value: user.id %>
         <% end %>
-        <% end %>
       </li>
       <% end %>
       <% end %>

--- a/app/views/admin/digital_products/_users.html.erb
+++ b/app/views/admin/digital_products/_users.html.erb
@@ -53,8 +53,8 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_user",
-        type: 'post',
-        data: "user[id]=" + $(this).data("id")
+        type: 'delete',
+        data: "user[id]=" + $(this).data("value")
       });
     });
   });

--- a/app/views/admin/digital_products/_users.html.erb
+++ b/app/views/admin/digital_products/_users.html.erb
@@ -17,13 +17,10 @@
           <%= user.email %>
         </span>
         <%- if digital_product_permissions?(digital_product: digital_product, user: current_user) %>
-        <a href="javascript:void(0);" class="remove-tag-link" data-id="<%= user.id %>">
-          <span class="fa fa-trash">
-            <span class="usa-sr-only">
-              Delete
-            </span>
-          </span>
-        </a>
+        <%= render "components/remove_tag_link",
+          klass: "remove-tag-link",
+          value: user.id %>
+        <% end %>
         <% end %>
       </li>
       <% end %>

--- a/app/views/admin/digital_service_accounts/_organizations.html.erb
+++ b/app/views/admin/digital_service_accounts/_organizations.html.erb
@@ -52,7 +52,7 @@
       var container = $('#sponsoring-agencies-div');
       $.ajax({
         url: container.attr("data-value") + "/remove_organization",
-        type: 'post',
+        type: 'delete',
         data: "organization_id=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/digital_service_accounts/_organizations.html.erb
+++ b/app/views/admin/digital_service_accounts/_organizations.html.erb
@@ -20,13 +20,10 @@
         </span>
 
         <%- if digital_service_account_permissions?(digital_service_account: @digital_service_account, user: current_user) %>
-        <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= agency.id %>">
-          <span class="fa fa-trash">
-            <span class="usa-sr-only">
-              Delete
-            </span>
-          </span>
-        </a>
+        <%= render "components/remove_tag_link",
+            klass: "remove-tag-link",
+            value: agency.id %>
+          <% end %>
         <% end %>
       </li>
       <% end %>

--- a/app/views/admin/digital_service_accounts/_organizations.html.erb
+++ b/app/views/admin/digital_service_accounts/_organizations.html.erb
@@ -23,7 +23,6 @@
         <%= render "components/remove_tag_link",
             klass: "remove-tag-link",
             value: agency.id %>
-          <% end %>
         <% end %>
       </li>
       <% end %>

--- a/app/views/admin/digital_service_accounts/_tags.html.erb
+++ b/app/views/admin/digital_service_accounts/_tags.html.erb
@@ -28,6 +28,7 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
+            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/digital_service_accounts/_tags.html.erb
+++ b/app/views/admin/digital_service_accounts/_tags.html.erb
@@ -63,7 +63,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "digital_service_account[tag_list]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/digital_service_accounts/_tags.html.erb
+++ b/app/views/admin/digital_service_accounts/_tags.html.erb
@@ -28,7 +28,6 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
-            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/digital_service_accounts/_users.html.erb
+++ b/app/views/admin/digital_service_accounts/_users.html.erb
@@ -17,13 +17,11 @@
           <%= user.email %>
         </span>
         <%- if digital_service_account_permissions?(digital_service_account: digital_service_account, user: current_user) %>
-        <a href="javascript:void(0);" class="remove-tag-link" data-id="<%= user.id %>">
-          <span class="fa fa-trash">
-            <span class="usa-sr-only">
-              Delete
-            </span>
-          </span>
-        </a>
+        <%= render "components/remove_tag_link",
+          klass: "remove-tag-link",
+          value: user.id %>
+        <% end %>
+
         <% end %>
       </li>
       <% end %>

--- a/app/views/admin/digital_service_accounts/_users.html.erb
+++ b/app/views/admin/digital_service_accounts/_users.html.erb
@@ -20,7 +20,6 @@
         <%= render "components/remove_tag_link",
           klass: "remove-tag-link",
           value: user.id %>
-        <% end %>
       </li>
       <% end %>
       <% end %>

--- a/app/views/admin/digital_service_accounts/_users.html.erb
+++ b/app/views/admin/digital_service_accounts/_users.html.erb
@@ -20,6 +20,7 @@
         <%= render "components/remove_tag_link",
           klass: "remove-tag-link",
           value: user.id %>
+        <% end %>
       </li>
       <% end %>
       <% end %>

--- a/app/views/admin/digital_service_accounts/_users.html.erb
+++ b/app/views/admin/digital_service_accounts/_users.html.erb
@@ -53,8 +53,8 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_user",
-        type: 'post',
-        data: "user[id]=" + $(this).data("id")
+        type: 'delete',
+        data: "user[id]=" + $(this).data("value")
       });
     });
   });

--- a/app/views/admin/digital_service_accounts/_users.html.erb
+++ b/app/views/admin/digital_service_accounts/_users.html.erb
@@ -21,8 +21,6 @@
           klass: "remove-tag-link",
           value: user.id %>
         <% end %>
-
-        <% end %>
       </li>
       <% end %>
       <% end %>

--- a/app/views/admin/forms/_tags.html.erb
+++ b/app/views/admin/forms/_tags.html.erb
@@ -10,13 +10,10 @@
           <span class="usa-tag">
             <%= tag %>
           </span>
-          <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-            <span class="fa fa-trash">
-              <span class="usa-sr-only">
-                Delete
-              </span>
-            </span>
-          </a>
+          <%= render "components/remove_tag_link",
+            klass: "remove-tag-link",
+            value: tag %>
+          <% end %>
         </li>
         <% end %>
       </ul>

--- a/app/views/admin/forms/_tags.html.erb
+++ b/app/views/admin/forms/_tags.html.erb
@@ -13,7 +13,6 @@
           <%= render "components/remove_tag_link",
             klass: "remove-tag-link",
             value: tag %>
-          <% end %>
         </li>
         <% end %>
       </ul>

--- a/app/views/admin/forms/_tags.html.erb
+++ b/app/views/admin/forms/_tags.html.erb
@@ -47,7 +47,7 @@
 
       $.ajax({
         url: pageUrl + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "form[tag_list]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/goals/_organizations.html.erb
+++ b/app/views/admin/goals/_organizations.html.erb
@@ -45,7 +45,7 @@
       var container = $('#sponsoring-agencies-div');
       $.ajax({
         url: container.attr("data-value") + "/remove_organization",
-        type: 'post',
+        type: 'delete',
         data: "organization_id=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/goals/_organizations.html.erb
+++ b/app/views/admin/goals/_organizations.html.erb
@@ -13,13 +13,10 @@
             <%= agency.name %>
           </span>
           &nbsp;
-          <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= agency.id %>">
-            <span class="fa fa-trash">
-              <span class="usa-sr-only">
-                Delete
-              </span>
-            </span>
-          </a>
+          <%= render "components/remove_tag_link",
+            klass: "remove-tag-link",
+            value: agency.id %>
+          <% end %>
         </li>
           <% end %>
       </ul>

--- a/app/views/admin/goals/_organizations.html.erb
+++ b/app/views/admin/goals/_organizations.html.erb
@@ -16,9 +16,8 @@
           <%= render "components/remove_tag_link",
             klass: "remove-tag-link",
             value: agency.id %>
-          <% end %>
         </li>
-          <% end %>
+        <% end %>
       </ul>
     </p>
   </div>

--- a/app/views/admin/goals/_tags.html.erb
+++ b/app/views/admin/goals/_tags.html.erb
@@ -21,7 +21,6 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
-            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/goals/_tags.html.erb
+++ b/app/views/admin/goals/_tags.html.erb
@@ -49,7 +49,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "goal[tag_list]=" + encodeURIComponent($(this).attr("data-value"))
       });
     })

--- a/app/views/admin/goals/_tags.html.erb
+++ b/app/views/admin/goals/_tags.html.erb
@@ -18,13 +18,10 @@
             <span class="usa-tag">
               <%= tag %>
             </span>
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: tag %>
+            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/objectives/_tags.html.erb
+++ b/app/views/admin/objectives/_tags.html.erb
@@ -21,7 +21,6 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
-            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/objectives/_tags.html.erb
+++ b/app/views/admin/objectives/_tags.html.erb
@@ -49,7 +49,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "objective[tag_list]=" + encodeURIComponent($(this).attr("data-value"))
       });
     });

--- a/app/views/admin/objectives/_tags.html.erb
+++ b/app/views/admin/objectives/_tags.html.erb
@@ -18,13 +18,10 @@
             <span class="usa-tag">
               <%= tag %>
             </span>
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: tag %>
+            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/offerings/_offering_personas.html.erb
+++ b/app/views/admin/offerings/_offering_personas.html.erb
@@ -51,7 +51,7 @@
       var container = $('#offering-personas-div');
       $.ajax({
         url: container.attr("data-value") + "/remove_offering_persona",
-        type: 'post',
+        type: 'delete',
         data: "persona_id=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/organizations/_tags.html.erb
+++ b/app/views/admin/organizations/_tags.html.erb
@@ -13,7 +13,6 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
-            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/organizations/_tags.html.erb
+++ b/app/views/admin/organizations/_tags.html.erb
@@ -10,9 +10,10 @@
             <span class="usa-tag">
               <%= tag %>
             </span>
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-              <span class="fa fa-trash"></span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: tag %>
+            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/organizations/_tags.html.erb
+++ b/app/views/admin/organizations/_tags.html.erb
@@ -48,7 +48,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "organization[tag_list]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/personas/_tags.html.erb
+++ b/app/views/admin/personas/_tags.html.erb
@@ -48,7 +48,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "persona[tag_list]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/personas/_tags.html.erb
+++ b/app/views/admin/personas/_tags.html.erb
@@ -12,13 +12,10 @@
             <span class="usa-tag">
               <%= tag %>
             </span>
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: tag %>
+            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/personas/_tags.html.erb
+++ b/app/views/admin/personas/_tags.html.erb
@@ -15,7 +15,6 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
-            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/service_providers/_service_provider_managers.html.erb
+++ b/app/views/admin/service_providers/_service_provider_managers.html.erb
@@ -13,9 +13,8 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: manager.id %>
-            <% end %>
           </li>
-            <% end %>
+          <% end %>
         </ul>
       </p>
       <%= select_tag :service_manager_id,

--- a/app/views/admin/service_providers/_service_provider_managers.html.erb
+++ b/app/views/admin/service_providers/_service_provider_managers.html.erb
@@ -10,13 +10,10 @@
               <%= manager.email %>
             </span>
             &nbsp;
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= manager.id %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: manager.id %>
+            <% end %>
           </li>
             <% end %>
         </ul>

--- a/app/views/admin/service_providers/_service_provider_managers.html.erb
+++ b/app/views/admin/service_providers/_service_provider_managers.html.erb
@@ -46,7 +46,7 @@
       var thisForm = $("#service_provider_selector");
       $.ajax({
         url: thisForm.attr("data-url") + "/remove_service_provider_manager",
-        type: 'POST',
+        type: 'delete',
         datatype: "json",
         data: {
           user_id: $(this).attr("data-value")

--- a/app/views/admin/service_providers/_tags.html.erb
+++ b/app/views/admin/service_providers/_tags.html.erb
@@ -53,7 +53,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "service_provider[tag_list]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/service_providers/_tags.html.erb
+++ b/app/views/admin/service_providers/_tags.html.erb
@@ -14,9 +14,10 @@
           <span class="usa-tag">
             <%= tag %>
           </span>
-          <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-            <span class="fa fa-trash"></span>
-          </a>
+          <%= render "components/remove_tag_link",
+            klass: "remove-tag-link",
+            value: tag %>
+          <% end %>
         </li>
         <% end %>
       </ul>

--- a/app/views/admin/service_providers/_tags.html.erb
+++ b/app/views/admin/service_providers/_tags.html.erb
@@ -17,7 +17,6 @@
           <%= render "components/remove_tag_link",
             klass: "remove-tag-link",
             value: tag %>
-          <% end %>
         </li>
         <% end %>
       </ul>

--- a/app/views/admin/services/_channels.html.erb
+++ b/app/views/admin/services/_channels.html.erb
@@ -48,7 +48,7 @@
       var thisForm = $("#channel_selector");
       $.ajax({
         url: thisForm.attr("data-url") + "/remove_channel",
-        type: 'POST',
+        type: 'delete',
         datatype: 'json',
         data: {
           channel: $(this).attr("data-value")

--- a/app/views/admin/services/_channels.html.erb
+++ b/app/views/admin/services/_channels.html.erb
@@ -17,9 +17,8 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: channel %>
-            <% end %>
           </li>
-            <% end %>
+          <% end %>
         </ul>
       </p>
     </div>

--- a/app/views/admin/services/_channels.html.erb
+++ b/app/views/admin/services/_channels.html.erb
@@ -14,13 +14,10 @@
                <%= channel %>
             </span>
             &nbsp;
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= channel %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: channel %>
+            <% end %>
           </li>
             <% end %>
         </ul>

--- a/app/views/admin/services/_service_managers.html.erb
+++ b/app/views/admin/services/_service_managers.html.erb
@@ -44,7 +44,7 @@
       var thisForm = $("#service_manager_selector");
       $.ajax({
         url: thisForm.attr("data-url") + "/remove_service_manager",
-        type: 'POST',
+        type: 'delete',
         datatype: 'json',
         data: {
           user_id: $(this).attr("data-value")

--- a/app/views/admin/services/_service_managers.html.erb
+++ b/app/views/admin/services/_service_managers.html.erb
@@ -13,9 +13,8 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: manager.id %>
-            <% end %>
           </li>
-            <% end %>
+          <% end %>
         </ul>
       </p>
     </div>

--- a/app/views/admin/services/_service_managers.html.erb
+++ b/app/views/admin/services/_service_managers.html.erb
@@ -10,13 +10,10 @@
                <%= manager.email %>
             </span>
             &nbsp;
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= manager.id %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: manager.id %>
+            <% end %>
           </li>
             <% end %>
         </ul>

--- a/app/views/admin/services/_tags.html.erb
+++ b/app/views/admin/services/_tags.html.erb
@@ -18,13 +18,10 @@
             <span class="usa-tag">
               <%= tag %>
             </span>
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: tag %>
+            <% end %>
           </li>
             <% end %>
         </ul>

--- a/app/views/admin/services/_tags.html.erb
+++ b/app/views/admin/services/_tags.html.erb
@@ -56,7 +56,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "service[tag_list]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/services/_tags.html.erb
+++ b/app/views/admin/services/_tags.html.erb
@@ -21,9 +21,8 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
-            <% end %>
           </li>
-            <% end %>
+          <% end %>
         </ul>
       </div>
     </div>

--- a/app/views/admin/submissions/_tags.html.erb
+++ b/app/views/admin/submissions/_tags.html.erb
@@ -75,7 +75,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "submission[tag]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/submissions/_tags.html.erb
+++ b/app/views/admin/submissions/_tags.html.erb
@@ -17,7 +17,6 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
-            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/submissions/_tags.html.erb
+++ b/app/views/admin/submissions/_tags.html.erb
@@ -14,13 +14,10 @@
             <span class="usa-tag">
               <%= tag %>
             </span>
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: tag %>
+            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/websites/_tags.html.erb
+++ b/app/views/admin/websites/_tags.html.erb
@@ -12,13 +12,10 @@
             <span class="usa-tag">
               <%= tag %>
             </span>
-            <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= tag %>">
-              <span class="fa fa-trash">
-                <span class="usa-sr-only">
-                  Delete
-                </span>
-              </span>
-            </a>
+            <%= render "components/remove_tag_link",
+              klass: "remove-tag-link",
+              value: tag %>
+            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/websites/_tags.html.erb
+++ b/app/views/admin/websites/_tags.html.erb
@@ -15,7 +15,6 @@
             <%= render "components/remove_tag_link",
               klass: "remove-tag-link",
               value: tag %>
-            <% end %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/websites/_tags.html.erb
+++ b/app/views/admin/websites/_tags.html.erb
@@ -47,7 +47,7 @@
       var thisForm = $(this).closest("form");
       $.ajax({
         url: thisForm.attr("action") + "/remove_tag",
-        type: 'post',
+        type: 'delete',
         data: "website[tag_list]=" + $(this).attr("data-value")
       });
     });

--- a/app/views/admin/websites/_website_managers.html.erb
+++ b/app/views/admin/websites/_website_managers.html.erb
@@ -20,9 +20,8 @@
           <%= render "components/remove_tag_link",
             klass: "remove-tag-link",
             value: manager.id %>
-          <% end %>
         </li>
-          <% end %>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/app/views/admin/websites/_website_managers.html.erb
+++ b/app/views/admin/websites/_website_managers.html.erb
@@ -17,9 +17,10 @@
             <%= manager.email %>
           </span>
           &nbsp;
-          <a href="javascript:void(0);" class="remove-tag-link" data-value="<%= manager.id %>">
-            <span class="fa fa-trash"></span>
-          </a>
+          <%= render "components/remove_tag_link",
+            klass: "remove-tag-link",
+            value: manager.id %>
+          <% end %>
         </li>
           <% end %>
       </ul>
@@ -27,9 +28,9 @@
   </div>
 </div>
 
-<%= select_tag :website_manager_id, 
-  options_for_select(@website_manager_options.map { |u| [u.email, u.id] }), 
-  prompt: "Select a User", 
+<%= select_tag :website_manager_id,
+  options_for_select(@website_manager_options.map { |u| [u.email, u.id] }),
+  prompt: "Select a User",
   class: "usa-select add-website-manager" %>
 
 <script>

--- a/app/views/admin/websites/_website_personas.html.erb
+++ b/app/views/admin/websites/_website_personas.html.erb
@@ -17,7 +17,7 @@
             klass: "remove-persona-link",
             value: persona.id %>
         </li>
-          <% end %>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/app/views/admin/websites/_website_personas.html.erb
+++ b/app/views/admin/websites/_website_personas.html.erb
@@ -45,7 +45,7 @@
       var container = $('#website-personas-div');
       $.ajax({
         url: container.attr("data-value") + "/remove_website_persona",
-        type: 'post',
+        type: 'delete',
         data: "persona_id=" + $(this).attr("data-value")
       });
     });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,7 +284,7 @@ Rails.application.routes.draw do
         post 'remove_organization', to: 'digital_service_accounts#remove_organization', as: :remove_organization
 
         post 'add_user', to: 'digital_service_accounts#add_user', as: :add_user
-        post 'remove_user', to: 'digital_service_accounts#remove_user', as: :remove_user
+        delete 'remove_user', to: 'digital_service_accounts#remove_user', as: :remove_user
       end
     end
 
@@ -306,7 +306,7 @@ Rails.application.routes.draw do
         post 'remove_organization', to: 'digital_products#remove_organization', as: :remove_organization
 
         post 'add_user', to: 'digital_products#add_user', as: :add_user
-        post 'remove_user', to: 'digital_products#remove_user', as: :remove_user
+        delete 'remove_user', to: 'digital_products#remove_user', as: :remove_user
       end
       resources :digital_product_versions
       resources :digital_product_platforms

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,9 +104,9 @@ Rails.application.routes.draw do
       end
       member do
         post 'add_tag', to: 'service_providers#add_tag', as: :add_tag
-        post 'remove_tag', to: 'service_providers#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'service_providers#remove_tag', as: :remove_tag
         post 'add_service_provider_manager', to: 'service_providers#add_service_provider_manager', as: :add_service_provider_manager
-        post 'remove_service_provider_manager', to: 'service_providers#remove_service_provider_manager', as: :remove_service_provider_manager
+        delete 'remove_service_provider_manager', to: 'service_providers#remove_service_provider_manager', as: :remove_service_provider_manager
       end
     end
     resources :cx_action_plans
@@ -120,12 +120,12 @@ Rails.application.routes.draw do
         get 'equity-assessment', to: 'services#equity_assessment', as: :equity_assessment
         get 'cx-reporting', to: 'services#omb_cx_reporting', as: :omb_cx_reporting
         post 'add_tag', to: 'services#add_tag', as: :add_tag
-        post 'remove_tag', to: 'services#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'services#remove_tag', as: :remove_tag
         post 'add_channel', to: 'services#add_channel', as: :add_channel
-        post 'remove_channel', to: 'services#remove_channel', as: :remove_channel
+        delete 'remove_channel', to: 'services#remove_channel', as: :remove_channel
 
         post 'add_service_manager', to: 'services#add_service_manager', as: :add_service_manager
-        post 'remove_service_manager', to: 'services#remove_service_manager', as: :remove_service_manager
+        delete 'remove_service_manager', to: 'services#remove_service_manager', as: :remove_service_manager
 
         post 'submit', to: 'services#submit', as: :submit
         post 'approve', to: 'services#approve', as: :approve
@@ -213,7 +213,7 @@ Rails.application.routes.draw do
         get 'targets', to: 'goals#goal_targets', as: :targets
         get 'goal_objectives', to: 'goals#goal_objectives', as: :goal_objectives
         post 'add_tag', to: 'goals#add_tag', as: :add_tag
-        post 'remove_tag', to: 'goals#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'goals#remove_tag', as: :remove_tag
         post 'add_organization', to: 'goals#add_organization', as: :add_organization
         delete 'remove_organization', to: 'goals#remove_organization', as: :remove_organization
         post 'add_sponsor', to: 'goals#add_sponsor', as: :add_sponsor
@@ -223,7 +223,7 @@ Rails.application.routes.draw do
       resources :objectives do
         member do
           post 'add_tag', to: 'objectives#add_tag', as: :add_tag
-          post 'remove_tag', to: 'objectives#remove_tag', as: :remove_tag
+          delete 'remove_tag', to: 'objectives#remove_tag', as: :remove_tag
         end
       end
     end
@@ -255,13 +255,13 @@ Rails.application.routes.draw do
         post 'reset', to: 'websites#reset', as: :reset
         get 'events', to: 'websites#events', as: :events
         post 'add_tag', to: 'websites#add_tag', as: :add_tag
-        post 'remove_tag', to: 'websites#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'websites#remove_tag', as: :remove_tag
         get 'versions', to: 'websites#versions', as: :versions
         get 'versions_export', to: 'websites#export_versions', as: :export_versions
         post 'add_website_manager', to: 'websites#add_website_manager', as: :add_website_manager
         post 'remove_website_manager', to: 'websites#remove_website_manager', as: :remove_website_manager
         post 'add_website_persona', to: 'websites#add_website_persona', as: :add_website_persona
-        post 'remove_website_persona', to: 'websites#remove_website_persona', as: :remove_website_persona
+        delete 'remove_website_persona', to: 'websites#remove_website_persona', as: :remove_website_persona
       end
     end
     get :registry, to: 'site#registry', as: :registry
@@ -278,7 +278,7 @@ Rails.application.routes.draw do
         post 'archive', to: 'digital_service_accounts#archive', as: :archive
         post 'reset', to: 'digital_service_accounts#reset', as: :reset
         post 'add_tag', to: 'digital_service_accounts#add_tag', as: :add_tag
-        post 'remove_tag', to: 'digital_service_accounts#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'digital_service_accounts#remove_tag', as: :remove_tag
 
         post 'add_organization', to: 'digital_service_accounts#add_organization', as: :add_organization
         delete 'remove_organization', to: 'digital_service_accounts#remove_organization', as: :remove_organization
@@ -300,7 +300,7 @@ Rails.application.routes.draw do
         post 'reset', to: 'digital_products#reset', as: :reset
 
         post 'add_tag', to: 'digital_products#add_tag', as: :add_tag
-        post 'remove_tag', to: 'digital_products#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'digital_products#remove_tag', as: :remove_tag
 
         post 'add_organization', to: 'digital_products#add_organization', as: :add_organization
         delete 'remove_organization', to: 'digital_products#remove_organization', as: :remove_organization
@@ -315,7 +315,7 @@ Rails.application.routes.draw do
     resources :personas do
       member do
         post 'add_tag', to: 'personas#add_tag', as: :add_tag
-        post 'remove_tag', to: 'personas#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'personas#remove_tag', as: :remove_tag
       end
     end
 
@@ -329,7 +329,7 @@ Rails.application.routes.draw do
         get 'export_a11_submissions', to: 'forms#export_a11_submissions', as: :export_a11_submissions
         get 'js', to: 'forms#js', as: :js
         post 'add_tag', to: 'forms#add_tag', as: :add_tag
-        post 'remove_tag', to: 'forms#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'forms#remove_tag', as: :remove_tag
         get 'permissions', to: 'forms#permissions', as: :permissions
         get 'compliance', to: 'forms#compliance', as: :compliance
         get 'questions', to: 'forms#questions', as: :questions
@@ -383,7 +383,7 @@ Rails.application.routes.draw do
           post 'archive', to: 'submissions#archive', as: :archive
           post 'unarchive', to: 'submissions#unarchive', as: :unarchive
           post 'add_tag', to: 'submissions#add_tag', as: :add_tag
-          post 'remove_tag', to: 'submissions#remove_tag', as: :remove_tag
+          delete 'remove_tag', to: 'submissions#remove_tag', as: :remove_tag
         end
       end
     end
@@ -409,7 +409,7 @@ Rails.application.routes.draw do
         get 'performance/edit', to: 'performance#edit', as: :performance_edit
         get 'performance/apg/:apg', to: 'performance#apg', as: :apg
         post 'add_tag', to: 'organizations#add_tag', as: :add_tag
-        post 'remove_tag', to: 'organizations#remove_tag', as: :remove_tag
+        delete 'remove_tag', to: 'organizations#remove_tag', as: :remove_tag
         get 'create_two_year_goal', to: 'organizations#create_two_year_goal', as: :create_two_year_goal
         get 'create_four_year_goal', to: 'organizations#create_four_year_goal', as: :create_four_year_goal
         delete 'delete_two_year_goal', to: 'organizations#delete_two_year_goal', as: :delete_two_year_goal

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,7 +215,7 @@ Rails.application.routes.draw do
         post 'add_tag', to: 'goals#add_tag', as: :add_tag
         post 'remove_tag', to: 'goals#remove_tag', as: :remove_tag
         post 'add_organization', to: 'goals#add_organization', as: :add_organization
-        post 'remove_organization', to: 'goals#remove_organization', as: :remove_organization
+        delete 'remove_organization', to: 'goals#remove_organization', as: :remove_organization
         post 'add_sponsor', to: 'goals#add_sponsor', as: :add_sponsor
         post 'remove_sponsor', to: 'goals#remove_sponsor', as: :remove_sponsor
       end
@@ -281,7 +281,7 @@ Rails.application.routes.draw do
         post 'remove_tag', to: 'digital_service_accounts#remove_tag', as: :remove_tag
 
         post 'add_organization', to: 'digital_service_accounts#add_organization', as: :add_organization
-        post 'remove_organization', to: 'digital_service_accounts#remove_organization', as: :remove_organization
+        delete 'remove_organization', to: 'digital_service_accounts#remove_organization', as: :remove_organization
 
         post 'add_user', to: 'digital_service_accounts#add_user', as: :add_user
         delete 'remove_user', to: 'digital_service_accounts#remove_user', as: :remove_user
@@ -303,7 +303,7 @@ Rails.application.routes.draw do
         post 'remove_tag', to: 'digital_products#remove_tag', as: :remove_tag
 
         post 'add_organization', to: 'digital_products#add_organization', as: :add_organization
-        post 'remove_organization', to: 'digital_products#remove_organization', as: :remove_organization
+        delete 'remove_organization', to: 'digital_products#remove_organization', as: :remove_organization
 
         post 'add_user', to: 'digital_products#add_user', as: :add_user
         delete 'remove_user', to: 'digital_products#remove_user', as: :remove_user


### PR DESCRIPTION
this is branched off `axe` ~~and the diff should be reviewed after `axe` is merged~~

this branch
* replaces all `remove-tag-link` html to a partial
* updates a handful of `post` requests that remove tags to `delete` requests (and routes)