### PR TITLE
Fixes issue where embedded touchpoints form interferes with existing USWDS elements on a page.

### DIFF
--- a/app/views/components/widget/_widget-uswds.js.erb
+++ b/app/views/components/widget/_widget-uswds.js.erb
@@ -3907,8 +3907,11 @@ const DatePicker = require("@uswds/uswds/packages/usa-date-picker/src/index.js")
 const Modal = require("@uswds/uswds/packages/usa-modal/src/index.js");
 
 // Initialize event listeners
-ComboBox.on();
-DatePicker.on();
-Modal.on();
+const fbaFormElement = document.querySelector(".touchpoints-form-wrapper");
+if (fbaFormElement) {
+  ComboBox.on(fbaFormElement); // Initialize all .usa-combo-box elements within the Touchpoints form
+  DatePicker.on(fbaFormElement); // Initialize all .usa-date-picker elements within the Touchpoints form
+}
+Modal.on(); // Initialize all .fba-usa-modal elements within the document
 
 },{"@uswds/uswds/packages/usa-combo-box/src/index.js":1,"@uswds/uswds/packages/usa-date-picker/src/index.js":2,"@uswds/uswds/packages/usa-modal/src/index.js":3}]},{},[25]);

--- a/uswds/widget-uswds.js
+++ b/uswds/widget-uswds.js
@@ -3,6 +3,10 @@ const DatePicker = require("@uswds/uswds/packages/usa-date-picker/src/index.js")
 const Modal = require("@uswds/uswds/packages/usa-modal/src/index.js");
 
 // Initialize event listeners
-ComboBox.on();
-DatePicker.on();
-Modal.on();
+const fbaFormElement = document.querySelector(".touchpoints-form-wrapper");
+if (fbaFormElement) {
+  ComboBox.on(fbaFormElement); // Initialize all .usa-combo-box elements within the Touchpoints form
+  DatePicker.on(fbaFormElement); // Initialize all .usa-date-picker elements within the Touchpoints form
+}
+
+Modal.on(); // Initialize all .fba-usa-modal elements within the document


### PR DESCRIPTION
USWDS reports that some of their preview widgets aren't working (on https://designsystem.digital.gov/components/combo-box/, for example) on pages that also have a Touchpoints modal on them. They suggest the problem is that the Touchpoints code is calling init on USWDS components within the base USWDS page, instead of limiting its scope to Touchpoints elements only. This PR should fix that problem and prevent Touchpoints from messing with the page it is embedded on.

I think it's possible that, with this code, 2 Touchpoints forms on the same page could interfere with and break each other. But that seems like an edge case, to be addressed later.