### PR TITLE
remove service_id from CxCollectionDetail and use the CxCollection.service instead

### DIFF
--- a/app/controllers/admin/cx_collection_details_controller.rb
+++ b/app/controllers/admin/cx_collection_details_controller.rb
@@ -31,7 +31,6 @@ class Admin::CxCollectionDetailsController < AdminController
 
   def create
     @cx_collection_detail = CxCollectionDetail.new(cx_collection_detail_params)
-    @cx_collection_detail.service_id = @cx_collection_detail.cx_collection.service_id
 
     respond_to do |format|
       if @cx_collection_detail.save
@@ -154,6 +153,6 @@ class Admin::CxCollectionDetailsController < AdminController
     end
 
     def cx_collection_detail_params
-      params.require(:cx_collection_detail).permit(:cx_collection_id, :service_id, :transaction_point, :channel, :service_stage_id, :volume_of_customers, :volume_of_customers_provided_survey_opportunity, :volume_of_respondents, :omb_control_number, :federal_register_url, :reflection_text, :survey_type, :survey_title, :trust_question_text)
+      params.require(:cx_collection_detail).permit(:cx_collection_id, :transaction_point, :channel, :service_stage_id, :volume_of_customers, :volume_of_customers_provided_survey_opportunity, :volume_of_respondents, :omb_control_number, :federal_register_url, :reflection_text, :survey_type, :survey_title, :trust_question_text)
     end
 end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -84,7 +84,10 @@ module Admin
       send_data @services.to_csv, filename: "touchpoints-services-#{Date.today}.csv"
     end
 
-    def show; end
+    def show
+      @omb_cx_reporting_collections = @service.omb_cx_reporting_collections.includes(:collection).order("collections.year", "collections.quarter")
+      @cx_collections = @service.cx_collections
+    end
 
     def new
       @service = Service.new

--- a/app/models/cx_collection_detail.rb
+++ b/app/models/cx_collection_detail.rb
@@ -1,5 +1,5 @@
 class CxCollectionDetail < ApplicationRecord
-  belongs_to :service
+  belongs_to :service, through: :cx_collection
   belongs_to :cx_collection
   belongs_to :service_stage, optional: true
   has_many :cx_responses, dependent: :delete_all

--- a/app/models/cx_collection_detail.rb
+++ b/app/models/cx_collection_detail.rb
@@ -1,10 +1,10 @@
 class CxCollectionDetail < ApplicationRecord
-  belongs_to :service, through: :cx_collection
   belongs_to :cx_collection
   belongs_to :service_stage, optional: true
   has_many :cx_responses, dependent: :delete_all
   has_one :cx_collection_detail
   has_one :service_provider, through: :cx_collection
+  has_one :service, through: :cx_collection
 
   validates :transaction_point, presence: true
   validates :channel, presence: true

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -14,8 +14,8 @@ class Service < ApplicationRecord
   has_many :omb_cx_reporting_collections
   has_many :collections, through: :omb_cx_reporting_collections
 
-  has_many :cx_collection_details
-  has_many :cx_collections, through: :cx_collection_details
+  has_many :cx_collections
+  has_many :cx_collection_details, through: :cx_collections
 
   has_many :forms
 

--- a/app/serializers/cx_collection_detail_serializer.rb
+++ b/app/serializers/cx_collection_detail_serializer.rb
@@ -22,15 +22,19 @@ class CxCollectionDetailSerializer < ActiveModel::Serializer
       object.service_provider.id if object.service_provider
     end
 
+    def service_provider_name
+      object.service_provider.name if object.service_provider
+    end
+
+    def service_id
+      object.service.id if object.service
+    end
+
     def service_name
       object.service.name if object.service
     end
 
     def service_stage_name
       object.service_stage.name if object.service_stage
-    end
-
-    def service_provider_name
-      object.service_provider.name if object.service
     end
 end

--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -288,9 +288,6 @@
   </div>
 </div>
 
-<% @omb_cx_reporting_collections = @service.omb_cx_reporting_collections.includes(:collection).order("collections.year", "collections.quarter") %>
-<% @cx_collection_details = @service.cx_collection_details.includes(:cx_collection).order("cx_collections.fiscal_year", "cx_collections.quarter") %>
-
 <div class="well">
   <h4>
     CX Data Collections (V1)
@@ -299,10 +296,18 @@
   <table class="usa-table">
     <thead>
       <tr>
-        <th>Fiscal year</th>
-        <th>Quarter</th>
-        <th>Collection name</th>
-        <th>Service name</th>
+        <th data-sortable scope="col">
+          Fiscal year
+        </th>
+        <th data-sortable scope="col">
+          Quarter
+        </th>
+        <th data-sortable scope="col">
+          Collection name
+        </th>
+        <th data-sortable scope="col">
+          Service name
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -331,30 +336,38 @@
   <h4>
     CX Data Collections (V2)
   </h4>
-  <%- if @cx_collection_details.present? %>
+  <%- if @cx_collections.present? %>
   <table class="usa-table">
     <thead>
       <tr>
-        <th>Fiscal year</th>
-        <th>Quarter</th>
-        <th>Collection name</th>
-        <th>Service name</th>
+        <th data-sortable scope="col">
+          Fiscal year
+        </th>
+        <th data-sortable scope="col">
+          Quarter
+        </th>
+        <th data-sortable scope="col">
+          Collection name
+        </th>
+        <th data-sortable scope="col">
+          Service name
+        </th>
       </tr>
     </thead>
     <tbody>
-      <% @cx_collection_details.each do |cx_collection_detail| %>
-      <tr>
+      <% @cx_collections.each do |cx_collection| %>
+      <tr data-id="<%= cx_collection.id %>">
         <td>
-          <%= cx_collection_detail.cx_collection.fiscal_year %>
+          <%= cx_collection.fiscal_year %>
         </td>
         <td>
-          <%= cx_collection_detail.cx_collection.quarter %>
+          <%= cx_collection.quarter %>
         </td>
         <td>
-          <%= link_to cx_collection_detail.cx_collection.name, admin_cx_collection_path(cx_collection_detail.cx_collection) %>
+          <%= link_to cx_collection.name, admin_cx_collection_path(cx_collection) %>
         </td>
         <td>
-          <%= link_to cx_collection_detail.service.name, admin_cx_collection_detail_path(cx_collection_detail) %>
+          <%= link_to cx_collection.service.name, admin_cx_collection_path(cx_collection) %>
         </td>
       </tr>
       <% end %>

--- a/db/migrate/20240826211558_remove_cx_collection_detail_service_id.rb
+++ b/db/migrate/20240826211558_remove_cx_collection_detail_service_id.rb
@@ -1,0 +1,5 @@
+class RemoveCxCollectionDetailServiceId < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :cx_collection_details, :service_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_15_183449) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_26_211558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -201,7 +201,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_183449) do
 
   create_table "cx_collection_details", force: :cascade do |t|
     t.integer "cx_collection_id"
-    t.integer "service_id"
     t.string "transaction_point"
     t.string "channel"
     t.integer "service_stage_id"

--- a/docs/models/cx_collection_details.md
+++ b/docs/models/cx_collection_details.md
@@ -2,13 +2,15 @@
 
 Each `CXCollection` has_many `CXCollectionDetail` records.
 
+A `CXCollectionDetail` record belongs_to a `CXCollection` record.
+
 | Field Name                                    | Format   | Description                                                                           | Sample Input                                                       |
 |-----------------------------------------------|----------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | channel                                       | string   | The channel through which the interaction occurred                                    | computer                                                           |
 | created_at                                    | datetime | The timestamp when the record was created                                             | 2023-07-31 12:34:56                                                |
 | cx_collection_id                              | integer  | Identifier for the CX Collection                                                      | 148                                                                |
 | omb_control_number                            | string   | OMB control number for the survey                                                     | 0412-0609                                                          |
-| service_id                                    | integer  | Identifier for the service                                                            | 132                                                                |
+| service_id                                    | integer  | Identifier for the CX Collection's Service                                            | 132                                                                |
 | service_name                                  | integer  | Name of the Service                                                                   | Passports                                                          |
 | service_provider_id                           | integer  | Identifier for the Service Provider                                                   | 9722                                                               |
 | service_provider_name                         | string   | Name of the Service Provider                                                          | Bureau of Consular Affairs                                         |

--- a/docs/models/cx_collections.md
+++ b/docs/models/cx_collections.md
@@ -17,6 +17,7 @@ Data is published for download at https://www.performance.gov/cx/data/.
 ++| organization_name (Service provider    | integer  | Organization Name                                                           | General Services Administration       |
 | quarter                                  | string   | The quarter of the fiscal year                                              | 2                                     |
 | rating                                   | string   | The rating for the service                                                  | true,false,partial                    |
+| service_id                               | integer  | Identifier for the service                                                  | 74                                    |
 ++| service_name                           | string   | Name for the service                                                        | USA.gov                               |
 | service_provider_id                      | integer  | Unique ID for the Service Provider                                          | 36                                    |
 ++| service_provider_name                  | integer  | Name of the Federal Agency Service Provider                                 | Public Experience Portfolio           |

--- a/docs/models/cx_collections.md
+++ b/docs/models/cx_collections.md
@@ -17,7 +17,6 @@ Data is published for download at https://www.performance.gov/cx/data/.
 ++| organization_name (Service provider    | integer  | Organization Name                                                           | General Services Administration       |
 | quarter                                  | string   | The quarter of the fiscal year                                              | 2                                     |
 | rating                                   | string   | The rating for the service                                                  | true,false,partial                    |
-| service_id                               | integer  | Identifier for the service                                                  | 74                                    |
 ++| service_name                           | string   | Name for the service                                                        | USA.gov                               |
 | service_provider_id                      | integer  | Unique ID for the Service Provider                                          | 36                                    |
 ++| service_provider_name                  | integer  | Name of the Federal Agency Service Provider                                 | Public Experience Portfolio           |


### PR DESCRIPTION
* removes the CxCollectionDetail.service_id field, because its CxCollection has a service_id field and it should use that
* this required model relationships changes regarding how the CxCollection accesses a Service and vice versa
* the `service_id` is ultimately retained for reporting purposes; CxCollectionDetail just looks it up through its CxCollection