### PR TITLE
show organization form approvers

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -42,4 +42,8 @@ class Organization < ApplicationRecord
   def to_param
     slug
   end
+
+  def organizational_form_approvers
+    users.where(organizational_form_approver: true)
+  end
 end

--- a/app/views/admin/forms/_organizational_form_approval_message.html.erb
+++ b/app/views/admin/forms/_organizational_form_approval_message.html.erb
@@ -3,7 +3,7 @@
     For any questions about Organizational Form Approval, please contact
     <%= form.organization.name %>'s
     form
-    <%= pluralize("approver", @organizational_form_approvers.size %>.
+    <%= pluralize("approver", @organizational_form_approvers.size) %>.
     <ul class="usa-list text-base font-sans-2xs">
     <% @organizational_form_approvers.each do |user| %>
         <li>

--- a/app/views/admin/forms/_organizational_form_approval_message.html.erb
+++ b/app/views/admin/forms/_organizational_form_approval_message.html.erb
@@ -3,7 +3,7 @@
     For any questions about Organizational Form Approval, please contact
     <%= form.organization.name %>'s
     form
-    <%= pluralize("approver", @organizational_form_approvers.size) %>.
+    <%= pluralize(@organizational_form_approvers.size, "approver") %>.
     <ul class="usa-list text-base font-sans-2xs">
     <% @organizational_form_approvers.each do |user| %>
         <li>

--- a/app/views/admin/forms/_organizational_form_approval_message.html.erb
+++ b/app/views/admin/forms/_organizational_form_approval_message.html.erb
@@ -3,7 +3,7 @@
     For any questions about Organizational Form Approval, please contact
     <%= form.organization.name %>'s
     form
-    <%= pluralize(@organizational_form_approvers.size, "approver") %>.
+    <%= "approver".pluralize(@organizational_form_approvers.size) %>.
     <ul class="usa-list text-base font-sans-2xs">
     <% @organizational_form_approvers.each do |user| %>
         <li>

--- a/app/views/admin/forms/_organizational_form_approval_message.html.erb
+++ b/app/views/admin/forms/_organizational_form_approval_message.html.erb
@@ -1,0 +1,12 @@
+<p class="text-base font-sans-2xs">
+    For any questions about Organizational Form Approval, please contact
+    <%= form.organization.name %>'s
+    form approvers.
+    <ul class="usa-list text-base font-sans-2xs">
+    <% form.organization.organizational_form_approvers.each do |user| %>
+        <li>
+            <%= link_to user.email, "mailto:#{user.email}" %>
+        </li>
+    <% end %>
+    </ul>
+</p>

--- a/app/views/admin/forms/_organizational_form_approval_message.html.erb
+++ b/app/views/admin/forms/_organizational_form_approval_message.html.erb
@@ -1,9 +1,11 @@
+<% @organizational_form_approvers = form.organization.organizational_form_approvers %>
 <p class="text-base font-sans-2xs">
     For any questions about Organizational Form Approval, please contact
     <%= form.organization.name %>'s
-    form approvers.
+    form
+    <%= pluralize("approver", @organizational_form_approvers.size %>.
     <ul class="usa-list text-base font-sans-2xs">
-    <% form.organization.organizational_form_approvers.each do |user| %>
+    <% @organizational_form_approvers.each do |user| %>
         <li>
             <%= link_to user.email, "mailto:#{user.email}" %>
         </li>

--- a/app/views/admin/forms/_task_bar.html.erb
+++ b/app/views/admin/forms/_task_bar.html.erb
@@ -104,12 +104,14 @@
       Form was submitted for review at
       <%= @form.submitted_at %>
     </p>
+    <%= render "admin/forms/organizational_form_approval_message", form: @form %>
     <% elsif @form.created? %>
     <div class="margin-top-2">
       <%= link_to submit_admin_form_path(form), method: :post, data: { confirm: 'Are you sure?' }, class: "usa-button width-full" do %>
       <i class="far fa-check-circle"></i>
       Submit for Organizational Approval
       <% end %>
+      <%= render "admin/forms/organizational_form_approval_message", form: @form %>
     </div>
     <% end %>
   <% end %>

--- a/spec/features/admin/forms/organizational_form_approval_spec.rb
+++ b/spec/features/admin/forms/organizational_form_approval_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Form - Organization Form Approval feature', js: true do
+  let(:organization) { FactoryBot.create(:organization, form_approval_enabled: true) }
+  let(:admin) { FactoryBot.create(:user, :admin, organization: organization) }
+  let!(:organizational_form_approver) { FactoryBot.create(:user, organization: organization, organizational_form_approver: true) }
+  let!(:form) { FactoryBot.create(:form, organization: organization) }
+  let!(:draft_form) { FactoryBot.create(:form, organization: organization, aasm_state: :created) }
+  let!(:submitted_form) { FactoryBot.create(:form, organization: organization, aasm_state: :submitted) }
+  let!(:user) { FactoryBot.create(:user, organization: organization) }
+
+  context 'as Admin' do
+    before do
+      login_as(admin)
+    end
+
+    describe 'message text describing organizational form approver' do
+      context 'a draft form is Submitted for approval' do
+        before do
+          visit admin_form_path(draft_form)
+        end
+
+        it 'displays text and Organization Form approver emails' do
+          expect(page).to have_text("For any questions about Organizational Form Approval")
+          expect(page).to have_text("please contact #{organization.name}'s form approvers")
+          expect(page).to have_link(organizational_form_approver.email)
+
+          expect(page).to have_link("Submit for Organizational Approval")
+        end
+      end
+    end
+
+    describe 'message text describing organizational form approver' do
+      context 'a draft form is Submitted for approval' do
+        before do
+          visit admin_form_path(submitted_form)
+        end
+
+        it 'displays text and Organization Form approver emails' do
+          expect(page).to have_text("For any questions about Organizational Form Approval")
+          expect(page).to have_text("please contact #{organization.name}'s form approvers")
+          expect(page).to have_link(organizational_form_approver.email)
+
+          expect(page).to have_button("Approve")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/admin/forms/organizational_form_approval_spec.rb
+++ b/spec/features/admin/forms/organizational_form_approval_spec.rb
@@ -24,7 +24,7 @@ feature 'Form - Organization Form Approval feature', js: true do
 
         it 'displays text and Organization Form approver emails' do
           expect(page).to have_text("For any questions about Organizational Form Approval")
-          expect(page).to have_text("please contact #{organization.name}'s form approvers")
+          expect(page).to have_text("please contact #{organization.name}'s form approver")
           expect(page).to have_link(organizational_form_approver.email)
 
           expect(page).to have_link("Submit for Organizational Approval")
@@ -40,7 +40,7 @@ feature 'Form - Organization Form Approval feature', js: true do
 
         it 'displays text and Organization Form approver emails' do
           expect(page).to have_text("For any questions about Organizational Form Approval")
-          expect(page).to have_text("please contact #{organization.name}'s form approvers")
+          expect(page).to have_text("please contact #{organization.name}'s form approver")
           expect(page).to have_link(organizational_form_approver.email)
 
           expect(page).to have_button("Approve")


### PR DESCRIPTION
shows the email of the organizational form approver roles for an org.

enables users to see who's approving forms

### Screenshot

![Screenshot 2024-08-27 at 2 54 24 PM](https://github.com/user-attachments/assets/5ca78778-44e0-4c7c-a673-5293c9bee3dd)
