### PR TITLE
support login.gov all_emails

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,7 +4,7 @@ module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     def login_dot_gov
       @kind = 'Login.gov'
-      @email = auth_hash['info']['email'] if auth_hash && auth_hash['info']['email_verified']
+      @email = auth_hash['info']['all_emails'].find { |email| email.end_with(".gov") || email.end_with(".mil") } if auth_hash && auth_hash['info']['email_verified']
 
       login
     end
@@ -30,7 +30,7 @@ module Users
     def login
       Event.log_event(Event.names[:user_authentication_attempt], 'Event::Generic', 1, "Email #{@email} attempted to authenticate on #{Date.today}")
 
-      @user = User.from_omniauth(auth_hash) if @email.present?
+      @user = User.from_omniauth(auth_hash, @email) if @email.present?
 
       # If user exists
       # Else, if valid email and no user, we create an account.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,10 +49,10 @@ class User < ApplicationRecord
     User.where(admin: true)
   end
 
-  def self.from_omniauth(auth)
+  def self.from_omniauth(auth, email)
     # Set login_dot_gov as Provider for legacy TP Devise accounts
     # TODO: Remove once all accounts are migrated/have `provider` and `uid` set
-    @existing_user = User.find_by_email(auth.info.email)
+    @existing_user = User.find_by_email(email)
     if @existing_user && @existing_user.provider.blank?
       @existing_user.provider = auth.provider
       @existing_user.uid = auth.uid
@@ -61,7 +61,7 @@ class User < ApplicationRecord
 
     # For login.gov native accounts
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.email = auth.info.email
+      user.email = email
       user.password = Devise.friendly_token[0, 24]
     end
   end


### PR DESCRIPTION
* rather than the `email`, which is the last used email (which could be a personal address)