### PR TITLE
Remove return-path from emails to enable SES event publishing.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,8 +76,7 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
 
-  config.action_mailer.default_options = { reply_to: 'feedback-analytics@gsa.gov',
-                                           return_path: 'feedback-analytics@gsa.gov' }
+  config.action_mailer.default_options = { reply_to: 'feedback-analytics@gsa.gov' }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -68,8 +68,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "touchpoints_#{Rails.env}"
   config.active_job.queue_adapter = :sidekiq
 
-  config.action_mailer.default_options = { reply_to: 'feedback-analytics@gsa.gov',
-                                           return_path: 'feedback-analytics@gsa.gov' }
+  config.action_mailer.default_options = { reply_to: 'feedback-analytics@gsa.gov' }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
A further effort to get bounce and complaint notifications working for emails.

I added `return-path` to our emails while I was trying to get [email feedback forwarding](https://docs.aws.amazon.com/ses/latest/dg/monitor-sending-activity-using-notifications-email.html) to work. For whatever reason, that never worked.

Now I'm trying to enable [SES event publishing](https://docs.aws.amazon.com/ses/latest/dg/monitor-using-event-publishing.html) instead. Based on testing in dev, event publishing only works if `return-path` is _not_ set (not sure why), so I'm getting rid of it.
