### PR TITLE
Prefix the 'visible' class in embedded widget.

### DIFF
--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -17,7 +17,7 @@
       tabindex="-1"
       autocomplete="off">
     <% form.form_sections.each_with_index do |section, index| %>
-      <div class="section <%= 'visible' if section == form.form_sections.first -%>">
+      <div class="section <%= 'fba-visible' if section == form.form_sections.first -%>">
         <%- if (section != form.form_sections.first) || (section != form.form_sections.last) %>
           <%- if section != form.form_sections.first %>
           <nav aria-label="Pagination" class="pagination-buttons margin-bottom-2">

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -334,10 +334,10 @@ function FBAform(d, N) {
 
 			// show page with validation error
 			var errorPage = question.closest(".section");
-			if (!errorPage.classList.contains("visible")) {
-				var visiblePage = this.formComponent().getElementsByClassName("section visible")[0];
-				visiblePage.classList.remove("visible");
-				errorPage.classList.add("visible");
+			if (!errorPage.classList.contains("fba-visible")) {
+				var visiblePage = this.formComponent().getElementsByClassName("section fba-visible")[0];
+				visiblePage.classList.remove("fba-visible");
+				errorPage.classList.add("fba-visible");
 			}
 
 			questionDiv.setAttribute('class', 'usa-form-group usa-form-group--error');
@@ -609,10 +609,10 @@ function FBAform(d, N) {
 					e.preventDefault();
 					var currentPage = e.target.closest(".section");
 					if (!this.validateForm(currentPage)) return false;
-					currentPage.classList.remove("visible");
+					currentPage.classList.remove("fba-visible");
 					this.currentPageNumber--;
 					this.showInstructions();
-					currentPage.previousElementSibling.classList.add("visible");
+					currentPage.previousElementSibling.classList.add("fba-visible");
 
 					const previousPageEvent = new CustomEvent('onTouchpointsFormPreviousPage', {
 						detail: {
@@ -634,10 +634,10 @@ function FBAform(d, N) {
 					e.preventDefault();
 					var currentPage = e.target.closest(".section");
 					if (!this.validateForm(currentPage)) return false;
-					currentPage.classList.remove("visible");
+					currentPage.classList.remove("fba-visible");
 					this.currentPageNumber++;
 					this.showInstructions();
-					currentPage.nextElementSibling.classList.add("visible");
+					currentPage.nextElementSibling.classList.add("fba-visible");
 
 					const nextPageEvent = new CustomEvent('onTouchpointsFormNextPage', {
 						detail: {

--- a/app/views/components/widget/_fba2.js.erb
+++ b/app/views/components/widget/_fba2.js.erb
@@ -305,10 +305,10 @@ function FBAform(d, N) {
 
 			// show page with validation error
 			var errorPage = question.closest(".section");
-			if (!errorPage.classList.contains("visible")) {
-				var visiblePage = this.formComponent().getElementsByClassName("section visible")[0];
-				visiblePage.classList.remove("visible");
-				errorPage.classList.add("visible");
+			if (!errorPage.classList.contains("fba-visible")) {
+				var visiblePage = this.formComponent().getElementsByClassName("section fba-visible")[0];
+				visiblePage.classList.remove("fba-visible");
+				errorPage.classList.add("fba-visible");
 			}
 
 			questionDiv.setAttribute('class', 'usa-form-group usa-form-group--error');
@@ -565,10 +565,10 @@ function FBAform(d, N) {
 					e.preventDefault();
 					var currentPage = e.target.closest(".section");
 					if (!this.validateForm(currentPage)) return false;
-					currentPage.classList.remove("visible");
+					currentPage.classList.remove("fba-visible");
 					this.currentPageNumber--;
 					this.showInstructions();
-					currentPage.previousElementSibling.classList.add("visible");
+					currentPage.previousElementSibling.classList.add("fba-visible");
 
 					const previousPageEvent = new CustomEvent('onTouchpointsFormPreviousPage', {
 						detail: {
@@ -590,10 +590,10 @@ function FBAform(d, N) {
 					e.preventDefault();
 					var currentPage = e.target.closest(".section");
 					if (!this.validateForm(currentPage)) return false;
-					currentPage.classList.remove("visible");
+					currentPage.classList.remove("fba-visible");
 					this.currentPageNumber++;
 					this.showInstructions();
-					currentPage.nextElementSibling.classList.add("visible");
+					currentPage.nextElementSibling.classList.add("fba-visible");
 
 					const nextPageEvent = new CustomEvent('onTouchpointsFormNextPage', {
 						detail: {

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -130,7 +130,7 @@
 .touchpoints-form-wrapper form div.section {
   display: none;
 }
-.touchpoints-form-wrapper form div.section.visible {
+.touchpoints-form-wrapper form div.section.fba-visible {
   display: block;
 }
 

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -198,6 +198,7 @@ FactoryBot.define do
     trait :kitchen_sink do
       name { 'Kitchen Sink Form 🧼' }
       kind { 'custom' }
+      title { 'Kitchen Sink Form' }
       after(:create) do |f, _evaluator|
         FactoryBot.create(:question,
                           form: f,
@@ -228,7 +229,7 @@ FactoryBot.define do
                           position: 20,
                           text: "Some custom <a href='#'>html</a>")
 
-        option_elements_section = f.form_sections.create(title: 'Option elements', position: 2)
+        option_elements_section = f.form_sections.create(title: 'Page 2', position: 2)
         radio_button_question = FactoryBot.create(:question,
                                                   form: f,
                                                   form_section: option_elements_section,
@@ -286,9 +287,11 @@ FactoryBot.define do
                                  position: 3,
                                })
 
+        custom_elements_section = f.form_sections.create(title: 'Page 3', position: 3)
+
         dropdown_question = Question.create!({
                                                form: f,
-                                               form_section: option_elements_section,
+                                               form_section: custom_elements_section,
                                                text: 'Custom Question Dropdown',
                                                question_type: 'dropdown',
                                                help_text: 'This is help text for a dropdown.',
@@ -315,7 +318,6 @@ FactoryBot.define do
                                  position: 3,
                                })
 
-        custom_elements_section = f.form_sections.create(title: 'Custom elements', position: 3)
         Question.create!({
                            form: f,
                            form_section: custom_elements_section,

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -253,15 +253,9 @@ FactoryBot.define do
                                })
         QuestionOption.create!({
                                  question: radio_button_question,
-                                 text: 'Option 3',
+                                 text: 'Otro',
                                  value: 3,
                                  position: 3,
-                               })
-        QuestionOption.create!({
-                                 question: radio_button_question,
-                                 text: 'Otro',
-                                 value: 4,
-                                 position: 4,
                                })
 
         checkbox_question = FactoryBot.create(:question,

--- a/spec/features/embedded_touchpoints_spec.rb
+++ b/spec/features/embedded_touchpoints_spec.rb
@@ -25,11 +25,11 @@ feature 'Touchpoints', js: true do
             click_on('Help improve this site') # opens modal
 
             expect(page).to have_content('Help improve this site')
-            expect(page).to have_content('Do you have a few minutes to help us test this site?')
+            expect(page).to have_content('Kitchen Sink Form')
 
             expect(page).to have_content('Page 1')
-            expect(page).to have_no_content('Option elements')
-            expect(page).to have_no_content('Custom elements')
+            expect(page).to have_no_content('Page 2')
+            expect(page).to have_no_content('Page 3')
             fill_in form.ordered_questions.first.ui_selector, with: 'input field'
             fill_in form.ordered_questions.second.ui_selector, with: 'email'
             fill_in form.ordered_questions.third.ui_selector, with: 'textarea'
@@ -41,9 +41,9 @@ feature 'Touchpoints', js: true do
 
             find(".pagination-buttons.text-right", visible: true).click_link("Next")
 
-            expect(page).to have_content('Option elements')
+            expect(page).to have_content('Page 2')
             expect(page).to have_no_content('Page 1')
-            expect(page).to have_no_content('Custom elements')
+            expect(page).to have_no_content('Page 3')
             expect(all("#question_#{form.ordered_questions[4].id} .usa-radio__label").size).to eq(3)
             all("#question_#{form.ordered_questions[4].id} .usa-radio__label").last.click
             fill_in("#{form.ordered_questions[4].ui_selector}_other", with: 'otro 2')
@@ -54,11 +54,11 @@ feature 'Touchpoints', js: true do
             expect(page).to have_css("##{form.ordered_questions[5].ui_selector}_other")
             fill_in("#{form.ordered_questions[5].ui_selector}_other", with: 'other 3')
 
-            select('Option 2', from: form.ordered_questions[6].ui_selector)
             find(".pagination-buttons.text-right", visible: true).click_link("Next")
-            expect(page).to have_content('Custom elements')
+            expect(page).to have_content('Page 3')
             expect(page).to have_no_content('Page 1')
-            expect(page).to have_no_content('Option elements')
+            expect(page).to have_no_content('Page 2')
+            select('Option 2', from: form.ordered_questions[6].ui_selector)
             find('.submit_form_button').click
 
             # shows success flash message

--- a/spec/features/embedded_touchpoints_spec.rb
+++ b/spec/features/embedded_touchpoints_spec.rb
@@ -28,8 +28,8 @@ feature 'Touchpoints', js: true do
             expect(page).to have_content('Kitchen Sink Form')
 
             expect(page).to have_content('Page 1')
-            expect(page).to have_no_content('Page 2')
-            expect(page).to have_no_content('Page 3')
+            expect(page).to_not have_content('Page 2')
+            expect(page).to_not have_content('Page 3')
             fill_in form.ordered_questions.first.ui_selector, with: 'input field'
             fill_in form.ordered_questions.second.ui_selector, with: 'email'
             fill_in form.ordered_questions.third.ui_selector, with: 'textarea'
@@ -42,8 +42,8 @@ feature 'Touchpoints', js: true do
             find(".pagination-buttons.text-right", visible: true).click_link("Next")
 
             expect(page).to have_content('Page 2')
-            expect(page).to have_no_content('Page 1')
-            expect(page).to have_no_content('Page 3')
+            expect(page).to_not have_content('Page 1')
+            expect(page).to_not have_content('Page 3')
             expect(all("#question_#{form.ordered_questions[4].id} .usa-radio__label").size).to eq(3)
             all("#question_#{form.ordered_questions[4].id} .usa-radio__label").last.click
             fill_in("#{form.ordered_questions[4].ui_selector}_other", with: 'otro 2')
@@ -56,8 +56,8 @@ feature 'Touchpoints', js: true do
 
             find(".pagination-buttons.text-right", visible: true).click_link("Next")
             expect(page).to have_content('Page 3')
-            expect(page).to have_no_content('Page 1')
-            expect(page).to have_no_content('Page 2')
+            expect(page).to_not have_content('Page 1')
+            expect(page).to_not have_content('Page 2')
             select('Option 2', from: form.ordered_questions[6].ui_selector)
             find('.submit_form_button').click
 

--- a/spec/features/embedded_touchpoints_spec.rb
+++ b/spec/features/embedded_touchpoints_spec.rb
@@ -23,9 +23,13 @@ feature 'Touchpoints', js: true do
         context 'default success text' do
           before do
             click_on('Help improve this site') # opens modal
-            expect(page).to have_content('Help improve this site')
 
+            expect(page).to have_content('Help improve this site')
             expect(page).to have_content('Do you have a few minutes to help us test this site?')
+
+            expect(page).to have_content('Page 1')
+            expect(page).to have_no_content('Option elements')
+            expect(page).to have_no_content('Custom elements')
             fill_in form.ordered_questions.first.ui_selector, with: 'input field'
             fill_in form.ordered_questions.second.ui_selector, with: 'email'
             fill_in form.ordered_questions.third.ui_selector, with: 'textarea'
@@ -38,7 +42,9 @@ feature 'Touchpoints', js: true do
             find(".pagination-buttons.text-right", visible: true).click_link("Next")
 
             expect(page).to have_content('Option elements')
-            expect(all("#question_#{form.ordered_questions[4].id} .usa-radio__label").size).to eq(4)
+            expect(page).to have_no_content('Page 1')
+            expect(page).to have_no_content('Custom elements')
+            expect(all("#question_#{form.ordered_questions[4].id} .usa-radio__label").size).to eq(3)
             all("#question_#{form.ordered_questions[4].id} .usa-radio__label").last.click
             fill_in("#{form.ordered_questions[4].ui_selector}_other", with: 'otro 2')
 
@@ -51,6 +57,8 @@ feature 'Touchpoints', js: true do
             select('Option 2', from: form.ordered_questions[6].ui_selector)
             find(".pagination-buttons.text-right", visible: true).click_link("Next")
             expect(page).to have_content('Custom elements')
+            expect(page).to have_no_content('Page 1')
+            expect(page).to have_no_content('Option elements')
             find('.submit_form_button').click
 
             # shows success flash message


### PR DESCRIPTION
A couple of our users' modal surveys began behaving strangely when they were switched to the new USWDS-based modal. In its hidden state, the modal was blocking content on the underlying page. Affected surveys were at:

- https://catalog.data.gov/dataset/series-information-for-2020-census-urban-growth-area-uga-state-based-tiger-line-shapefiles-curr
- https://www.faa.gov/regulations_policies/airworthiness_directives

Both sites are using Bootstrap, which defines a visibility CSS rule:

```
.visible {
  visibility: visible !important;
}
```

This is a case where the CSS on the base site interferes with the styling of our embedded widget. We also use a `visible` class on an element in the modal:

```
<div class="section visible">
```

The USWDS modal conceals itself when closed by applying `visibility: hidden; opacity: 0` to itself.

Put this all together and the `section` element inside our survey is styled as:

.touchpoints-form-wrapper form div.section.visible {
    display: block;
}

.visible {
    visibility: visible !important;
}

.fba-usa-modal-wrapper.is-hidden {
   ~visibility: hidden;~
    opacity: 0;
    position: fixed;
}


which means that [it is invisible but it still accepts pointer events](https://stackoverflow.com/a/34529598).