### PR TITLE
more consistent delete buttons, send emails for dormant forms

### DIFF
--- a/.circleci/cron.sh
+++ b/.circleci/cron.sh
@@ -68,7 +68,7 @@ cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:send_t
 # cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:send_weekly_notifications"
 # cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:check_expiring_forms"
 # cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:archive_forms"
-# cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
+cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
 
 echo "Production tasks have completed."
 

--- a/app/views/admin/barriers/edit.html.erb
+++ b/app/views/admin/barriers/edit.html.erb
@@ -11,8 +11,11 @@
 <%= render 'form', barrier: @barrier %>
 
 <p>
-  <%= link_to admin_barrier_path(@barrier), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary" do %>
-  <i class="fa fa-trash"></i>
-  Delete
+  <%= link_to admin_barrier_path(@barrier), method: :delete, data: { confirm: 'Are you sure?' },
+  class: "usa-button usa-button--secondary" do %>
+    <i class="fas fa-trash"></i>
+    <span class="usa-sr-only">
+      Delete
+    </span>
   <% end %>
 </p>

--- a/app/views/admin/cscrm_data_collections2/edit.html.erb
+++ b/app/views/admin/cscrm_data_collections2/edit.html.erb
@@ -14,9 +14,14 @@
   <%= render "form", cscrm_data_collection: @cscrm_data_collection %>
 
   <%- if @cscrm_data_collection.persisted? %>
-    <%= button_to "Destroy", admin_cscrm_data_collections2_path(@cscrm_data_collection),
+    <%= button_to admin_cscrm_data_collections2_path(@cscrm_data_collection),
         class: "usa-button usa-button--secondary float-right",
-        method: :delete %>
+        method: :delete do %>
+      <i class="fas fa-trash"></i>
+      <span>
+        Delete this collection
+      </span>
+    <% end %>
   <% end %>
   </div>
 </div>

--- a/app/views/admin/forms/_task_bar.html.erb
+++ b/app/views/admin/forms/_task_bar.html.erb
@@ -163,7 +163,9 @@
     <div class="margin-top-2">
     <%= link_to admin_form_path(form), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary width-full" do %>
       <i class="fas fa-trash"></i>
-      Delete
+      <span>
+        Delete
+      </span>
     <% end %>
     </div>
   <% end %>

--- a/app/views/admin/omb_cx_reporting_collections/edit.html.erb
+++ b/app/views/admin/omb_cx_reporting_collections/edit.html.erb
@@ -12,8 +12,11 @@
 <%= render 'form', omb_cx_reporting_collection: @omb_cx_reporting_collection %>
 
 <p>
-  <%= link_to admin_omb_cx_reporting_collection_path(@omb_cx_reporting_collection), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary" do %>
-  <i class="fas fa-trash"></i>
-  Delete
+  <%= link_to admin_omb_cx_reporting_collection_path(@omb_cx_reporting_collection), method: :delete, data: { confirm: 'Are you sure?' },
+    class: "usa-button usa-button--secondary" do %>
+    <i class="fas fa-trash"></i>
+    <span class="usa-sr-only">
+      Delete
+    </span>
   <% end %>
 </p>

--- a/app/views/admin/organizations/edit.html.erb
+++ b/app/views/admin/organizations/edit.html.erb
@@ -13,6 +13,8 @@
 <p>
   <%= link_to admin_organization_path(@organization.slug), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary" do %>
     <i class="fas fa-trash"></i>
-    Delete
+    <span class="usa-sr-only">
+      Delete
+    </span>
   <% end %>
 </p>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -228,7 +228,9 @@
     <%- if admin_permissions? %>
       <%= link_to admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' }, class: "usa-button usa-button--secondary float-right" do %>
         <i class="fas fa-trash"></i>
-        Delete User
+        <span class="usa-sr-only">
+          Delete
+        </span>
       <% end %>
     <% end %>
   </div>

--- a/app/views/components/_roles_and_permissions.html.erb
+++ b/app/views/components/_roles_and_permissions.html.erb
@@ -66,7 +66,9 @@
                 <%- if user != current_user && is_at_least_form_manager?(user: current_user, form: form) %>
                 <a href="javascript:void(0)" class="remove-user usa-button usa-button--secondary float-right" data-id="<%= user.id %>">
                   <i class="fas fa-trash"></i>
-                  Delete
+                  <span class="usa-sr-only">
+                    Delete
+                  </span>
                 </a>
                 <% end %>
               </td>

--- a/spec/features/admin/forms/form_permissions_spec.rb
+++ b/spec/features/admin/forms/form_permissions_spec.rb
@@ -31,7 +31,7 @@ feature 'Forms', js: true do
           end
 
           it 'see the email displayed and can remove the role' do
-            expect(page).to_not have_content('User Role successfully added to Form')
+            expect(page).to have_content('User Role successfully added to Form')
             within(".roles-and-permissions") do
               expect(page).to_not have_content('No users at this time')
             end

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -564,7 +564,7 @@ feature 'Forms', js: true do
         end
 
         describe '/admin/forms/:uuid/example' do
-          describe 'Form with `inline` delivery_method' do
+          context 'Form with `inline` delivery_method' do
             let!(:inline_form) { FactoryBot.create(:form, :open_ended_form, :inline, organization:) }
 
             before '/admin/forms/:uuid/example' do


### PR DESCRIPTION
* correct spec to expect successful flash message
* this PR adds consistent markup to the delete buttons throughout the app. in a few places (like the permissions screen), make the delete text screen-reader only


![Screenshot 2024-09-03 at 2 48 32 PM](https://github.com/user-attachments/assets/573e3ecc-70be-4a46-b104-c8df7838837c)
