### PR TITLE
ensure filtered params are passed to the refreshed results

### DIFF
--- a/app/models/digital_service_account.rb
+++ b/app/models/digital_service_account.rb
@@ -23,11 +23,14 @@ class DigitalServiceAccount < ApplicationRecord
   scope :filtered_accounts, lambda { |query, organization_abbreviation, aasm_state, account|
     @organization = Organization.find_by_abbreviation(organization_abbreviation)
 
+    wildcard_query = "%#{query}%"
+
     items = all
     items = items.tagged_with(@organization.id, context: 'organizations') if @organization.present?
     items = items.where(aasm_state:) if aasm_state.present? && aasm_state.downcase != 'all'
-    items = items.where(account: account) if account.present? && account.downcase != 'all'
-    items = items.where('name ILIKE ?', "%#{query}%") if query.present?
+    items = items.where(service: account) if account.present? && account.downcase != 'all'
+    items = items.where("name ILIKE ? OR account ILIKE ? OR short_description ILIKE ? OR service_url ILIKE ?", wildcard_query, wildcard_query, wildcard_query, wildcard_query) if query && query.length >= 3
+
     items
   }
 

--- a/app/views/admin/digital_service_accounts/_results.html.erb
+++ b/app/views/admin/digital_service_accounts/_results.html.erb
@@ -20,6 +20,10 @@
             <span class="usa-tag bg-success">
               <%= digital_service_account.aasm_state %>
             </span>
+          <% elsif digital_service_account.aasm_state == "created" %>
+            <span class="usa-tag bg-green-cool-10">
+              <%= digital_service_account.aasm_state %>
+            </span>
           <% elsif digital_service_account.aasm_state == "archived" %>
             <span class="usa-tag bg-base-lighter">
               <%= digital_service_account.aasm_state %>
@@ -37,3 +41,10 @@
     <% end %>
   </tbody>
 </table>
+
+<div class="margin-bottom-2">
+  <%= link_to export_admin_digital_service_accounts_path(query: params[:query], org_abbr: params[:org_abbr], account: params[:account], aasm_state: params[:aasm_state], format: :csv), class: "usa-button usa-button--outline" do %>
+    <i class="fa fa-download"></i>
+    Export to CSV
+  <% end %>
+</div>

--- a/app/views/admin/digital_service_accounts/index.html.erb
+++ b/app/views/admin/digital_service_accounts/index.html.erb
@@ -56,22 +56,10 @@
   </div>
 </div>
 
-<p hidden>
-  <%= link_to "Export results to .csv", admin_digital_service_accounts_path(org_abbr: params[:org_abbr], account: params[:account]), class: "usa-button" %>
-</p>
-
 <div class="search-results">
   <%= render 'results', digital_service_accounts: @digital_service_accounts %>
   <%= paginate @digital_service_accounts %>
 </div>
-
-<p>
-  <a href="/admin/digital_service_accounts/export" class="usa-button usa-button--outline">
-    <i class="fa fa-download"></i>
-    Export to CSV
-  </a>
-  <%= link_to "Export results to .csv", export_admin_digital_service_accounts_path(query: params[:query], org_abbr: params[:org_abbr], account: params[:account], aasm_state: params[:aasm_state], format: :csv), class: "usa-button" %>
-</p>
 
 <script>
   function performSearch() {

--- a/spec/controllers/api/v1/cx_responses_controller_spec.rb
+++ b/spec/controllers/api/v1/cx_responses_controller_spec.rb
@@ -64,7 +64,7 @@ describe Api::V1::CxResponsesController, type: :controller do
           expect(@parsed_response['data'].size).to eq(500)
           expect(@parsed_response['data'].first.class).to be(Hash)
           expect(@parsed_response['data'].first["type"]).to eq("cx_responses")
-          expect(@parsed_response['data'].first['id']).to eq(cx_response.id.to_s)
+          expect(@parsed_response['data'].first['id'].to_s).to eq(cx_response.id.to_s)
         end
       end
 
@@ -83,7 +83,7 @@ describe Api::V1::CxResponsesController, type: :controller do
           expect(@parsed_response['data'].size).to eq(100)
           expect(@parsed_response['data'].last.class).to be(Hash)
           expect(@parsed_response['data'].last["type"]).to eq("cx_responses")
-          expect(@parsed_response['data'].last['id']).to eq(CxResponse.last.id.to_s)
+          expect(@parsed_response['data'].last['id'].to_s).to eq(CxResponse.last.id.to_s)
         end
       end
     end


### PR DESCRIPTION
* use same query params for service accounts as before