### PR TITLE
A11 combined export

### DIFF
--- a/app/controllers/admin/digital_products_controller.rb
+++ b/app/controllers/admin/digital_products_controller.rb
@@ -212,8 +212,10 @@ module Admin
       search_text = params[:search]
       organization_id = params[:organization_id]
 
+      search_text = "%#{search_text}%"
+
       @digital_products = DigitalProduct.all
-      @digital_products = @digital_products.where("name ilike '%#{search_text}%'") if search_text && search_text.length >= 3
+      @digital_products = @digital_products.where("name ILIKE ?", search_text) if search_text && search_text.length >= 3
       @digital_products = @digital_products.tagged_with(organization_id, context: 'organizations') if organization_id.present? && organization_id != ''
       @digital_products = @digital_products.where(service: params[:service]) if params[:service].present? && params[:service] != 'All'
       @digital_products = @digital_products.where(aasm_state: params[:aasm_state].downcase) if params[:aasm_state].present? && params[:aasm_state] != 'All'

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -171,7 +171,7 @@ module Admin
       tag_name = params[:tag]
       if search_text.present?
         search_text = "%#{search_text}%"
-        @organizations = Organization.where(' domain ilike ? or name ilike ? or abbreviation ilike ? or url ilike ?  ', search_text, search_text, search_text, search_text)
+        @organizations = Organization.where('domain ILIKE ? or name ILIKE ? or abbreviation ILIKE ? or url ILIKE ?', search_text, search_text, search_text, search_text)
       elsif tag_name.present?
         @organizations = Organization.tagged_with(tag_name)
       else

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -688,6 +688,12 @@ class Form < ApplicationRecord
 
   # use this validator to provide soft UI guidance, rather than strong model validation
   def ensure_a11_v2_format
+    # ensure `answer_01` is a big thumbs question
+    question_1 = self.ordered_questions.find { |q| q.answer_field == "answer_01" }
+    if question_1.question_type != 'big_thumbs_up_down_buttons'
+      errors.add(:base, "The question for `answer_01` must be a \"Big Thumbs Up/Down\" component")
+    end
+
     # ensure the form has the 4 required questions
     required_elements = ["answer_01", "answer_02", "answer_03", "answer_04"]
     unless contains_elements?(questions.collect(&:answer_field), required_elements)

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -8,11 +8,6 @@
     Export All Responses to CSV
   <% end %>
   <br>
-  <%- if form.kind == "a11_v2" %>
-  <p>
-  <%= link_to "Export A11-v2 Responses to CSV", export_a11_v2_submissions_admin_form_url(form, start_date: "2019-10-01"), class: "usa-button" %>
-  </p>
-  <% end -%>
   <p>
     <%= link_to "Export FY2020", export_admin_form_url(form, start_date: "2019-10-01", end_date: "2020-09-30"), class: "usa-button usa-button--outline" %>
     <%= link_to "Export FY2021", export_admin_form_url(form, start_date: "2020-10-01", end_date: "2021-09-30"), class: "usa-button usa-button--outline" %>
@@ -20,6 +15,19 @@
     <%= link_to "Export FY2023", export_admin_form_url(form, start_date: "2022-10-01", end_date: "2023-09-30"), class: "usa-button usa-button--outline" %>
     <%= link_to "Export FY2024", export_admin_form_url(form, start_date: "2023-10-01", end_date: "2024-09-30"), class: "usa-button usa-button--outline" %>
   </p>
+  <%- if form.kind == "a11_v2" %>
+  <div class="margin-top-6">
+    <span class="usa-tag">
+      A-11 v2 Reporting
+    </span>
+    <p>
+    <%= link_to "Export A11-v2 Responses to CSV", export_a11_v2_submissions_admin_form_url(form, start_date: "2019-10-01"), class: "usa-button" %>
+    </p>
+    <p>
+    <%= link_to "Export Form + A11-v2 Responses to CSV", export_form_and_a11_v2_submissions_admin_form_url(form, start_date: "2019-10-01"), class: "usa-button" %>
+    </p>
+  </div>
+  <% end -%>
 <% else %>
   <div class="usa-alert usa-alert--info">
     <div class="usa-alert__body">

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -475,7 +475,7 @@ FactoryBot.define do
 
     trait :a11_v2 do
       name { 'Version 2 of the A11 form' }
-      kind { 'custom' }
+      kind { 'a11_v2' }
       after(:create) do |f, _evaluator|
         FactoryBot.create(:question,
                           :with_radio_buttons,

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -486,20 +486,29 @@ FactoryBot.define do
                           position: 1,
                           )
         FactoryBot.create(:question,
-                          :with_checkbox_options,
+                          :with_a11_v2_checkbox_options,
                           form: f,
                           answer_field: :answer_02,
                           form_section: f.form_sections.first,
-                          text: 'Name',
+                          text: 'Positive indicators',
                           position: 2,
                           )
         FactoryBot.create(:question,
+                          :with_a11_v2_checkbox_options,
                           form: f,
                           answer_field: :answer_03,
                           question_type: 'textarea',
                           form_section: f.form_sections.first,
-                          text: 'Additional comments',
+                          text: 'Negative indicators',
                           position: 3
+                          )
+        FactoryBot.create(:question,
+                          form: f,
+                          answer_field: :answer_04,
+                          question_type: 'textarea',
+                          form_section: f.form_sections.first,
+                          text: 'Additional comments',
+                          position: 4
                           )
       end
     end

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -478,10 +478,9 @@ FactoryBot.define do
       kind { 'a11_v2' }
       after(:create) do |f, _evaluator|
         FactoryBot.create(:question,
-                          :with_radio_buttons,
                           form: f,
                           answer_field: :answer_01,
-                          question_type: 'star_radio_buttons',
+                          question_type: 'big_thumbs_up_down_buttons',
                           form_section: f.form_sections.first,
                           text: 'Please rate your experience as a customer of Agency of Departments.',
                           position: 1,

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -49,6 +49,20 @@ FactoryBot.define do
       end
     end
 
+    trait :with_a11_v2_checkbox_options do
+      text { 'Indicators' }
+      question_type { 'checkbox' }
+      after(:create) do |checkbox_question, _evaluator|
+        FactoryBot.create(:question_option, question: checkbox_question, position: 1, text: 'effectiveness')
+        FactoryBot.create(:question_option, question: checkbox_question, position: 2, text: 'ease')
+        FactoryBot.create(:question_option, question: checkbox_question, position: 3, text: 'efficiency')
+        FactoryBot.create(:question_option, question: checkbox_question, position: 4, text: 'transparency')
+        FactoryBot.create(:question_option, question: checkbox_question, position: 4, text: 'humanity')
+        FactoryBot.create(:question_option, question: checkbox_question, position: 4, text: 'employee')
+        FactoryBot.create(:question_option, question: checkbox_question, position: 4, text: 'other')
+      end
+    end
+
     trait :with_dropdown_options do
       text { 'Test Dropdown Question' }
       question_type { 'dropdown' }

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -1337,6 +1337,41 @@ feature 'Forms', js: true do
     end
   end
 
+  context 'Form Manager with an A11 v2 form' do
+    let(:user) { FactoryBot.create(:user, organization:) }
+    let(:form) { FactoryBot.create(:form, :a11_v2, organization:) }
+    let!(:user_role) { FactoryBot.create(:user_role, :form_manager, form:, user: user) }
+
+    describe "a valid a11 form" do
+      before do
+        login_as(user)
+        visit question_admin_form_path(form)
+      end
+
+      it 'can edit form' do
+        expect(page.current_path).to eq(edit_admin_form_path(form))
+        expect(page).to have_content('Editing Form')
+      end
+    end
+
+    describe "an invalid a11 form" do
+      before do
+        q1 = form.ordered_questions.first
+        q1.update(question_type: "radio_buttons") # update this question to an invalid question_type (for the a11-v2)
+        login_as(user)
+        visit questions_admin_form_path(form)
+      end
+
+      it 'displays a11 v2 form validation warnings' do
+        expect(page).to have_content('This form needs attention:')
+        expect(page).to have_content('The question for `answer_01` must be a "Big Thumbs Up/Down" component')
+        expect(page).to have_content('The A-11 v2 form must have questions for answer_01, answer_02, answer_03, and answer_04')
+        expect(page).to have_content('The question options for Question 2 must include: effectiveness, ease')
+        expect(page).to have_content('The question options for Question 3 must include: effectiveness, ease')
+      end
+    end
+  end
+
   context 'Form owner with Form Manager permissions' do
     let(:user) { FactoryBot.create(:user, organization:) }
     let(:form) { FactoryBot.create(:form, :custom, organization:) }

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -1348,9 +1348,10 @@ feature 'Forms', js: true do
         visit questions_admin_form_path(form)
       end
 
-      it 'can edit form' do
-        expect(page.current_path).to eq(edit_admin_form_path(form))
-        expect(page).to have_content('Editing Form')
+      it 'displays no validation warnings' do
+        expect(page.current_path).to eq(questions_admin_form_path(form))
+        expect(page).to_not have_content('This form needs attention:')
+        expect(page).to have_content("Please rate your experience as a customer of Agency of Departments.")
       end
     end
 
@@ -1358,6 +1359,11 @@ feature 'Forms', js: true do
       before do
         q1 = form.ordered_questions.first
         q1.update(question_type: "radio_buttons") # update this question to an invalid question_type (for the a11-v2)
+        q2 = form.ordered_questions.second
+        q2.question_options.delete_all
+        q3 = form.ordered_questions.third
+        q3.question_options.delete_all
+        q4 = form.ordered_questions.last.destroy # remove question 4
         login_as(user)
         visit questions_admin_form_path(form)
       end

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -1345,7 +1345,7 @@ feature 'Forms', js: true do
     describe "a valid a11 form" do
       before do
         login_as(user)
-        visit question_admin_form_path(form)
+        visit questions_admin_form_path(form)
       end
 
       it 'can edit form' do

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -1679,6 +1679,22 @@ feature 'Forms', js: true do
           end
         end
       end
+
+      context 'when Submissions exist for an a11_v2 form' do
+        describe 'click the combine export button' do
+          let(:form) { FactoryBot.create(:form, :a11_v2, organization:) }
+          let!(:submission) { FactoryBot.create(:submission, form:) }
+
+          before do
+            visit responses_admin_form_path(form)
+          end
+
+          it 'click the combine export button then see a flash message for an async job' do
+            click_on("Export Form + A11-v2 Responses to CSV")
+            expect(page).to have_content("Touchpoints has initiated an asynchronous job that will take a few minutes.")
+          end
+        end
+      end
     end
 
     context 'user for another Form' do

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -485,10 +485,11 @@ feature 'Touchpoints', js: true do
         expect(page).to have_content("This is help text.")
         find("svg[aria-labelledby='thumbs-up-icon']").click # the thumbs up
         expect(page).to have_content("Positive indicators")
-        expect(page).to have_content("One")
-        expect(page).to have_content("Two")
-        expect(page).to have_content("Three")
-        expect(page).to have_content("Four")
+        expect(page).to have_content("effectiveness")
+        expect(page).to have_content("ease")
+        expect(page).to have_content("efficiency")
+        expect(page).to have_content("transparency")
+        find("label[for='question_option_1']").click
         find("label[for='question_option_4']").click
         click_button 'Submit'
 
@@ -496,9 +497,9 @@ feature 'Touchpoints', js: true do
 
         last_submission = Submission.last
         expect(last_submission.answer_01).to eq '1'
-        expect(last_submission.answer_02).to eq 'Four'
+        expect(last_submission.answer_02).to eq 'effectiveness,transparency'
         expect(last_submission.answer_03).to eq ""
-        expect(last_submission.answer_04).to eq nil
+        expect(last_submission.answer_04).to eq ""
       end
     end
 

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -484,7 +484,7 @@ feature 'Touchpoints', js: true do
         expect(page).to have_content(form.title)
         expect(page).to have_content("This is help text.")
         find("svg[aria-labelledby='thumbs-up-icon']").click # the thumbs up
-        expect(page).to have_content("Name")
+        expect(page).to have_content("Positive indicators")
         expect(page).to have_content("One")
         expect(page).to have_content("Two")
         expect(page).to have_content("Three")

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -474,25 +474,31 @@ feature 'Touchpoints', js: true do
     end
 
     describe 'A-11 Version 2 Form' do
-      let!(:custom_form) { FactoryBot.create(:form, :a11_v2, organization:) }
+      let!(:a11_v2_form) { FactoryBot.create(:form, :a11_v2, organization:) }
 
       before do
-        visit submit_touchpoint_path(custom_form)
-        expect(page).to have_content("This is help text.")
-        find("label[for='#{custom_form.ordered_questions.first.ui_selector}_star4']").click
-        fill_in(custom_form.ordered_questions.last.ui_selector, with: 'User feedback')
-        click_button 'Submit'
+        visit submit_touchpoint_path(a11_v2_form)
       end
 
       it 'submits successfully' do
+        expect(page).to have_content(form.title)
+        expect(page).to have_content("This is help text.")
+        find("svg[aria-labelledby='thumbs-up-icon']").click # the thumbs up
+        expect(page).to have_content("Name")
+        expect(page).to have_content("One")
+        expect(page).to have_content("Two")
+        expect(page).to have_content("Three")
+        expect(page).to have_content("Four")
+        find("label[for='question_option_4']").click
+        click_button 'Submit'
+
         expect(page).to have_content('Thank you. Your feedback has been received.')
 
-        # Asserting against the database/model directly here isn't ideal.
-        # An alternative is to send location_code back to the client and assert against it
         last_submission = Submission.last
-        expect(last_submission.answer_01).to eq '4'
-        # expect(last_submission.answer_02).to eq "TEST_LOCATION_CODE"
-        expect(last_submission.answer_03).to eq 'User feedback'
+        expect(last_submission.answer_01).to eq '1'
+        expect(last_submission.answer_02).to eq 'Four'
+        expect(last_submission.answer_03).to eq ""
+        expect(last_submission.answer_04).to eq nil
       end
     end
 


### PR DESCRIPTION
This branch is primarily about adding this button to trigger the combined form and a11 download.

![Screenshot 2024-09-06 at 3 21 44 PM](https://github.com/user-attachments/assets/bbd1f195-c2e5-425e-a33a-33339649440d)

It also adds a soft-validation when viewing an A-11 v2 form, if the `answer_01` question isn't a big thumbs component.
