### PR TITLE
Set max width and border on 'new' version of inline widget.

### DIFF
--- a/app/views/components/widget/_fba2.js.erb
+++ b/app/views/components/widget/_fba2.js.erb
@@ -82,6 +82,7 @@ function FBAform(d, N) {
 		} else if (this.options.deliveryMethod && this.options.deliveryMethod === 'inline') { <%# inject the form interface for inline with the modal wrapper %>
 			if (this.options.elementSelector) {
 				if(d.getElementById(this.options.elementSelector) != null) {
+					d.getElementById(this.options.elementSelector).classList.add('fba-inline-container');
 					d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBody();
 				}
 			}

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -98,6 +98,11 @@
     max-width: inherit;
 }
 <% else %>
+.fba-modal-dialog {
+  font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
+  font-size: 100%;
+}
+
 .fba-modal-dialog h1 {
   margin-right: 20px;
   margin-top: -1rem;

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -105,6 +105,13 @@
 }
 <% end %>
 
+.fba-inline-container {
+  background: #fff;
+  border: 1px solid #E5E5E5;
+  max-width: 35rem;
+  margin: 0 auto 40px auto;
+}
+
 .fixed-tab-button {
   bottom: 0;
   padding: 5px 10px;


### PR DESCRIPTION
The code changes that switched the modal version of our widget to use the USWDS modal also changed the appearance of the inline version of the widget. This PR restores the original appearance of the inline widget.

Inline widget before the USWDS modal changes:
<img width="1507" alt="Screenshot 2024-09-18 at 10 18 34 AM" src="https://github.com/user-attachments/assets/be4fbf91-6c40-4743-94b5-0f3ffb709b02">

Inline widget after the USWDS modal changes:
<img width="1511" alt="Screenshot 2024-09-18 at 10 19 32 AM" src="https://github.com/user-attachments/assets/40eea2d3-4c45-4b3d-b36b-12297b30c983">


Inline widget after this PR:

<img width="1502" alt="Screenshot 2024-09-18 at 10 21 24 AM" src="https://github.com/user-attachments/assets/fc98214a-9942-4382-95e1-0542f17fd1d2">

