### PR TITLE
Set legacy_form_embed = false when a form is copied.

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -220,6 +220,7 @@ class Form < ApplicationRecord
     new_form.legacy_touchpoint_uuid = nil
     new_form.template = false
     new_form.organization = new_user.organization
+    new_form.legacy_form_embed = false
     new_form.save!
 
     # Manually remove the Form Section created with create_first_form_section


### PR DESCRIPTION
When a legacy form is copied, the copy should not be legacy.

Making this change has 2 effects:

1. Prevents new forms from being created with the legacy setting (we're trying to drive the number of legacy forms down to zero, so new legacy forms being created is not helpful).
2. Users who are stuck on the legacy form and trying to convert can easily create a non-legacy copy of their form to test changes on.