### PR TITLE
Don't use generic class 'wrapper' in embedded widget.

### DIFF
--- a/app/views/components/widget/_no_modal.html.erb
+++ b/app/views/components/widget/_no_modal.html.erb
@@ -3,7 +3,7 @@
   id="touchpoints-form-<%= form.short_uuid %>"
   data-touchpoints-form-id="<%= form.short_uuid %>"
 >
-  <div class="wrapper">
+  <div class="touchpoints-inner-form-wrapper">
     <%- if form.legacy_form_embed %>
     <%- unless form.delivery_method == "inline" %>
       <a class="fba-modal-close"

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -24,7 +24,7 @@
     word-wrap: break-word;
 }
 
-.fba-modal-dialog .wrapper {
+.fba-modal-dialog .touchpoints-inner-form-wrapper {
     padding-left: 20px;
     padding-right: 20px;
 }


### PR DESCRIPTION
We use the CSS class name "wrapper" in our embedded widget. This is a pretty generic name that is likely to also be used by some of the sites our widget is embedded in. For instance, Touchpoints is used on https://www.dfas.mil/contractorsvendors/phonenumbers/ and that site has a CSS rule:

```
.wrapper {
    box-shadow: 10px 7px 14px 4px rgba(0,0,0,.12),-10px 7px 14px 4px rgba(0,0,0,.12);
    -webkit-box-shadow: 10px 7px 14px 4px rgba(0,0,0,.12),-10px 7px 14px 4px rgba(0,0,0,.12);
    background: #fff;
    margin: 0 auto;
    max-width: 1170px;
}
```
which affects the appearance of the Touchpoints widget in some cases.

This PR changes the class name to something much less likely to conflict.