### PR TITLE
USDR account to service

### DIFF
--- a/app/models/digital_service_account.rb
+++ b/app/models/digital_service_account.rb
@@ -14,7 +14,7 @@ class DigitalServiceAccount < ApplicationRecord
 
   validates :name, presence: true
   validates :name, uniqueness: { scope: :account }
-  validates :account, presence: true
+  validates :service, presence: true
   validate :validate_account_types
   validates :service_url, presence: true
   validates :service_url, uniqueness: true

--- a/app/views/admin/digital_service_accounts/_form.html.erb
+++ b/app/views/admin/digital_service_accounts/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= form.label :account, "Account platform", class: "usa-label" %>
-    <%= form.select :account, options_for_select(DigitalServiceAccount.list, form.object.account), { prompt: "Select" }, class: "usa-select", required: true %>
+    <%= form.select :account, options_for_select(DigitalServiceAccount.list, form.object.service), { prompt: "Select" }, class: "usa-select", required: true %>
   </div>
 
   <div class="field">

--- a/app/views/admin/digital_service_accounts/_results.html.erb
+++ b/app/views/admin/digital_service_accounts/_results.html.erb
@@ -11,7 +11,7 @@
   <tbody>
     <% digital_service_accounts.each do |digital_service_account| %>
       <tr>
-        <td><%= digital_service_account.account %></td>
+        <td><%= digital_service_account.service %></td>
         <td>
           <%= link_to digital_service_account.name, admin_digital_service_account_path(digital_service_account) %>
         </td>

--- a/app/views/admin/digital_service_accounts/review.html.erb
+++ b/app/views/admin/digital_service_accounts/review.html.erb
@@ -35,8 +35,8 @@
     <% @digital_service_accounts.each do |digital_service_account| %>
     <tr>
       <td>
-        <%- if digital_service_account.account? %>
-        <%= link_to digital_service_account.account, admin_digital_service_account_path(digital_service_account) %>
+        <%- if digital_service_account.service? %>
+        <%= link_to digital_service_account.service, admin_digital_service_account_path(digital_service_account) %>
         <% else %>
         <%= link_to "** unnamed account **", admin_digital_service_account_path(digital_service_account) %>
         <% end %>

--- a/app/views/admin/digital_service_accounts/show.html.erb
+++ b/app/views/admin/digital_service_accounts/show.html.erb
@@ -43,7 +43,7 @@
     <p>
       <%= label_tag "Account type", nil, class: "usa-label" %>
       <br>
-      <%= @digital_service_account.account %>
+      <%= @digital_service_account.service %>
     </p>
 
     <p>

--- a/app/views/user_mailer/social_media_account_created_notification.html.erb
+++ b/app/views/user_mailer/social_media_account_created_notification.html.erb
@@ -6,7 +6,7 @@
 
 <h2>Social Media Account Details</h2>
 <p><em>Social Media Account Name:</em> <%= @digital_service_account.name %></p>
-<p><em>Account Type:</em> <%= @digital_service_account.account %></p>
+<p><em>Account Type:</em> <%= @digital_service_account.service %></p>
 <p><em>Account URL:</em> <%= @digital_service_account.service_url %></p>
 <p><em>Short Description:</em> <%= @digital_service_account.short_description %></p>
 <p><em>Long Description:</em> <%= @digital_service_account.long_description %></p>

--- a/app/views/user_mailer/social_media_account_created_notification.text.erb
+++ b/app/views/user_mailer/social_media_account_created_notification.text.erb
@@ -6,9 +6,9 @@ Social Media Account Details
 
 Social Media Account Name: <%=@digital_service_account.name %>
 
-Account Type: <%= @digital_service_account.account %>
+Service Type: <%= @digital_service_account.service %>
 
-Account URL: <%= @digital_service_account.service_url %>
+Service URL: <%= @digital_service_account.service_url %>
 
 Short Description: <%= @digital_service_account.short_description %>
 


### PR DESCRIPTION
this PR deprecates the duplicative 'account' field which is/should be the same as 'service' field

note: the USDR may be deprecated as well, given M-17-06 was rescinded by M-23-22