### PR TITLE
refactor submissions status to a single-click

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -220,7 +220,7 @@ module Admin
     end
 
     def status_params
-      params.require(:submission).permit(:aasm_state)
+      params.permit(:aasm_state)
     end
 
     def tag_params

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -31,7 +31,7 @@ class Submission < ApplicationRecord
       transitions from: [:acknowledged], to: :dispatched
     end
     event :respond do
-      transitions from: %i[dispatched archived], to: :responded
+      transitions from: %i[dispatched], to: :responded
     end
     event :archive do
       transitions to: :archived

--- a/app/views/admin/submissions/_status_form.html.erb
+++ b/app/views/admin/submissions/_status_form.html.erb
@@ -1,39 +1,42 @@
-<%= form_with(model: submission, url: admin_form_submission_path(form, submission), local: true) do |f| %>
-  <%- if form.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(form.errors.count, "error") %> prohibited this form from being saved:</h2>
+<fieldset class="usa-fieldset">
+  <legend class="usa-legend font-serif-md">Submissions status
+    <%= link_to "https://github.com/GSA/touchpoints/wiki/Feedback-lifecyle", target: "_blank", rel: "noopener" do %>
+      <span class="fa fa-info-circle"></span>
+    <% end %>
+  </legend>
+  <p class="font-sans-xs">
+    Every response begins with a "received" status.
+    You have the option to track additional states of a response by updating its status.
+  </p>
 
-      <% form.errors.full_messages.each do |message| %>
-        <div class="usa-alert usa-alert--error">
-          <div class="usa-alert__body">
-            <h3 class="usa-alert__heading">Error</h3>
-            <p class="usa-alert__text">
-              <%= message %>
-            </p>
+  <ol class="usa-process-list">
+    <% @submission.aasm.states.each do |state| %>
+      <li class="usa-process-list__item padding-bottom-4">
+        <p class="usa-process-list__heading font-sans-md line-height-sans-4">
+          <span class="<%= @submission.aasm_state == state.name.to_s ? "" : "text-normal text-base-lighter" %>">
+            <%= state.name.capitalize %>
+          </span>
+          <br>
+          <div class="font-sans-xs">
+          <% unique_transitions = Set.new %>
+          <% @submission.aasm.events(permitted: true).each do |event| %>
+            <% if @submission.aasm_state == state.to_s %>
+              <% event.transitions.each do |transition| %>
+                <% if unique_transitions.add?(transition.to) && @submission.aasm_state != transition.to.to_s  %>
+                  <%= link_to event.to_s.capitalize,
+                        admin_form_submission_path(form, @submission, aasm_state: transition.to),
+                        method: :patch
+                  %>&nbsp;
+                  <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
           </div>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-
-  <div class="grid-row grid-gap-md">
-    <div class="grid-col-12">
-      <p>
-        Every response begins with a "received" status.
-        You have the option to track
-        additional states of a response by updating its status.
-      </p>
-      <fieldset class="usa-fieldset">
-        <div>
-          <%= f.label :aasm_state, "Status", class: "usa-label" %>
-          <%= f.select :aasm_state, [:received, :acknowledged, :dispatched, :responded], {}, class: "usa-select" %>
-        </div>
-      </fieldset>
-    </div>
-  </div>
-  <br>
-  <%= f.submit "Update status", class: "usa-button" %>
-<% end %>
+        </p>
+    </li>
+    <% end %>
+  </ol>
+</fieldset>
 
 <script>
   $(function(){

--- a/app/views/admin/submissions/_status_form.html.erb
+++ b/app/views/admin/submissions/_status_form.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="usa-fieldset">
-  <legend class="usa-legend font-serif-md">Submissions status
+  <legend class="usa-legend font-serif-md">Submission status
     <%= link_to "https://github.com/GSA/touchpoints/wiki/Feedback-lifecyle", target: "_blank", rel: "noopener" do %>
       <span class="fa fa-info-circle"></span>
     <% end %>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -193,22 +193,8 @@
   </div>
   <div class="grid-col-4">
     <div class="well usa-section usa-section--dark">
-      <div class="text-uppercase font-body-3xs">
-        Processing each response
-      </div>
       <%= render 'admin/submissions/status_form', { form: @form, submission: @submission } %>
     </div>
-    <div class="usa-alert usa-alert--info usa-alert--slim">
-      <div class="usa-alert__body">
-        <p class="usa-alert__text">
-          About the
-          <%= link_to "https://github.com/GSA/touchpoints/wiki/Feedback-lifecyle", target: "_blank", rel: "noopener" do %>
-          Feedback lifecycle
-          <% end %>
-        </p>
-      </div>
-    </div>
-    <br>
     <div class="tags-div well">
       <%= render 'admin/submissions/tags', submission: @submission %>
     </div>

--- a/spec/features/admin/submissions_spec.rb
+++ b/spec/features/admin/submissions_spec.rb
@@ -104,10 +104,7 @@ feature 'Submissions', js: true do
               end
 
               it 'try to update a submission that has had its question validations changed' do
-                select("acknowledged", from: 'submission_aasm_state')
-                select("responded", from: 'submission_aasm_state')
-                click_on("Update status")
-
+                click_on("Acknowledge")
                 expect(page).to have_content("Response could not be updated.")
               end
             end


### PR DESCRIPTION
## Before

![Screenshot 2025-01-07 at 3 29 37 PM](https://github.com/user-attachments/assets/6429563b-197a-4ddd-9c1b-50bd4eaab124)

## After

![Screenshot 2025-01-07 at 3 30 07 PM](https://github.com/user-attachments/assets/456dc2ff-8f03-431b-970e-dc365a978342)

