### PR TITLE
submission with tags update

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -220,7 +220,17 @@ module Admin
     end
 
     def status_params
-      params.permit(:aasm_state)
+      permitted_params = params.permit(:aasm_state)
+
+      if permitted_params[:aasm_state].present?
+        unless Submission.aasm.states.map(&:name).include?(permitted_params[:aasm_state].to_sym)
+          raise ActionController::ParameterMissing, "Invalid state: #{permitted_params[:aasm_state]}"
+        end
+      else
+        raise ActionController::ParameterMissing, "aasm_state parameter is missing"
+      end
+
+      permitted_params
     end
 
     def tag_params

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -62,6 +62,7 @@ class Submission < ApplicationRecord
     answered_questions.delete('language')
     answered_questions.delete('referer')
     answered_questions.delete('aasm_state')
+    answered_questions.delete('tags')
     answered_questions.delete('spam_score')
     answered_questions.delete('created_at')
     answered_questions.delete('updated_at')

--- a/app/views/admin/submissions/_status_form.html.erb
+++ b/app/views/admin/submissions/_status_form.html.erb
@@ -12,7 +12,7 @@
   <ol class="usa-process-list">
     <% @submission.aasm.states.each do |state| %>
       <li class="usa-process-list__item padding-bottom-4">
-        <p class="usa-process-list__heading font-sans-md line-height-sans-4">
+        <p class="usa-process-list__heading font-sans-md line-height-sans-2">
           <span class="<%= @submission.aasm_state == state.name.to_s ? "" : "text-normal text-base-lighter" %>">
             <%= state.name.capitalize %>
           </span>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -36,7 +36,7 @@
           <label class="usa-label">
             Organization
           </label>
-          <%= link_to(@submission.form.organization.name, admin_organization_path(@submission.form.organization)) %>
+          <%= render "admin/organizations/badge", organization: @submission.form.organization %>
         </div>
         <div class="grid-col-4">
           <label class="usa-label">

--- a/spec/features/admin/submissions_spec.rb
+++ b/spec/features/admin/submissions_spec.rb
@@ -109,6 +109,21 @@ feature 'Submissions', js: true do
               end
             end
           end
+
+          context 'with one Response that has tags' do
+            let!(:submission) { FactoryBot.create(:submission, form:, tags: ["this", "that"]) }
+
+            describe 'click View link in responses table' do
+              before do
+                visit admin_form_submission_path(form, submission)
+              end
+
+              it 'update a submission that has tags' do
+                click_on("Acknowledge")
+                expect(page).to have_content("Response was successfully updated.")
+              end
+            end
+          end
         end
 
         describe 'tag a Response' do


### PR DESCRIPTION
## Issue / Bug

Submissions that have tags were not able to have their status changed by Form Managers.

## Cause

This was caused by additional validations on incoming Submission that were added in December.

## Action taken

Prevent tags from being considered when a Submission is updated.
This prevents the Submission validation from flagging tags when a Submission is updated (which was the cause of the error).

An automated test was added for this case as well.