### PR TITLE
bulk actions on submissions

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -461,8 +461,8 @@ span.usa-hint.save-notice {
   }
   .question {
     margin: 10px 0;
-    padding-bottom: 20px;
-    padding-left: 20px;
+    padding-bottom: 1rem;
+    padding-left: 1rem;
     padding-top: 1px;
     padding-right: 1rem;
   }
@@ -608,4 +608,13 @@ abbr[title=required] {
   .usa-table .usa-nav__primary button[aria-expanded=false] span::after {
     right: auto;
   }
+}
+
+#batch-actions {
+  background-color: #f0f0f0;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
 }

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -20,6 +20,7 @@ module Admin
       responses_by_status
       performance_gov
       submissions_table
+      bulk_update
     ]
 
     def show; end
@@ -202,6 +203,36 @@ module Admin
       end
 
       all_question_responses
+    end
+
+    def bulk_update
+      submission_ids = params[:submission_ids] # Array of selected form_response ids
+      bulk_action = params[:bulk_action] # The selected action ('archive' or 'change_status')
+
+      if submission_ids.present?
+        submissions = @form.submissions.where(id: submission_ids)
+
+        case bulk_action
+        when 'archive'
+          submissions.each do |submission|
+            Event.log_event(Event.names[:response_archived], 'Submission', submission.id, "Submission #{submission.id} archived at #{DateTime.now}", current_user.id)
+            submission.archive_without_validation!
+          end
+          flash[:notice] = "#{submissions.count} Submissions archived."
+        when 'flag'
+          submissions.each do |submission|
+            Event.log_event(Event.names[:response_flagged], 'Submission', submission.id, "Submission #{submission.id} flagged at #{DateTime.now}", current_user.id)
+            submission.update_attribute(:flagged, true)
+          end
+          flash[:notice] = "#{submissions.count} Submissions flagged."
+        else
+          flash[:alert] = "Invalid action selected."
+        end
+      else
+        flash[:alert] = "No Submissions selected."
+      end
+
+      redirect_to responses_admin_form_path(@form)
     end
 
     private

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -206,8 +206,8 @@ module Admin
     end
 
     def bulk_update
-      submission_ids = params[:submission_ids] # Array of selected form_response ids
-      bulk_action = params[:bulk_action] # The selected action ('archive' or 'change_status')
+      submission_ids = params[:submission_ids] # Array of selected submission_ids
+      bulk_action = params[:bulk_action] # The selected action ('flag' or 'archive')
 
       if submission_ids.present?
         submissions = @form.submissions.where(id: submission_ids)

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -225,6 +225,12 @@ module Admin
             submission.update_attribute(:flagged, true)
           end
           flash[:notice] = "#{submissions.count} Submissions flagged."
+        when 'spam'
+          submissions.each do |submission|
+            Event.log_event(Event.names[:response_marked_as_spam], 'Submission', submission.id, "Submission #{submission.id} marked as spam at #{DateTime.now}", current_user.id)
+            submission.update_attribute(:spam, true)
+          end
+          flash[:notice] = "#{submissions.count} Submissions marked as 'spam'."
         else
           flash[:alert] = "Invalid action selected."
         end

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -230,7 +230,7 @@ module Admin
             Event.log_event(Event.names[:response_marked_as_spam], 'Submission', submission.id, "Submission #{submission.id} marked as spam at #{DateTime.now}", current_user.id)
             submission.update_attribute(:spam, true)
           end
-          flash[:notice] = "#{submissions.count} Submissions marked as 'spam'."
+          flash[:notice] = "#{submissions.count} Submissions marked as spam."
         else
           flash[:alert] = "Invalid action selected."
         end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -57,6 +57,7 @@ class Event < ApplicationRecord
     cx_collection_detail_upload_created: 'cx_collection_detail_upload_created',
     cx_collection_detail_upload_deleted: 'cx_collection_detail_upload_deleted',
 
+    response_marked_as_spam: 'response_marked_as_spam',
     response_flagged: 'response_flagged',
     response_unflagged: 'response_unflagged',
     response_archived: 'response_archived',

--- a/app/views/admin/submissions/_submissions.html.erb
+++ b/app/views/admin/submissions/_submissions.html.erb
@@ -60,25 +60,31 @@
 <p>
   <%= paginate submissions, remote: true %>
 </p>
-
-
 <div class="responses table-scroll">
-  <div class="table-wrap">
   <%= form_with url: bulk_update_admin_form_submissions_path(form), method: :post do |f| %>
-    <div
-      id="batch-actions">
-      <label for="bulk_action">Bulk Action:</label>
-      <span id="selected-count" class="margin-right-1"></span>
-      <button class="usa-button" name="bulk_action" type="submit" value="flag">
-        <i class="far fa-flag"></i>
-        Flag
-      </button>
-      <button class="usa-button usa-button--accent-cool" id="archive-button" type="button">
-        <i class="fa fa-inbox"></i>
-        Archive
-      </button>
-    </div>
-    <table class="usa-table submissions">
+  <div
+    id="batch-actions">
+    <label for="bulk_action">Bulk Action:</label>
+    <span id="selected-count" class="margin-right-1"></span>
+    <button
+      class="usa-button"
+      name="bulk_action"
+      type="submit"
+      value="flag">
+      <i class="far fa-flag"></i>
+      Flag
+    </button>
+    <button
+      class="usa-button usa-button--accent-cool"
+      name="bulk_action"
+      type="submit"
+      value="archive">
+      <i class="fa fa-inbox"></i>
+      Archive
+    </button>
+  </div>
+  <div class="table-wrap">
+    <table class="usa-table submissions font-sans-2xs">
       <thead>
         <tr>
           <td></td>
@@ -225,7 +231,7 @@
 
       if (selectedCount > 0) {
         batchActions.style.display = "block";
-        selectedCountSpan.textContent = `${selectedCount} item(s) selected`;
+        selectedCountSpan.textContent = `${selectedCount} selected`;
       } else {
         batchActions.style.display = "none";
         selectedCountSpan.textContent = "";

--- a/app/views/admin/submissions/_submissions.html.erb
+++ b/app/views/admin/submissions/_submissions.html.erb
@@ -60,11 +60,28 @@
 <p>
   <%= paginate submissions, remote: true %>
 </p>
+
+
 <div class="responses table-scroll">
   <div class="table-wrap">
+  <%= form_with url: bulk_update_admin_form_submissions_path(form), method: :post do |f| %>
+    <div
+      id="batch-actions">
+      <label for="bulk_action">Bulk Action:</label>
+      <span id="selected-count" class="margin-right-1"></span>
+      <button class="usa-button" name="bulk_action" type="submit" value="flag">
+        <i class="far fa-flag"></i>
+        Flag
+      </button>
+      <button class="usa-button usa-button--accent-cool" id="archive-button" type="button">
+        <i class="fa fa-inbox"></i>
+        Archive
+      </button>
+    </div>
     <table class="usa-table submissions">
       <thead>
         <tr>
+          <td></td>
           <td></td>
           <td></td>
           <td></td>
@@ -83,6 +100,9 @@
         <% end %>
         </tr>
         <tr>
+          <th>
+            <%= check_box_tag "submission_ids[]", id: "toggle-all-checkbox" %>
+          </th>
           <th>View</th>
           <th>Flag</th>
           <th>Archive</th>
@@ -111,6 +131,7 @@
           <% next %>
         <% end %>
         <tr class="response" title="Response ID <%= submission.id %>" data-id="<%= submission.uuid %>">
+          <td><%= check_box_tag "submission_ids[]", submission.id, class: "batch-checkbox" %></td>
           <td>
             <%= link_to admin_form_submission_path(submission.form, submission), class: "usa-button usa-button--outline" do %>
               View
@@ -160,6 +181,7 @@
         <% end %>
       </tbody>
     </table>
+    <% end %>
   </div>
 </div>
 <p>
@@ -192,5 +214,35 @@
         type: 'get'
       });
     });
+
+    const headerCheckbox = document.getElementById("toggle-all-checkbox");
+    const submissionCheckboxes = document.querySelectorAll(".batch-checkbox");
+    const batchActions = document.getElementById("batch-actions");
+    const selectedCountSpan = document.getElementById("selected-count");
+
+    function updateBatchActionsVisibility() {
+      const selectedCount = Array.from(submissionCheckboxes).filter((checkbox) => checkbox.checked).length;
+
+      if (selectedCount > 0) {
+        batchActions.style.display = "block";
+        selectedCountSpan.textContent = `${selectedCount} item(s) selected`;
+      } else {
+        batchActions.style.display = "none";
+        selectedCountSpan.textContent = "";
+      }
+    }
+
+    headerCheckbox?.addEventListener("click", () => {
+      submissionCheckboxes.forEach((checkbox) => {
+        checkbox.checked = headerCheckbox.checked;
+        updateBatchActionsVisibility();
+      });
+    });
+
+    submissionCheckboxes.forEach((checkbox) => {
+      checkbox.addEventListener("change", updateBatchActionsVisibility);
+    });
+
+    updateBatchActionsVisibility();
   })
 </script>

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -7,7 +7,6 @@
     Export responses
   </div>
 
-
   <form
     class="usa-form"
     id="export-buttons"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -326,6 +326,9 @@ Rails.application.routes.draw do
         end
       end
       resources :submissions, only: %i[show update destroy] do
+        collection do
+          post :bulk_update
+        end
         member do
           post 'flag', to: 'submissions#flag', as: :flag
           post 'unflag', to: 'submissions#unflag', as: :unflag

--- a/db/migrate/20250117004643_add_spam_to_submissions.rb
+++ b/db/migrate/20250117004643_add_spam_to_submissions.rb
@@ -1,0 +1,7 @@
+class AddSpamToSubmissions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :submissions, :spam, :boolean, default: false
+
+    Submission.update_all(spam: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_15_175322) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_17_004643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -652,6 +652,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_175322) do
     t.string "tags", default: [], array: true
     t.integer "spam_score", default: 0
     t.text "query_string"
+    t.boolean "spam", default: false
     t.index ["created_at"], name: "index_submissions_on_created_at"
     t.index ["flagged"], name: "index_submissions_on_flagged"
     t.index ["form_id"], name: "index_submissions_on_form_id"

--- a/spec/controllers/admin/submissions_controller_spec.rb
+++ b/spec/controllers/admin/submissions_controller_spec.rb
@@ -133,4 +133,45 @@ RSpec.describe Admin::SubmissionsController, type: :controller do
       expect(submission.flagged).to be false
     end
   end
+
+  describe 'POST #bulk_update' do
+    let!(:submission) { FactoryBot.create(:submission, form:) }
+    let!(:submission2) { FactoryBot.create(:submission, form:) }
+    let!(:submission3) { FactoryBot.create(:submission, form:) }
+
+    describe "bulk_action=flag" do
+      before do
+        post :bulk_update, params: { submission_ids: Submission.all.collect(&:id), form_id: form.short_uuid, bulk_action: "flag" }, session: valid_session
+      end
+
+      it 'flags the submission' do
+        expect(response.status).to eq(302)
+        expect(flash[:notice]).to eq("3 Submissions flagged.")
+        expect(Submission.where(flagged: true).count).to eq(3)
+      end
+    end
+
+    describe "bulk_action=archive" do
+      before do
+        post :bulk_update, params: { submission_ids: Submission.all.collect(&:id), form_id: form.short_uuid, bulk_action: "archive" }, session: valid_session
+      end
+
+      it 'archives the submission' do
+        expect(response.status).to eq(302)
+        expect(flash[:notice]).to eq("3 Submissions archived.")
+        expect(Submission.where(aasm_state: :archived).count).to eq(3)
+      end
+    end
+
+    describe "bulk_action=nil" do
+      before do
+        post :bulk_update, params: { submission_ids: Submission.all.collect(&:id), form_id: form.short_uuid }, session: valid_session
+      end
+
+      it 'is invalid' do
+        expect(response.status).to eq(302)
+        expect(flash[:alert]).to eq("Invalid action selected.")
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/submissions_controller_spec.rb
+++ b/spec/controllers/admin/submissions_controller_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Admin::SubmissionsController, type: :controller do
         post :bulk_update, params: { submission_ids: Submission.all.collect(&:id), form_id: form.short_uuid, bulk_action: "flag" }, session: valid_session
       end
 
-      it 'flags the submission' do
+      it 'flags the submissions' do
         expect(response.status).to eq(302)
         expect(flash[:notice]).to eq("3 Submissions flagged.")
         expect(Submission.where(flagged: true).count).to eq(3)
@@ -156,10 +156,22 @@ RSpec.describe Admin::SubmissionsController, type: :controller do
         post :bulk_update, params: { submission_ids: Submission.all.collect(&:id), form_id: form.short_uuid, bulk_action: "archive" }, session: valid_session
       end
 
-      it 'archives the submission' do
+      it 'archives the submissions' do
         expect(response.status).to eq(302)
         expect(flash[:notice]).to eq("3 Submissions archived.")
         expect(Submission.where(aasm_state: :archived).count).to eq(3)
+      end
+    end
+
+    describe "bulk_action=spam" do
+      before do
+        post :bulk_update, params: { submission_ids: Submission.all.collect(&:id), form_id: form.short_uuid, bulk_action: "spam" }, session: valid_session
+      end
+
+      it 'marks the submissions as spam' do
+        expect(response.status).to eq(302)
+        expect(flash[:notice]).to eq("3 Submissions marked as spam.")
+        expect(Submission.where(spam: true).count).to eq(3)
       end
     end
 
@@ -171,6 +183,17 @@ RSpec.describe Admin::SubmissionsController, type: :controller do
       it 'is invalid' do
         expect(response.status).to eq(302)
         expect(flash[:alert]).to eq("Invalid action selected.")
+      end
+    end
+
+    describe "submission_ids=nil" do
+      before do
+        post :bulk_update, params: { submission_ids: nil, form_id: form.short_uuid }, session: valid_session
+      end
+
+      it 'is invalid' do
+        expect(response.status).to eq(302)
+        expect(flash[:alert]).to eq("No Submissions selected.")
       end
     end
   end

--- a/spec/features/admin/submissions_spec.rb
+++ b/spec/features/admin/submissions_spec.rb
@@ -549,6 +549,19 @@ feature 'Submissions', js: true do
               expect(all("table.submissions a.usa-button.usa-button--secondary").size).to eq(2)
             end
 
+            xit 'bulk select responses and marks them as spam' do
+              expect(page).to_not have_content("Bulk Action")
+              within("table.submissions") do
+                checkboxes = all("input[type='checkbox']")
+                find("input#toggle-all-checkbox").click
+              end
+              within("#batch-actions") do
+                expect(page).to have_content("Bulk Action: 2 selected")
+                click_on("Mark as spam")
+              end
+              expect(page).to have_content("2 Submissions marked as spam.")
+            end
+
             it 'bulk select responses and mark them as archived' do
               expect(page).to_not have_content("Bulk Action")
               within("table.submissions") do

--- a/spec/features/admin/submissions_spec.rb
+++ b/spec/features/admin/submissions_spec.rb
@@ -513,6 +513,58 @@ feature 'Submissions', js: true do
             end
           end
         end
+
+        describe 'batch actions' do
+          context 'with multiple Responses' do
+
+            it 'bulk selects and de-selects all responses' do
+              within("table.submissions") do
+                checkboxes = all("input[type='checkbox']")
+                expect(checkboxes.size).to eq(3)
+                checkboxes.each do |checkbox|
+                  expect(checkbox).not_to be_checked
+                end
+                find("input#toggle-all-checkbox").click
+                checkboxes.each do |checkbox|
+                  expect(checkbox).to be_checked
+                end
+                find("input#toggle-all-checkbox").click
+                checkboxes.each do |checkbox|
+                  expect(checkbox).to_not be_checked
+                end
+              end
+            end
+
+            it 'bulk select responses and mark them as flagged' do
+              expect(page).to_not have_content("Bulk Action")
+              within("table.submissions") do
+                checkboxes = all("input[type='checkbox']")
+                find("input#toggle-all-checkbox").click
+              end
+              within("#batch-actions") do
+                expect(page).to have_content("Bulk Action: 2 selected")
+                click_on("Flag")
+              end
+              expect(page).to have_content("2 Submissions flagged.")
+              expect(all("table.submissions a.usa-button.usa-button--secondary").size).to eq(2)
+            end
+
+            it 'bulk select responses and mark them as archived' do
+              expect(page).to_not have_content("Bulk Action")
+              within("table.submissions") do
+                checkboxes = all("input[type='checkbox']")
+                find("input#toggle-all-checkbox").click
+              end
+              within("#batch-actions") do
+                expect(page).to have_content("Bulk Action: 2 selected")
+                click_on("Archive")
+              end
+              expect(page).to have_content("2 Submissions archived.")
+              expect(page).to have_content("Export is not available. This Form has yet to receive any Responses.")
+            end
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
enables users to bulk select responses and a) flag them or b) mark them as archived.

later, additional options may be added, like: mark as spam, or assign tags, in bulk