### PR TITLE
revert to ruby 3.3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 jobs:
   build:
     docker:
-       - image: cimg/ruby:3.3.6-browsers
+       - image: cimg/ruby:3.3.4-browsers
          environment:
             RAILS_ENV: test
             PGHOST: 127.0.0.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.3.6'
+ruby '3.3.4'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     aes_key_wrap (1.1.0)
     ast (2.4.2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.1040.0)
+    aws-partitions (1.1041.0)
     aws-record (2.13.2)
       aws-sdk-dynamodb (~> 1, >= 1.85.0)
     aws-sdk-core (3.216.0)
@@ -281,7 +281,7 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.0)
-    irb (1.15.0)
+    irb (1.15.1)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
@@ -700,7 +700,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.3.6p108
+   ruby 3.3.4p94
 
 BUNDLED WITH
    2.5.16


### PR DESCRIPTION
* cloud.gov ruby buildpack is at 3.3.4 for now