### PR TITLE
fba-button, as a `button`

### DIFF
--- a/app/controllers/admin/forms_controller.rb
+++ b/app/controllers/admin/forms_controller.rb
@@ -593,6 +593,7 @@ module Admin
         :service_id,
         :service_stage_id,
         :enforce_new_submission_validations,
+        :legacy_link_feature_flag,
       )
     end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -227,6 +227,7 @@ class Form < ApplicationRecord
     new_form.organization = new_user.organization
     new_form.template = false
     new_form.enforce_new_submission_validations = true
+    new_form.legacy_link_feature_flag = false
     new_form.save!
 
     # Manually remove the Form Section created with create_first_form_section

--- a/app/views/admin/forms/_admin_options.html.erb
+++ b/app/views/admin/forms/_admin_options.html.erb
@@ -66,6 +66,15 @@
             <% end %>
           </div>
         </fieldset>
+        <fieldset class="usa-fieldset">
+          <legend class="usa-sr-only">legacy_link_feature_flag</legend>
+          <div class="usa-checkbox">
+            <%= f.check_box :legacy_link_feature_flag, class: "usa-checkbox__input" %>
+            <%= f.label :legacy_link_feature_flag, class: "usa-checkbox__label" do %>
+              legacy_link_feature_flag
+            <% end %>
+          </div>
+        </fieldset>
       </div>
     </div>
     <p class="margin-top-4">

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -369,12 +369,18 @@ function FBAform(d, N) {
 			this.landmarkElement.setAttribute('role', 'complementary');
 
 			// Add the fixed, floating tab button
-			this.buttonEl = d.createElement('a');
+			<%# FEATURE FLAG %>
+			if(this.options.legacyLink) {
+				this.buttonEl = d.createElement('a');
+				this.buttonEl.setAttribute('href', 'javascript:void(0)');
+			} else {
+				this.buttonEl = d.createElement('button');
+			}
 			this.buttonEl.setAttribute('id', 'fba-button');
 			this.buttonEl.setAttribute('data-id', this.options.formId);
 			this.buttonEl.setAttribute('class', 'fba-button fixed-tab-button usa-button');
 			this.buttonEl.setAttribute('name', 'fba-button');
-			this.buttonEl.setAttribute('href', 'javascript:void(0)');
+			this.buttonEl.setAttribute('aria-label', this.options.modalButtonText);
 			this.buttonEl.setAttribute('aria-haspopup', 'dialog');
 			this.buttonEl.setAttribute('aria-controls', this.modalId());
 			this.buttonEl.setAttribute('data-open-modal', '');
@@ -639,6 +645,7 @@ function FBAform(d, N) {
 
 // Specify the options for your form
 const touchpointFormOptions<%= form.short_uuid %> = {
+	'legacyLink': <%= form.legacy_link_feature_flag? %>,
 	'formId': "<%= form.short_uuid %>",
 	'modalButtonText': "<%= form.modal_button_text %>",
 	'elementSelector': "<%= form.element_selector %>",

--- a/db/migrate/20250130195535_add_forms_legacy_link_feature_flag.rb
+++ b/db/migrate/20250130195535_add_forms_legacy_link_feature_flag.rb
@@ -1,0 +1,7 @@
+class AddFormsLegacyLinkFeatureFlag < ActiveRecord::Migration[7.2]
+  def change
+    add_column :forms, :legacy_link_feature_flag, :boolean, default: false
+
+    Form.update_all(legacy_link_feature_flag: false)
+  end
+end

--- a/db/migrate/20250130195535_add_forms_legacy_link_feature_flag.rb
+++ b/db/migrate/20250130195535_add_forms_legacy_link_feature_flag.rb
@@ -1,6 +1,6 @@
 class AddFormsLegacyLinkFeatureFlag < ActiveRecord::Migration[7.2]
   def change
-    add_column :forms, :legacy_link_feature_flag, :boolean, default: false
+    add_column :forms, :legacy_link_feature_flag, :boolean, default: false, comment: "when true, render fba-button as an A, otherwise render as BUTTON"
 
     Form.update_all(legacy_link_feature_flag: false)
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_17_004643) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_30_195535) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -311,6 +311,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_17_004643) do
     t.string "short_uuid", limit: 8
     t.boolean "enforce_new_submission_validations", default: true
     t.integer "service_stage_id"
+    t.boolean "legacy_link_feature_flag", default: false
     t.index ["legacy_touchpoint_id"], name: "index_forms_on_legacy_touchpoint_id"
     t.index ["legacy_touchpoint_uuid"], name: "index_forms_on_legacy_touchpoint_uuid"
     t.index ["organization_id"], name: "index_forms_on_organization_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -255,7 +255,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_195535) do
     t.text "success_text"
     t.string "modal_button_text"
     t.boolean "display_header_square_logo"
-    t.boolean "early_submission", default: false
     t.integer "user_id"
     t.boolean "template", default: false
     t.string "uuid"
@@ -311,7 +310,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_195535) do
     t.string "short_uuid", limit: 8
     t.boolean "enforce_new_submission_validations", default: true
     t.integer "service_stage_id"
-    t.boolean "legacy_link_feature_flag", default: false
+    t.boolean "legacy_link_feature_flag", default: false, comment: "when true, render fba-button as an A, otherwise render as BUTTON"
     t.index ["legacy_touchpoint_id"], name: "index_forms_on_legacy_touchpoint_id"
     t.index ["legacy_touchpoint_uuid"], name: "index_forms_on_legacy_touchpoint_uuid"
     t.index ["organization_id"], name: "index_forms_on_organization_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -255,6 +255,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_195535) do
     t.text "success_text"
     t.string "modal_button_text"
     t.boolean "display_header_square_logo"
+    t.boolean "early_submission", default: false
     t.integer "user_id"
     t.boolean "template", default: false
     t.string "uuid"

--- a/spec/features/embedded_touchpoints_spec.rb
+++ b/spec/features/embedded_touchpoints_spec.rb
@@ -6,8 +6,9 @@ feature 'Touchpoints', js: true do
   let(:organization) { FactoryBot.create(:organization) }
   let!(:user) { FactoryBot.create(:user, :admin, organization:) }
 
+  [true, false].each do |legacy_link_feature_flag_setting|
     context "as Admin" do
-      let!(:form) { FactoryBot.create(:form, :kitchen_sink, organization:) }
+      let!(:form) { FactoryBot.create(:form, :kitchen_sink, organization:, legacy_link_feature_flag: legacy_link_feature_flag_setting) }
 
       describe '/forms/:id/example' do
         before do
@@ -96,4 +97,5 @@ feature 'Touchpoints', js: true do
         end
       end
     end
+  end # legacy_link_feature_flag_setting
 end


### PR DESCRIPTION
This PR updates the fba-button link that hovers in the bottom right-hand corner of pages, 
and updates from a `<a>` to a `<button>`, to improve accessibility and to be more semantically accurate.

also adds an `aria-label` with the same text as the button, for improved accessibility (reported by Amy Cole of USWDS)

A feature flag on the Form object called `legacy_link_feature_flag` exists, in case there are any issues with this update (eg: custom CSS or js that targets that `a`)