### PR TITLE
Cache submission preview text

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -11,6 +11,7 @@ class Submission < ApplicationRecord
 
   before_create :set_uuid
   after_create :update_form
+  after_create :set_preview
   after_commit :send_notifications, on: :create
 
   scope :active, -> { where(flagged: false, spam: false, archived: false, deleted: false) }
@@ -207,12 +208,13 @@ class Submission < ApplicationRecord
     form.organization.present? ? form.organization.name : 'Org Name'
   end
 
-  def preview
+  def set_preview
     # only select the answer fields
     fields = attributes.select { |attr| attr.include?("answer")}
     # only select text fields
     text_fields = fields.values.select { |v| v.is_a?(String) }
-    text_fields.join(" - ").truncate(120)
+    preview_text = text_fields.join(" - ").truncate(120)
+    self.update_attribute(:preview, preview_text)
   end
 
   def set_uuid

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -70,6 +70,7 @@ class Submission < ApplicationRecord
     answered_questions.delete('spam')
     answered_questions.delete('archived')
     answered_questions.delete('deleted')
+    answered_questions.delete('preview')
     answered_questions.delete('created_at')
     answered_questions.delete('updated_at')
     answered_questions.delete('deleted_at')

--- a/app/views/admin/forms/responses.html.erb
+++ b/app/views/admin/forms/responses.html.erb
@@ -10,9 +10,6 @@
   <% end %>
 </p>
 <%= render 'admin/forms/nav', form: @form %>
-<h3>
-  Customer Feedback Analysis
-</h3>
 <%- if admin_permissions? && @form.kind == "a11" %>
   <div class="a11-analysis-widget"><span class="usa-label">Loading A11 Analysis...</span></div>
 <% end %>

--- a/app/views/components/_responses_by_status.html.erb
+++ b/app/views/components/_responses_by_status.html.erb
@@ -73,16 +73,24 @@
 
       </td>
       <td>
+        <%= link_to responses_admin_form_path(@form, flagged: 1) do %>
         <%= number_with_delimiter(responses_by_status["flagged"]) %>
+        <% end %>
       </td>
       <td>
-        <%= number_with_delimiter(responses_by_status["marked"]) %>
+        <%= link_to responses_admin_form_path(@form, spam: 1) do %>
+          <%= number_with_delimiter(responses_by_status["marked"]) %>
+        <% end %>
       </td>
       <td>
-        <%= number_with_delimiter(responses_by_status["archived"]) %>
+        <%= link_to responses_admin_form_path(@form, archived: 1) do %>
+          <%= number_with_delimiter(responses_by_status["archived"]) %>
+        <% end %>
       </td>
       <td>
-        <%= number_with_delimiter(responses_by_status["deleted"]) %>
+        <%= link_to responses_admin_form_path(@form, deleted: 1) do %>
+          <%= number_with_delimiter(responses_by_status["deleted"]) %>
+        <% end %>
       </td>
       <td>
       </td>

--- a/db/migrate/20250214194816_cache_submission_preview.rb
+++ b/db/migrate/20250214194816_cache_submission_preview.rb
@@ -1,0 +1,11 @@
+class CacheSubmissionPreview < ActiveRecord::Migration[7.2]
+  def change
+    add_column :submissions, :preview, :string, default: ""
+
+    Submission.unscoped.in_batches(of: 10_000) do |batch|
+      batch.each do |submission|
+        submission.set_preview
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_11_191435) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_14_194816) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -651,6 +651,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_11_191435) do
     t.boolean "archived", default: false
     t.boolean "deleted", default: false
     t.datetime "deleted_at"
+    t.string "preview", default: ""
     t.index ["archived"], name: "index_submissions_on_archived"
     t.index ["created_at"], name: "index_submissions_on_created_at"
     t.index ["flagged"], name: "index_submissions_on_flagged"

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -178,16 +178,19 @@ FactoryBot.define do
       after(:create) do |f, _evaluator|
         FactoryBot.create(:question,
                           form: f,
+                          answer_field: :answer_01,
                           question_type: 'textarea',
                           form_section: f.form_sections.first,
                           text: 'Body')
         FactoryBot.create(:question,
                           form: f,
+                          answer_field: :answer_02,
                           question_type: 'textarea',
                           form_section: f.form_sections.first,
                           text: 'Name')
         FactoryBot.create(:question,
                           form: f,
+                          answer_field: :answer_03,
                           question_type: 'textarea',
                           form_section: f.form_sections.first,
                           text: 'Email')

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -542,7 +542,6 @@ feature 'Forms', js: true do
             end
 
             it 'display table list of Responses and Export responses dropdown' do
-              expect(page).to have_content('Customer Feedback Analysis')
               expect(page).to have_content('RESPONSES BY STATUS')
               expect(page).to have_content('Responses per day')
               expect(page).to have_content('Total submissions received over period')

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -88,4 +88,42 @@ RSpec.describe Submission, type: :model do
       expect(submission.spam_score).to eq(0)
     end
   end
+
+  describe "callbacks" do
+    describe "after_create :set_preview" do
+      let(:open_ended_contact_form) { FactoryBot.create(:form, :open_ended_form_with_contact_information, organization:, notification_emails: "#{admin.email}, second@example.gov") }
+
+      it "sets preview from answer fields" do
+        new_submission = Submission.create(
+          form: open_ended_contact_form,
+          answer_01: "First answer",
+          answer_02: "Second answer",
+          answer_03: "Third answer",
+        )
+        expect(new_submission.preview).to eq("First answer - Second answer - Third answer")
+      end
+
+      it "ignores non-answer fields" do
+        new_submission = Submission.create(
+          form: open_ended_contact_form,
+          answer_01: "First answer",
+          answer_02: "Second answer",
+          language: "en"
+        )
+        expect(new_submission.preview).to eq("First answer - Second answer")
+      end
+
+      it "truncates the preview to 120 characters" do
+        long_text = "A" * 150
+        new_submission = Submission.create(
+          form: open_ended_contact_form,
+          answer_01: long_text,
+          answer_02: "Another answer"
+        )
+        expect(new_submission.preview.length).to be <= 120
+        expect(new_submission.preview).to end_with("...")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
this PR caches Submission.preview text for performance
* adds links to summary table to view flagged, spam, archived, and deleted responses