### PR TITLE
check the path string rather than interpret the route

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,15 +15,7 @@ class Rack::Attack
 
   # Is the request to the form submission route?
   def self.submission_route?(req)
-    begin
-      recognized_route = Rails.application.routes.recognize_path(req.path, method: req.request_method)
-      recognized_route[:controller] == 'submissions' &&
-        recognized_route[:action] == 'create' &&
-        recognized_route[:touchpoint_id].present? &&
-        recognized_route[:format] == 'json'
-    rescue ActionController::RoutingError
-      false
-    end
+    !!(req.path =~ %r{^/submissions/\d+\.json$})
   end
 
   # Response for throttled requests


### PR DESCRIPTION
* routing invokes authentication, which isn't necessary here
* !! forces a boolean return