### PR TITLE
A-11 v2 with Radio Buttons (5 options, conditional 2nd & 3rd question)

### DIFF
--- a/app/controllers/admin/forms_controller.rb
+++ b/app/controllers/admin/forms_controller.rb
@@ -218,6 +218,7 @@ module Admin
     def questions
       @form.warn_about_not_too_many_questions
       @form.ensure_a11_v2_format if @form.kind == "a11_v2"
+      @form.ensure_a11_v2_radio_format if @form.kind == "a11_v2_radio"
       ensure_form_manager(form: @form) unless @form.template?
       @questions = @form.ordered_questions
     end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -735,6 +735,41 @@ class Form < ApplicationRecord
     end
   end
 
+  def ensure_a11_v2_radio_format
+    question_1 = self.ordered_questions.find { |q| q.answer_field == "answer_01" }
+    if question_1.question_type != 'radio_buttons'
+      errors.add(:base, "The question for `answer_01` must be a Radio Buttons component with 5 options, with values 1-5")
+    end
+
+    # ensure the form has the 4 required questions
+    required_elements = ["answer_01", "answer_02", "answer_03", "answer_04"]
+    unless contains_elements?(questions.collect(&:answer_field), required_elements)
+      errors.add(:base, "The A-11 v2 form must have questions for #{required_elements.to_sentence}")
+    end
+
+    # ensure the positive indicators include ease and effectiveness
+    question_2 = self.ordered_questions.find { |q| q.answer_field == "answer_02" }
+    question_options = question_2.question_options
+
+    question_option_values = question_options.collect(&:value)
+    required_options = ["effectiveness", "ease"]
+    missing_options = required_options - question_option_values
+    if missing_options.any?
+      errors.add(:base, "The question options for Question 2 must include: #{missing_options.join(', ')}")
+    end
+
+    # ensure the positive indicators include ease and effectiveness
+    question_3 = self.ordered_questions.find { |q| q.answer_field == "answer_03" }
+    question_options = question_3.question_options
+
+    question_option_values = question_options.collect(&:value)
+    required_options = ["effectiveness", "ease"]
+    missing_options = required_options - question_option_values
+    if missing_options.any?
+      errors.add(:base, "The question options for Question 3 must include: #{missing_options.join(', ')}")
+    end
+  end
+
   def warn_about_not_too_many_questions
     if questions.size > 12
       errors.add(:base, "Touchpoints supports a maximum of 20 questions. There are currently #{questions_count} questions. Fewer questions tend to yield higher response rates.")

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -57,7 +57,8 @@ class Form < ApplicationRecord
   def self.kinds
     [
       "a11",
-      "a11_v2", # launched fall 2023
+      "a11_v2", # launched Fall 2023
+      "a11_v2_radio", # launched May 2025
       "a11_yes_no",
       "open_ended",
       "other", # TODO: deprecate in favor of custom,
@@ -289,7 +290,7 @@ class Form < ApplicationRecord
   def self.find_inactive_forms_since(days_ago)
     min_time = Time.now - days_ago.days
     max_time = Time.now - (days_ago - 1).days
-    Form.published.where("last_response_created_at BETWEEN ? AND ?", min_time, max_time)
+    Form.non_templates.published.where("last_response_created_at BETWEEN ? AND ?", min_time, max_time)
   end
 
   def deployable_form?

--- a/app/views/components/_form_a11_v2_radio_script.html.erb
+++ b/app/views/components/_form_a11_v2_radio_script.html.erb
@@ -1,0 +1,52 @@
+// Assumes: 4 questions:
+//  1. 5 radio buttons with values 1-5
+//  2. positive checkbox indicators
+//  3. negative checkbox indicators
+//  4. open text
+// Hides the 2nd and 3rd questions to start
+// reveals 2 when selecting thumbs up
+// reveals 3 when selecting thumbs down
+<%
+  question_1 = form.ordered_questions.find { |q| q.answer_field == "answer_01"}
+  question_2 = form.ordered_questions.find { |q| q.answer_field == "answer_02"}
+  question_3 = form.ordered_questions.find { |q| q.answer_field == "answer_03"}
+%>
+
+document.addEventListener('onTouchpointsFormLoaded', function(e) {
+  const formElement = e.detail.formComponent.formElement();
+  const q2_container = formElement.querySelector("#<%= dom_id(question_2) %>");
+  const q3_container = formElement.querySelector("#<%= dom_id(question_3) %>");
+
+  function hideQ2() {
+    q2_container.style.display = 'none';
+  }
+  function showQ2() {
+    q2_container.style.display = 'block';
+  }
+
+  function hideQ3() {
+    q3_container.style.display = 'none';
+  }
+  function showQ3() {
+    q3_container.style.display = 'block';
+  }
+
+  function showAndHideQuestions(selectedOption) {
+    if (selectedOption === "1" || selectedOption === "2" || selectedOption === "3") {
+      hideQ2()
+      showQ3()
+    } else if (selectedOption === "4" || selectedOption === "5") {
+      showQ2()
+      hideQ3()
+    }
+  }
+
+  formElement.querySelectorAll('input[name="<%= question_1.ui_selector %>"]').forEach((radio) => {
+    radio.addEventListener('change', (event) => {
+      showAndHideQuestions(event.target.value);
+    });
+  });
+
+  hideQ2()
+  hideQ3()
+})

--- a/app/views/components/forms/question_types/_radio_buttons.html.erb
+++ b/app/views/components/forms/question_types/_radio_buttons.html.erb
@@ -3,14 +3,15 @@
   <div class="question-options">
   <% question.question_options.each_with_index do |option, index| %>
     <% @option_id = dom_id(option) %>
-    <div class="radio-button usa-radio question-option"
+    <div
+      class="radio-button usa-radio question-option"
       data-id="<%= option.id %>"
       <%- if question.help_text.present? %>
       aria-describedby="<%= "question-id-#{question.id}-help-text" %>"
       <% end %>
     >
-      <%= radio_button_tag(@option_id, option.value, nil, { id: @option_id, name: question.ui_selector, class: "usa-radio__input usa-radio__input--tile", required: question.is_required  }) %>
-      <%= label_tag(@option_id, nil, class: "usa-radio__label") do %><%= option.text %><% end %>
+      <%= radio_button_tag(question.ui_selector, option.value.to_s, nil, { id: @option_id, class: "usa-radio__input usa-radio__input--tile", required: question.is_required  }) %>
+      <%= label_tag(@option_id, option.text, class: "usa-radio__label") %>
       <%- if option.other_option %>
       <div class="margin-top-1">
         <%= label_tag(nil, for: "#{question.ui_selector}_other", class: "usa-input__label") do %><%= t 'form.enter_other_text' %><% end %>

--- a/app/views/components/forms/question_types/_radio_buttons.html.erb
+++ b/app/views/components/forms/question_types/_radio_buttons.html.erb
@@ -10,10 +10,15 @@
       aria-describedby="<%= "question-id-#{question.id}-help-text" %>"
       <% end %>
     >
-      <%= radio_button_tag(question.ui_selector, option.value.to_s, nil, { id: @option_id, class: "usa-radio__input usa-radio__input--tile", required: question.is_required  }) %>
+      <%= radio_button_tag(question.ui_selector, option[:value], nil, {
+          id: @option_id,
+          class: "usa-radio__input usa-radio__input--tile",
+          required: question.is_required
+        }) %>
       <%= label_tag(@option_id, option.text, class: "usa-radio__label") %>
       <%- if option.other_option %>
-      <div class="margin-top-1">
+      <div
+        class="margin-top-1">
         <%= label_tag(nil, for: "#{question.ui_selector}_other", class: "usa-input__label") do %><%= t 'form.enter_other_text' %><% end %>
         <input type="text"
           name="<%= question.ui_selector %>_other"

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -794,7 +794,7 @@ var touchpointFormOptions<%= form.short_uuid %> = {
 	'css' : "<%= escape_javascript(render partial: 'components/widget/widget', formats: :css, locals: { form: form }) %>",
 	'loadCSS' : <%= form.load_css %>,
 	'formSpecificScript' : function() {
-		<%- if ["a11_v2", "a11_yes_no"].include?(form.kind) %>
+		<%- if ["a11_v2", "a11_v2_radio", "a11_yes_no"].include?(form.kind) %>
 		<%= render "components/form_#{form.kind}_script", form: form %>
 		<% end %>
 	},

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -501,6 +501,7 @@ FactoryBot.define do
                           form_section: f.form_sections.first,
                           text: 'Please rate your experience as a customer of Agency of Departments.',
                           position: 1,
+                          is_required: true,
                           )
         FactoryBot.create(:question,
                           :with_a11_v2_checkbox_options,
@@ -514,7 +515,6 @@ FactoryBot.define do
                           :with_a11_v2_checkbox_options,
                           form: f,
                           answer_field: :answer_03,
-                          question_type: 'textarea',
                           form_section: f.form_sections.first,
                           text: 'Negative indicators',
                           position: 3
@@ -527,6 +527,77 @@ FactoryBot.define do
                           text: 'Additional comments',
                           position: 4
                           )
+      end
+    end
+
+    trait :a11_v2_radio do
+      name { 'Version 2 of the A11 form (Radio Buttons)' }
+      kind { 'a11_v2_radio' }
+      after(:create) do |f, _evaluator|
+        question_1_radio_buttons = FactoryBot.create(:question,
+                          form: f,
+                          answer_field: :answer_01,
+                          question_type: 'radio_buttons',
+                          form_section: f.form_sections.first,
+                          text: 'Please rate your experience as a customer of Agency of Departments.',
+                          position: 1,
+                          is_required: true,
+                          )
+        FactoryBot.create(:question,
+                          :with_a11_v2_checkbox_options,
+                          form: f,
+                          answer_field: :answer_02,
+                          form_section: f.form_sections.first,
+                          text: 'Positive indicators',
+                          position: 2,
+                          )
+        FactoryBot.create(:question,
+                          :with_a11_v2_checkbox_options,
+                          form: f,
+                          answer_field: :answer_03,
+                          form_section: f.form_sections.first,
+                          text: 'Negative indicators',
+                          position: 3
+                          )
+        FactoryBot.create(:question,
+                          form: f,
+                          answer_field: :answer_04,
+                          question_type: 'textarea',
+                          form_section: f.form_sections.first,
+                          text: 'Additional comments',
+                          position: 4
+                          )
+
+        QuestionOption.create!({
+          question: question_1_radio_buttons,
+          text: 'Strongly disagree',
+          value: 1,
+          position: 1,
+        })
+        QuestionOption.create!({
+          question: question_1_radio_buttons,
+          text: 'Disagree',
+          value: 2,
+          position: 2,
+        })
+        QuestionOption.create!({
+          question: question_1_radio_buttons,
+          text: 'Neutral',
+          value: 3,
+          position: 3,
+        })
+        QuestionOption.create!({
+          question: question_1_radio_buttons,
+          text: 'Agree',
+          value: 4,
+          position: 4,
+        })
+        QuestionOption.create!({
+          question: question_1_radio_buttons,
+          text: 'Strongly agree',
+          value: 5,
+          position: 5,
+        })
       end
     end
 

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -520,7 +520,7 @@ feature 'Touchpoints', js: true do
       end
     end
 
-    describe 'A-11 Version 2 Form' do
+    describe 'A-11 Version 2 Form (Thumbs up/down)' do
       let!(:a11_v2_form) { FactoryBot.create(:form, :a11_v2, organization:) }
 
       before do
@@ -528,7 +528,7 @@ feature 'Touchpoints', js: true do
       end
 
       it 'submits successfully' do
-        expect(page).to have_content(form.title)
+        expect(page).to have_content(a11_v2_form.title)
         expect(page).to have_content("This is help text.")
         find("svg[aria-labelledby='thumbs-up-icon']").click # the thumbs up
         expect(page).to have_content("Positive indicators")
@@ -545,6 +545,50 @@ feature 'Touchpoints', js: true do
         expect(latest_submission.answer_01).to eq '1'
         expect(latest_submission.answer_02).to eq 'effectiveness,transparency'
         expect(latest_submission.answer_03).to eq ""
+        expect(latest_submission.answer_04).to eq ""
+      end
+    end
+
+    describe 'A-11 Version 2 (Radio Button) Form' do
+      let!(:a11_v2_radio_form) { FactoryBot.create(:form, :a11_v2_radio, organization:) }
+
+      before do
+        visit submit_touchpoint_path(a11_v2_radio_form)
+      end
+
+      it 'toggles positive and negative indicators and submits successfully' do
+        expect(page).to have_content(a11_v2_radio_form.title)
+        expect(page).to_not have_content("Negative indicators")
+        expect(page).to_not have_content("Positive indicators")
+
+        find_all("label")[0].click # option 1
+        expect(page).to have_content("Negative indicators")
+
+        find_all("label")[3].click # option 4
+        expect(page).to have_content("Positive indicators")
+
+        find_all("label")[1].click # option 2
+        expect(page).to have_content("Negative indicators")
+
+        find_all("label")[4].click # option 5
+        expect(page).to have_content("Positive indicators")
+
+        find_all("label")[2].click # option 3
+        expect(page).to have_content("Negative indicators")
+
+        expect(page).to have_content("This is help text.")
+        expect(page).to have_content("effectiveness")
+        expect(page).to have_content("ease")
+        expect(page).to have_content("efficiency")
+        expect(page).to have_content("transparency")
+
+        click_button 'Submit'
+        expect(page).to have_content('Thank you. Your feedback has been received.')
+
+        latest_submission = Submission.ordered.first
+        expect(latest_submission.answer_01).to eq '3'
+        expect(latest_submission.answer_02).to eq nil
+        expect(latest_submission.answer_03).to eq nil
         expect(latest_submission.answer_04).to eq ""
       end
     end

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -544,7 +544,7 @@ feature 'Touchpoints', js: true do
         latest_submission = Submission.ordered.first
         expect(latest_submission.answer_01).to eq '1'
         expect(latest_submission.answer_02).to eq 'effectiveness,transparency'
-        expect(latest_submission.answer_03).to eq ""
+        expect(latest_submission.answer_03).to eq nil
         expect(latest_submission.answer_04).to eq ""
       end
     end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Form, type: :model do
       end
 
       it 'adds an error for kind' do
-        expect(form_with_invalid_kind.errors.messages[:kind]).to eq(['kind must be one of the following: a11, a11_v2, a11_yes_no, custom, open_ended, other, recruiter, yes_no'])
+        expect(form_with_invalid_kind.errors.messages[:kind]).to eq(['kind must be one of the following: a11, a11_v2, a11_v2_radio, a11_yes_no, custom, open_ended, other, recruiter, yes_no'])
       end
     end
 


### PR DESCRIPTION
This PR adds a form type `a11_v2_radio` which expects 4 questions:

1. radio buttons with 5 question options (strongly disagree (1) to strongly agree (5)
2. negative a11 indicator checkboxes 
3. positive a11 indicator checkboxes
4. open text box

---

Questions 2 and 3 are hidden by default.
When 1-3 are selected in the question 1 radio buttons, the negative indicator question #2 shows and question #3 is hidden.
When 4-5 are selected in the question 1 radio buttons, the positive indicator question #3 shows and question #2 is hidden.
