### PR TITLE
Some fixes to Cron

### DIFF
--- a/.circleci/cron.sh
+++ b/.circleci/cron.sh
@@ -2,7 +2,7 @@
 
 # Fail if anything within this script returns
 # a non-zero exit code
-# set -e
+set -e
 
 echo "Logging into cloud.gov"
 cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE

--- a/.circleci/cron.sh
+++ b/.circleci/cron.sh
@@ -2,7 +2,7 @@
 
 # Fail if anything within this script returns
 # a non-zero exit code
-set -e
+# set -e
 
 echo "Logging into cloud.gov"
 cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
@@ -13,18 +13,20 @@ cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_S
 
 echo "Running tasks in Staging..."
 
+STAGING_TASK="cf run-task touchpoints-staging-sidekiq-worker --wait -c"
+
 # Users
-cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:send_one_week_until_inactivation_warning"
-cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
-cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:deactivate_inactive_users"
+$STAGING_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning"
+$STAGING_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
+$STAGING_TASK "rake scheduled_jobs:deactivate_inactive_users"
 
 # Forms
-cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:send_daily_notifications"
-cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:send_weekly_notifications"
-cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:check_expiring_forms"
-cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:archive_forms"
-cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
-# cf run-task touchpoints-staging-sidekiq-worker -c "rake scheduled_jobs:delete_submissions_trash"
+$STAGING_TASK "rake scheduled_jobs:send_daily_notifications"
+$STAGING_TASK "rake scheduled_jobs:send_weekly_notifications"
+$STAGING_TASK "rake scheduled_jobs:check_expiring_forms"
+$STAGING_TASK "rake scheduled_jobs:archive_forms"
+$STAGING_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
+# $STAGING_TASK "rake scheduled_jobs:delete_submissions_trash"
 
 echo "Staging tasks have completed."
 
@@ -33,19 +35,20 @@ echo "Staging tasks have completed."
 #
 
 echo "Running tasks in Demo..."
+DEMO_TASK="cf run-task touchpoints-demo-sidekiq-worker --wait -c"
 
 # Users
-cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:send_one_week_until_inactivation_warning"
-cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
-cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:deactivate_inactive_users"
+$DEMO_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning"
+$DEMO_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
+$DEMO_TASK "rake scheduled_jobs:deactivate_inactive_users"
 
 # Forms
-cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:send_daily_notifications"
-cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:send_weekly_notifications"
-cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:check_expiring_forms"
-cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:archive_forms"
-cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
-# cf run-task touchpoints-demo-sidekiq-worker -c "rake scheduled_jobs:delete_submissions_trash"
+$DEMO_TASK "rake scheduled_jobs:send_daily_notifications"
+$DEMO_TASK "rake scheduled_jobs:send_weekly_notifications"
+$DEMO_TASK "rake scheduled_jobs:check_expiring_forms"
+$DEMO_TASK "rake scheduled_jobs:archive_forms"
+$DEMO_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
+# $DEMO_TASK "rake scheduled_jobs:delete_submissions_trash"
 
 echo "Demo tasks have completed."
 
@@ -60,18 +63,19 @@ cf login -a $CF_API_ENDPOINT -u $CF_PRODUCTION_SPACE_DEPLOYER_USERNAME -p $CF_PR
 
 echo "Running tasks in Production..."
 
+PROD_TASK="cf run-task touchpoints-production-sidekiq-worker --wait -c"
 # Users
-cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:send_one_week_until_inactivation_warning"
-cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
-cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:deactivate_inactive_users"
+$PROD_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning"
+$PROD_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
+$PROD_TASK "rake scheduled_jobs:deactivate_inactive_users"
 
 # Forms
-# cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:send_daily_notifications"
-# cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:send_weekly_notifications"
-# cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:check_expiring_forms"
-# cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:archive_forms"
-cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
-# cf run-task touchpoints-production-sidekiq-worker -c "rake scheduled_jobs:delete_submissions_trash"
+# $PROD_TASK "rake scheduled_jobs:send_daily_notifications"
+# $PROD_TASK "rake scheduled_jobs:send_weekly_notifications"
+# $PROD_TASK "rake scheduled_jobs:check_expiring_forms"
+# $PROD_TASK "rake scheduled_jobs:archive_forms"
+$PROD_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
+# $PROD_TASK "rake scheduled_jobs:delete_submissions_trash"
 
 echo "Production tasks have completed."
 

--- a/.circleci/cron.sh
+++ b/.circleci/cron.sh
@@ -4,79 +4,83 @@
 # a non-zero exit code
 set -e
 
-echo "Logging into cloud.gov"
+# Set # of failures to 0
+F=0
+
+function run_production_tasks() {
+	# === PRODUCTION environment ===================================================
+	echo "Running tasks in Production..."
+
+	PROD_TASK="cf run-task touchpoints-production-sidekiq-worker --wait -c" 
+	# Users
+	$PROD_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning" || F=$((F+=1))
+	$PROD_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning" || F=$((F+=1))
+	$PROD_TASK "rake scheduled_jobs:deactivate_inactive_users" || F=$((F+=1))
+
+	# Forms
+	# $PROD_TASK "rake scheduled_jobs:send_daily_notifications" || F=$((F+=1))
+	# $PROD_TASK "rake scheduled_jobs:send_weekly_notifications" || F=$((F+=1))
+	# $PROD_TASK "rake scheduled_jobs:check_expiring_forms" || F=$((F+=1))
+	# $PROD_TASK "rake scheduled_jobs:archive_forms" || F=$((F+=1))
+	$PROD_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms" || F=$((F+=1))
+	# $PROD_TASK "rake scheduled_jobs:delete_submissions_trash" || F=$((F+=1))
+	echo "Production tasks have completed."
+}
+
+
+function run_staging_tasks() {
+	# === STAGING environment ======================================================
+	echo "Running tasks in Staging..."
+
+	STAGING_TASK="cf run-task touchpoints-staging-sidekiq-worker --wait -c"
+
+	# Users
+	$STAGING_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning" || F=$((F+=1))
+	$STAGING_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning" || F=$((F+=1))
+	$STAGING_TASK "rake scheduled_jobs:deactivate_inactive_users" || F=$((F+=1))
+
+	# Forms
+	$STAGING_TASK "rake scheduled_jobs:send_daily_notifications" || F=$((F+=1))
+	$STAGING_TASK "rake scheduled_jobs:send_weekly_notifications" || F=$((F+=1))
+	$STAGING_TASK "rake scheduled_jobs:check_expiring_forms" || F=$((F+=1))
+	$STAGING_TASK "rake scheduled_jobs:archive_forms" || F=$((F+=1))
+	$STAGING_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms" || F=$((F+=1))
+	# $STAGING_TASK "rake scheduled_jobs:delete_submissions_trash" || F=$((F+=1))
+
+	echo "Staging tasks have completed."
+}
+
+function run_demo_tasks() {
+	# === DEMO environment =========================================================
+	echo "Running tasks in Demo..."
+	DEMO_TASK="cf run-task touchpoints-demo-sidekiq-worker --wait -c"
+
+	# Users
+	$DEMO_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning" || F=$((F+=1))
+	$DEMO_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning" || F=$((F+=1))
+	$DEMO_TASK "rake scheduled_jobs:deactivate_inactive_users" || F=$((F+=1))
+
+	# Forms
+	$DEMO_TASK "rake scheduled_jobs:send_daily_notifications" || F=$((F+=1))
+	$DEMO_TASK "rake scheduled_jobs:send_weekly_notifications" || F=$((F+=1))
+	$DEMO_TASK "rake scheduled_jobs:check_expiring_forms" || F=$((F+=1))
+	$DEMO_TASK "rake scheduled_jobs:archive_forms" || F=$((F+=1))
+	$DEMO_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms" || F=$((F+=1))
+	# $DEMO_TASK "rake scheduled_jobs:delete_submissions_trash" || F=$((F+=1))
+
+	echo "Demo tasks have completed."
+}
+
+echo "Logging into cloud.gov non-prod"
 cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
-
-#
-# === STAGING environment ======================================================
-#
-
-echo "Running tasks in Staging..."
-
-STAGING_TASK="cf run-task touchpoints-staging-sidekiq-worker --wait -c"
-
-# Users
-$STAGING_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning"
-$STAGING_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
-$STAGING_TASK "rake scheduled_jobs:deactivate_inactive_users"
-
-# Forms
-$STAGING_TASK "rake scheduled_jobs:send_daily_notifications"
-$STAGING_TASK "rake scheduled_jobs:send_weekly_notifications"
-$STAGING_TASK "rake scheduled_jobs:check_expiring_forms"
-$STAGING_TASK "rake scheduled_jobs:archive_forms"
-$STAGING_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
-# $STAGING_TASK "rake scheduled_jobs:delete_submissions_trash"
-
-echo "Staging tasks have completed."
-
-#
-# === DEMO environment =========================================================
-#
-
-echo "Running tasks in Demo..."
-DEMO_TASK="cf run-task touchpoints-demo-sidekiq-worker --wait -c"
-
-# Users
-$DEMO_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning"
-$DEMO_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
-$DEMO_TASK "rake scheduled_jobs:deactivate_inactive_users"
-
-# Forms
-$DEMO_TASK "rake scheduled_jobs:send_daily_notifications"
-$DEMO_TASK "rake scheduled_jobs:send_weekly_notifications"
-$DEMO_TASK "rake scheduled_jobs:check_expiring_forms"
-$DEMO_TASK "rake scheduled_jobs:archive_forms"
-$DEMO_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
-# $DEMO_TASK "rake scheduled_jobs:delete_submissions_trash"
-
-echo "Demo tasks have completed."
-
+run_staging_tasks
+run_demo_tasks
 cf logout
 
-#
-# === PRODUCTION environment ===================================================
-#
-
-echo "Logging into cloud.gov"
+echo "Logging into cloud.gov production environment"
 cf login -a $CF_API_ENDPOINT -u $CF_PRODUCTION_SPACE_DEPLOYER_USERNAME -p $CF_PRODUCTION_SPACE_DEPLOYER_PASSWORD -o $CF_ORG -s prod
-
-echo "Running tasks in Production..."
-
-PROD_TASK="cf run-task touchpoints-production-sidekiq-worker --wait -c"
-# Users
-$PROD_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning"
-$PROD_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning"
-$PROD_TASK "rake scheduled_jobs:deactivate_inactive_users"
-
-# Forms
-# $PROD_TASK "rake scheduled_jobs:send_daily_notifications"
-# $PROD_TASK "rake scheduled_jobs:send_weekly_notifications"
-# $PROD_TASK "rake scheduled_jobs:check_expiring_forms"
-# $PROD_TASK "rake scheduled_jobs:archive_forms"
-$PROD_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms"
-# $PROD_TASK "rake scheduled_jobs:delete_submissions_trash"
-
-echo "Production tasks have completed."
-
+run_production_tasks
 cf logout
+
+echo "$0 exiting with failure count: $F"
+exit $F


### PR DESCRIPTION
Trying to address a few problems with this PR:

1. Running all the tasks in sequence without waiting for them resulting in a big spike in resource consumption, hitting quota, and the failing the last run-tasks
2. Using `--wait` apparently uncovers some failures that were masked when we just kicked off the task and hoped for the best
3. Using `set -e` would cause the later tasks not to run if there was a failure earlier.
