### PR TITLE
Fix: Make Rust widget renderer optional to prevent Sidekiq worker crashes

### DIFF
--- a/ext/widget_renderer/lib/widget_renderer.rb
+++ b/ext/widget_renderer/lib/widget_renderer.rb
@@ -112,4 +112,16 @@ path = File.join(root, 'lib')
 
 puts "WidgetRenderer: Initializing Rutie with path: #{path}"
 
-Rutie.new(:widget_renderer).init 'Init_widget_renderer', path
+# Only initialize Rutie if we found the native library
+if found_path
+  begin
+    Rutie.new(:widget_renderer).init 'Init_widget_renderer', path
+    puts "WidgetRenderer: Rust extension loaded successfully"
+  rescue Fiddle::DLError => e
+    puts "WidgetRenderer: Failed to load native library: #{e.message}"
+    puts "WidgetRenderer: Rust extension will not be available, falling back to ERB"
+  end
+else
+  puts "WidgetRenderer: Native library not found, Rust extension will not be available"
+  puts "WidgetRenderer: Form rendering will use ERB fallback"
+end


### PR DESCRIPTION
## Problem
The Sidekiq worker was crashing on startup with `Fiddle::DLError: libwidget_renderer.so: cannot open shared object file`.

This occurred because the Rails initializer loads `widget_renderer.rb` for ALL processes (including Sidekiq), but the Sidekiq worker deployment doesn't include the Rust buildpack, so the native library doesn't exist.

## Root Cause
`widget_renderer.rb` was calling `Rutie.init` unconditionally, which would fail with a `Fiddle::DLError` when the `.so` file wasn't present.

## Solution
Modified `ext/widget_renderer/lib/widget_renderer.rb` to only call `Rutie.init` when the library file is actually found. If the library isn't present, it logs a warning and the WidgetRenderer class simply won't be available.

This is safe because:
1. The `Form#touchpoints_js_string` method already has a fallback to ERB rendering when WidgetRenderer is unavailable
2. Sidekiq doesn't need the WidgetRenderer - it's only used by the web controller for serving form widgets

## Testing
- ✅ Deployed to staging Sidekiq worker - now running successfully
- ✅ Staging web app still has WidgetRenderer available (library found in release directory)

## Changes
- `ext/widget_renderer/lib/widget_renderer.rb`: Added conditional check before calling `Rutie.init`