### PR TITLE
Fix cx_collections export_csv 500 error

### DIFF
--- a/app/models/cx_collection.rb
+++ b/app/models/cx_collection.rb
@@ -87,7 +87,10 @@ class CxCollection < ApplicationRecord
   end
 
   def self.to_csv
-    collections = all.includes(:organization, :service_provider, :service, :user).references(:organization).order(:fiscal_year, :quarter, 'organizations.name')
+    collections = all
+      .includes(:organization, :service, :user, :cx_collection_details, service_provider: :organization)
+      .references(:organization)
+      .order(:fiscal_year, :quarter, 'organizations.name')
 
     attributes = %i[
       id
@@ -118,7 +121,7 @@ class CxCollection < ApplicationRecord
       csv << attributes
 
       collections.each do |collection|
-        csv << attributes = [
+        csv << [
           collection.id,
           collection.name,
           collection.organization_id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,9 @@ class User < ApplicationRecord
 
   def cx_collections
     user_org = organization
-    user_parent_org = user_org&.parent
+    return CxCollection.none if user_org.nil?
+
+    user_parent_org = user_org.parent
 
     CxCollection.where(cx_collections: { organization_id: [user_org.id, user_parent_org&.id].compact })
   end

--- a/db/migrate/20251210192727_add_indexes_to_cx_collections.rb
+++ b/db/migrate/20251210192727_add_indexes_to_cx_collections.rb
@@ -1,0 +1,16 @@
+class AddIndexesToCxCollections < ActiveRecord::Migration[8.0]
+  def change
+    # cx_collections table - missing all FK indexes
+    add_index :cx_collections, :organization_id
+    add_index :cx_collections, :user_id
+    add_index :cx_collections, :service_provider_id
+    add_index :cx_collections, :service_id
+
+    # cx_collection_details table - missing FK index
+    add_index :cx_collection_details, :cx_collection_id
+
+    # cx_responses table - missing FK indexes
+    add_index :cx_responses, :cx_collection_detail_id
+    add_index :cx_responses, :cx_collection_detail_upload_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_17_034402) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_10_192727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,6 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_17_034402) do
     t.text "trust_question_text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["cx_collection_id"], name: "index_cx_collection_details_on_cx_collection_id"
   end
 
   create_table "cx_collections", force: :cascade do |t|
@@ -124,6 +125,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_17_034402) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "submitted_at"
+    t.index ["organization_id"], name: "index_cx_collections_on_organization_id"
+    t.index ["service_id"], name: "index_cx_collections_on_service_id"
+    t.index ["service_provider_id"], name: "index_cx_collections_on_service_provider_id"
+    t.index ["user_id"], name: "index_cx_collections_on_user_id"
   end
 
   create_table "cx_responses", force: :cascade do |t|
@@ -149,6 +154,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_17_034402) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "external_id"
+    t.index ["cx_collection_detail_id"], name: "index_cx_responses_on_cx_collection_detail_id"
+    t.index ["cx_collection_detail_upload_id"], name: "index_cx_responses_on_cx_collection_detail_upload_id"
   end
 
   create_table "digital_product_versions", force: :cascade do |t|


### PR DESCRIPTION
## Problem
The 'DOWNLOAD Collections as .csv' button at `/admin/cx_collections/export_csv` returns a 500 error ('We're sorry, but something went wrong').

## Root Cause
The `User#cx_collections` method calls `user_org.id` without checking if `user_org` is `nil`. When a user has no organization, this throws:
```
NoMethodError: undefined method 'id' for nil:NilClass
```

## Solution
1. **`app/models/user.rb`** - Added early return `CxCollection.none` when user has no organization
2. **`app/models/cx_collection.rb`** - Improved eager loading to include `service_provider.organization` and `cx_collection_details` to prevent N+1 queries
3. **Database migration** - Added missing indexes on `cx_collections`, `cx_collection_details`, and `cx_responses` tables for better query performance

## Testing
- Verified the fix handles nil organization gracefully
- CSV export now works for users with and without organizations

## Related
Fixes issue reported by OMB (Bin Zheng) since Nov 19, 2025