### PR TITLE
Fix WidgetRenderer load when native lib missing

### DIFF
--- a/config/initializers/widget_renderer.rb
+++ b/config/initializers/widget_renderer.rb
@@ -2,7 +2,7 @@
 begin
   # Try loading the precompiled Rutie extension.
   require_relative '../../ext/widget_renderer/lib/widget_renderer'
-  
+
   # Verify the class was properly defined
   if defined?(WidgetRenderer) && WidgetRenderer.respond_to?(:generate_js)
     Rails.logger.info "WidgetRenderer: Rust extension loaded successfully! generate_js method available."
@@ -14,6 +14,9 @@ begin
 rescue LoadError => e
   Rails.logger.warn "Widget renderer native library not available: #{e.message}"
   Rails.logger.warn 'Rust extension must be built during staging; falling back to ERB template rendering.'
+rescue SystemExit => e
+  Rails.logger.error "Widget renderer exited during load: #{e.message}"
+  Rails.logger.warn 'Falling back to ERB template rendering'
 rescue StandardError => e
   Rails.logger.error "Widget renderer failed to load: #{e.class}: #{e.message}"
   Rails.logger.error e.backtrace.join("\n") if e.backtrace


### PR DESCRIPTION
## What
Prevent the Rust widget renderer (Rutie) from hard-exiting the process when the native library is missing/unavailable during boot/staging.

## Why
During staging (e.g., asset precompile / before the CF rust buildpack finalizes), the native library may not exist yet. Rutie init can raise SystemExit, which kills the process and fails staging.

## How
- ext/widget_renderer/lib/widget_renderer.rb: only initializes Rutie after a library is found; convert SystemExit to LoadError.
- config/initializers/widget_renderer.rb: also rescues SystemExit so boot can fall back safely.

## Notes
No behavior change when the native library is present; runtime still prefers the Rust renderer.