### PR TITLE
Address PR #1925 feedback

### DIFF
--- a/ext/widget_renderer/extconf.rb
+++ b/ext/widget_renderer/extconf.rb
@@ -30,8 +30,6 @@ cargo_bin = ensure_rust
 
 puts "Current directory: #{Dir.pwd}"
 puts "Using cargo executable: #{cargo_bin}"
-puts "Cleaning previous build artifacts..."
-system("#{cargo_bin} clean 2>&1")
 puts "Running cargo build --release..."
 system("#{cargo_bin} build --release 2>&1") or abort 'Failed to build Rust extension'
 

--- a/ext/widget_renderer/src/template_renderer.rs
+++ b/ext/widget_renderer/src/template_renderer.rs
@@ -965,7 +965,8 @@ window.touchpointForm{uuid}.init(touchpointFormOptions{uuid});
 			}}
 		}}
 		// Ensure the custom button is also initialized if it exists (for 'custom-button-modal' delivery method)
-		const customButtonEl = document.getElementById('{element_selector}');
+		const customButtonSelector = '{element_selector}';
+		const customButtonEl = customButtonSelector ? document.getElementById(customButtonSelector) : null;
 		if (customButtonEl && ('{delivery_method}' === 'custom-button-modal')) {{
 			if (fbaUswds.Modal) {{
 				fbaUswds.Modal.on(customButtonEl);

--- a/ext/widget_renderer/src/template_renderer.rs
+++ b/ext/widget_renderer/src/template_renderer.rs
@@ -966,7 +966,7 @@ window.touchpointForm{uuid}.init(touchpointFormOptions{uuid});
 		}}
 		// Ensure the custom button is also initialized if it exists (for 'custom-button-modal' delivery method)
 		const customButtonSelector = '{element_selector}';
-		const customButtonEl = customButtonSelector ? document.getElementById(customButtonSelector) : null;
+		const customButtonEl = (customButtonSelector && customButtonSelector.length > 0) ? document.getElementById(customButtonSelector) : null;
 		if (customButtonEl && ('{delivery_method}' === 'custom-button-modal')) {{
 			if (fbaUswds.Modal) {{
 				fbaUswds.Modal.on(customButtonEl);


### PR DESCRIPTION
## Summary

Addresses code review feedback from PR #1925:

### Changes

1. **Fix element_selector handling** (`template_renderer.rs`)
   - Added null check for `element_selector` before calling `getElementById`
   - Prevents potential JavaScript errors with empty/null selectors

2. **Remove unnecessary cargo clean** (`extconf.rb`)
   - Removed `cargo clean` call before build
   - Clean CI environment doesn't need cargo clean, and removing cached artifacts significantly increases build time

3. **Extract mock request setup to helper method** (`form.rb`)
   - Created `build_controller_with_mock_request` private method
   - Reduces code duplication between `touchpoints_js_string` and `render_widget_css`
   - Improves maintainability

### Not Addressed (Out of Scope)

- **Sleep in specs** - Would require broader refactoring of test patterns
- **Production migrations** - Intentional design decision (migrations run separately)
- **Sidekiq deploy strategy** - Would require broader deployment architecture changes
- **Staging rake task syntax** - Would need verification in staging environment