### PR TITLE
Bust Cargo cache to force Rust widget rebuild

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v2-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}
-            - v2-cargo-
+            - v3-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}
+            - v3-cargo-
 
       - run:
           name: Build widget renderer (Rust)
@@ -89,7 +89,7 @@ jobs:
             - ext/widget_renderer/target
             - ~/.cargo/registry
             - ~/.cargo/git
-          key: v2-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}
+          key: v3-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}
 
       # Download and cache dependencies
       - restore_cache:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "widget_renderer"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "rutie",
  "serde",

--- a/ext/widget_renderer/Cargo.toml
+++ b/ext/widget_renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "widget_renderer"
-version = "0.1.1"
+version = "0.1.3"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Summary

- Bump Cargo cache version from v2 to v3 to force full Rust rebuild
- Bump widget_renderer version to 0.1.3

## Problem

The previous deployment did not include the modal button fix because CircleCI was using a cached version of the Rust library. The cache key was based only on `Cargo.lock`, not the Rust source code (`template_renderer.rs`), so source code changes didn't trigger rebuilds.

## Solution

Bump the cache version to invalidate the old cache and force a fresh build of the Rust widget renderer with the modal button fix.