### PR TITLE
Fix Cargo cache key to include source checksum (v4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v3-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}
-            - v3-cargo-
+            - v4-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}-{{ checksum "ext/widget_renderer/src/template_renderer.rs" }}
+            - v4-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}-
 
       - run:
           name: Build widget renderer (Rust)
@@ -89,7 +89,7 @@ jobs:
             - ext/widget_renderer/target
             - ~/.cargo/registry
             - ~/.cargo/git
-          key: v3-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}
+          key: v4-cargo-{{ checksum "ext/widget_renderer/Cargo.lock" }}-{{ checksum "ext/widget_renderer/src/template_renderer.rs" }}
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
## Summary

Fix the CircleCI Cargo cache key to include source file checksum, ensuring Rust source changes trigger rebuilds.

## Problem

The cache key only included `Cargo.lock` checksum. When `template_renderer.rs` was modified but `Cargo.lock` didn't change, CircleCI restored the cached (old) compiled library.

## Solution

Cache key now includes both:
- `Cargo.lock` checksum (dependency changes)
- `template_renderer.rs` checksum (source code changes)

Also bumped version to v4 to guarantee a fresh build.