### PR TITLE
Fix cf-cli installation using APT repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,16 +121,16 @@ jobs:
             mkdir /tmp/test-results
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
 
-            bundle exec rspec --format progress \
-                            --format RspecJunitFormatter \
-                            --out /tmp/test-results/rspec.xml \
-                            --format progress \
-                            $TEST_FILES
+             bundle exec rspec --format progress \
+                             --format RspecJunitFormatter \
+                             --out /tmp/test-results/rspec.xml \
+                             --format progress \
+                             $TEST_FILES
       # Install Cloud Foundry cli (cf) before deploy step. cf is used to push to Cloud.gov
       - run:
           name: Install-cf-cli
           command: |
-            curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable?release=debian64&source=github'
+            curl -L -o cf-cli_amd64.deb 'https://github.com/cloudfoundry/cli/releases/download/v8.17.0/cf8-cli-installer_8.17.0_x86-64.deb'
             sudo dpkg -i cf-cli_amd64.deb
             cf -v
       # collect reports
@@ -180,7 +180,7 @@ jobs:
       - run:
           name: Install-cf-cli
           command: |
-            curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable?release=debian64&source=github'
+            curl -L -o cf-cli_amd64.deb 'https://github.com/cloudfoundry/cli/releases/download/v8.17.0/cf8-cli-installer_8.17.0_x86-64.deb'
             sudo dpkg -i cf-cli_amd64.deb
             cf -v
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,8 +183,9 @@ jobs:
       - run:
           name: Install-cf-cli
           command: |
-            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-            echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            # Install Cloud Foundry CLI repository key using modern signed-by mechanism
+            sudo wget -q -O /etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key
+            echo "deb [signed-by=/etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
             sudo apt-get update
             sudo apt-get install -y cf8-cli
             cf -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,9 @@ jobs:
       - run:
           name: Install-cf-cli
           command: |
-            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-            echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            sudo mkdir -p /etc/apt/trusted.gpg.d
+            sudo wget -q -O /etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key
+            echo "deb [signed-by=/etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
             sudo apt-get update
             sudo apt-get install -y cf8-cli
             cf -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,10 @@ jobs:
       - run:
           name: Install-cf-cli
           command: |
-            curl -L -o cf-cli_amd64.deb 'https://github.com/cloudfoundry/cli/releases/download/v8.17.0/cf8-cli-installer_8.17.0_x86-64.deb'
-            sudo dpkg -i cf-cli_amd64.deb
+            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+            echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            sudo apt-get update
+            sudo apt-get install -y cf8-cli
             cf -v
       # collect reports
       - store_test_results:
@@ -180,8 +182,10 @@ jobs:
       - run:
           name: Install-cf-cli
           command: |
-            curl -L -o cf-cli_amd64.deb 'https://github.com/cloudfoundry/cli/releases/download/v8.17.0/cf8-cli-installer_8.17.0_x86-64.deb'
-            sudo dpkg -i cf-cli_amd64.deb
+            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+            echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            sudo apt-get update
+            sudo apt-get install -y cf8-cli
             cf -v
       - run:
           name: Run CRON tasks


### PR DESCRIPTION
## Summary
- Switch cf-cli installation from direct GitHub download to CloudFoundry APT repository to fix download failures in CI environment
- The direct curl download was only receiving 107 bytes (likely proxy/redirect issue) instead of the full package