### PR TITLE
Fix CF CLI GPG key installation for modern apt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,9 @@ jobs:
       - run:
           name: Install-cf-cli
           command: |
-            sudo mkdir -p /etc/apt/trusted.gpg.d
-            sudo wget -q -O /etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key
-            echo "deb [signed-by=/etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            # Download and convert the GPG key to binary format for modern apt
+            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo gpg --dearmor -o /usr/share/keyrings/cloudfoundry-cli.gpg
+            echo "deb [signed-by=/usr/share/keyrings/cloudfoundry-cli.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
             sudo apt-get update
             sudo apt-get install -y cf8-cli
             cf -v
@@ -183,9 +183,9 @@ jobs:
       - run:
           name: Install-cf-cli
           command: |
-            # Install Cloud Foundry CLI repository key using modern signed-by mechanism
-            sudo wget -q -O /etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key
-            echo "deb [signed-by=/etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            # Download and convert the GPG key to binary format for modern apt
+            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo gpg --dearmor -o /usr/share/keyrings/cloudfoundry-cli.gpg
+            echo "deb [signed-by=/usr/share/keyrings/cloudfoundry-cli.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
             sudo apt-get update
             sudo apt-get install -y cf8-cli
             cf -v


### PR DESCRIPTION
## Summary
Fix the GPG key installation for CloudFoundry CLI to work with modern apt.

## Problem
The previous fix saved the ASCII-armored GPG key directly as a `.gpg` file, but modern apt requires the key to be in binary format.

Error was:
```
The key(s) in the keyring /etc/apt/trusted.gpg.d/cloudfoundry-cli.gpg are ignored as the file has an unsupported filetype.
```

## Fix
- Use `gpg --dearmor` to convert the key to binary format
- Store in `/usr/share/keyrings/` (preferred location for modern apt)