### PR TITLE
Add SKIP_WIDGET_RENDERER to manifests

### DIFF
--- a/touchpoints-demo.yml
+++ b/touchpoints-demo.yml
@@ -19,6 +19,7 @@ applications:
       TOUCHPOINTS_EMAIL_SENDER:
       TOUCHPOINTS_GTM_CONTAINER_ID:
       TOUCHPOINTS_WEB_DOMAIN: touchpoints-demo.app.cloud.gov
+      SKIP_WIDGET_RENDERER: "true"
     buildpacks:
       - https://github.com/rileyseaburg/rust-buildpack-touchpoints.git
       - nodejs_buildpack

--- a/touchpoints-staging.yml
+++ b/touchpoints-staging.yml
@@ -25,6 +25,7 @@ applications:
       TURNSTILE_SECRET_KEY: ((TURNSTILE_SECRET_KEY))
       TOUCHPOINTS_WEB_DOMAIN2: app-staging.touchpoints.digital.gov
       ASSET_HOST: app-staging.touchpoints.digital.gov
+      SKIP_WIDGET_RENDERER: "true"
     buildpacks:
       - https://github.com/rileyseaburg/rust-buildpack-touchpoints.git
       - nodejs_buildpack

--- a/touchpoints.yml
+++ b/touchpoints.yml
@@ -14,6 +14,7 @@ applications:
     RAILS_SERVE_STATIC_FILES: "true"
     TOUCHPOINTS_WEB_DOMAIN: touchpoints.app.cloud.gov
     INDEX_URL: /admin
+    SKIP_WIDGET_RENDERER: "true"
     # Secrets managed via cf set-env (DO NOT add empty keys here):
     # - AWS_SES_ACCESS_KEY_ID
     # - AWS_SES_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Summary
- Adds `SKIP_WIDGET_RENDERER: "true"` to all manifest files (production, staging, demo)
- Prevents CF from removing this env var during deployments, which was causing instances to crash when trying to load the Rust widget renderer library