### PR TITLE
Fix sidekiq worker to run Sidekiq instead of Rails server

### DIFF
--- a/.circleci/deploy-sidekiq.sh
+++ b/.circleci/deploy-sidekiq.sh
@@ -130,6 +130,7 @@ cf_push_with_retry() {
     # Let CF auto-detect buildpacks to avoid re-running supply phase (Rust already built in CircleCI)
     if cf push "$app_name" \
       -t 180 \
+      -c "bundle exec sidekiq -C config/sidekiq.yml" \
       --health-check-type process; then
       echo "Successfully pushed $app_name"
       


### PR DESCRIPTION
## Summary
CRITICAL FIX for production sidekiq worker crashes.

## Problem
The sidekiq worker app has been crashing repeatedly because it's running `bin/rails server` (Rails web server) instead of Sidekiq. This causes:
- Continuous crashes (every ~16 minutes)
- 0/1 instances running (worker completely down)
- No background jobs processing (exports, emails, scheduled tasks)
- Continuous Cloud Foundry failure emails

## Changes
This PR contains a single commit cherry-picked from PR #1945:

- `.circleci/deploy-sidekiq.sh`: Add `-c "bundle exec sidekiq -C config/sidekiq.yml"` flag

This is the minimal fix to restore job processing in production.

## Impact
- Production sidekiq worker will start properly (currently showing 0/1 instances)
- Background jobs will resume processing (exports, emails, scheduled tasks)
- Failure emails will stop

## Verification After Merge
```bash
cf app touchpoints-production-sidekiq-worker  
# Should show: instances: 1/1

cf logs touchpoints-production-sidekiq-worker --recent  
# Should show Sidekiq startup, not Rails server
```

Fixes #1944