### PR TITLE
Fix test splitting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
             mkdir /tmp/test-results
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb")"
             echo "$TEST_FILES" | circleci tests run --verbose --split-by=timings \
-              --command="bundle exec rspec --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml"
+              --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml"
 
       # collect test reports
       - store_test_results:


### PR DESCRIPTION
CircleCI was running all 747 tests on each of 4 parallel runners instead of splitting the 747 tests _over_ 4 parallel runners, which is what is supposed to be doing. This PR fixes that.