### PR TITLE
Stop automatically loading Rust widget renderer on startup.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'sidekiq', '>= 8.0.4'
 
 # Rust integration for high-performance widget rendering
 gem 'rutie', '~> 0.0.4'
-gem 'widget_renderer', path: 'ext/widget_renderer'
+gem 'widget_renderer', path: 'ext/widget_renderer', require: false
 
 group :development, :test do
   gem 'dotenv'

--- a/ext/widget_renderer/lib/widget_renderer.rb
+++ b/ext/widget_renderer/lib/widget_renderer.rb
@@ -1,24 +1,5 @@
 # frozen_string_literal: true
 
-# Check if widget renderer should be skipped (for deployments where native library is unavailable)
-if ENV['SKIP_WIDGET_RENDERER'] == 'true'
-  puts 'WidgetRenderer: SKIP_WIDGET_RENDERER is set, using stub implementation'
-  
-  # Define a stub class that provides the same interface but uses ERB fallback
-  class WidgetRenderer
-    def self.render_widget(template, data)
-      # Return nil to signal caller should use ERB fallback
-      nil
-    end
-    
-    def self.available?
-      false
-    end
-  end
-  
-  return # Exit early, don't load native library
-end
-
 require 'rutie'
 require 'fileutils'
 


### PR DESCRIPTION
Adds `require: false` to the Rust widget_renderer gem in the application Gemfile, which tells Bundler not to automatically load the gem when the Rails application starts. Instead, the gem must be loaded manually.

The main reason for this change is to ensure that, in development environments, the environment variables are set by Dotenv _before_ the application attempts to load the widget_renderer gem. The code that loads widget_renderer can be conditionally disabled by an environment variable, but this only works if the environment has a chance to be set up before the loading code runs.

With this PR, the steps during start up are:

1. In application.rb, load gems listed in Gemfile with `Bundler.require(*Rails.groups)`. This _does not_ load the widget_renderer gem since it is now specified with `require: false`.
2. In application.rb, environment variables are set with `Dotenv::Rails.load if Rails.env.development? || Rails.env.test?`.
3. Initializer files are executed, including widget_renderer.rb. In that file, the Rust widget renderer is loaded only if the env variable `SKIP_WIDGET_RENDERER` is not set.

