### PR TITLE
Replace ruby command in deploy script with bash tools.

### DIFF
--- a/.circleci/sync-login-gov-env.sh
+++ b/.circleci/sync-login-gov-env.sh
@@ -11,7 +11,7 @@ require_env() {
 }
 
 escape_private_key() {
-  ruby -e 'print STDIN.read.gsub("\r\n", "\n").gsub("\n", "\\n")'
+  tr -d '\r' | sed 's/\n/\\n/g'
 }
 
 sync_login_gov_env() {


### PR DESCRIPTION
One of the scripts that handles deployment to cloud.gov uses Ruby to perform string manipulation. This PR replaces that line of Ruby code with an equivalent line using only standard bash tools. That way, the deploy job doesn't need a Ruby image but can use a base Ubuntu image. Not that the Ruby image was hurting anything really but this feels cleaner.

Pushing this into production first because that's the only environment that uses the script in question. I'll merge back to main/develop once I've confirmed the change works in production.