### PR TITLE
Deploy demo environment from production branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,14 @@ jobs:
           path: coverage
 
   deploy:
+    parameters:
+      deploy_environment:
+        type: enum
+        enum:
+          - staging
+          - demo
+          - production
+        default: staging
     docker:
       - image: cimg/base:2025.01
     steps:
@@ -162,7 +170,7 @@ jobs:
             # echo "Removing prebuilt Rust library (will be rebuilt on CF)..."
             # rm -rf ext/widget_renderer/target/release/libwidget_renderer.so 2>/dev/null || true
             # rm -f ext/widget_renderer/libwidget_renderer.so 2>/dev/null || true
-            ./.circleci/deploy-sidekiq.sh
+            ./.circleci/deploy-sidekiq.sh << parameters.deploy_environment >>
           no_output_timeout: 30m
 
       - run:
@@ -174,7 +182,7 @@ jobs:
             # echo "Removing prebuilt Rust library (will be rebuilt on CF)..."
             # rm -rf ext/widget_renderer/target/release/libwidget_renderer.so 2>/dev/null || true
             # rm -f ext/widget_renderer/libwidget_renderer.so 2>/dev/null || true
-            ./.circleci/deploy.sh
+            ./.circleci/deploy.sh << parameters.deploy_environment >>
           no_output_timeout: 30m
 
   cron_tasks:
@@ -215,11 +223,29 @@ workflows:
           requires:
             - build
       - deploy:
+          name: deploy-to-staging
+          deploy_environment: staging
           requires:
             - test
           filters:
             branches:
               only:
                 - develop
-                - main
+      - deploy:
+          name: deploy-to-demo
+          deploy_environment: demo
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - production
+      - deploy:
+          name: deploy-to-production
+          deploy_environment: production
+          requires:
+            - test
+          filters:
+            branches:
+              only:
                 - production

--- a/.circleci/deploy-sidekiq.sh
+++ b/.circleci/deploy-sidekiq.sh
@@ -166,40 +166,43 @@ cf_push_with_retry() {
   return 1
 }
 
-if [ "${CIRCLE_BRANCH}" == "production" ]
-then
-  echo "Logging into cloud.gov"
-  # Log into CF and push
-  cf login -a $CF_API_ENDPOINT -u $CF_PRODUCTION_SPACE_DEPLOYER_USERNAME -p $CF_PRODUCTION_SPACE_DEPLOYER_PASSWORD -o $CF_ORG -s prod
-  echo "PUSHING to PRODUCTION..."
-  echo "Syncing Login.gov environment variables..."
-  ./.circleci/sync-login-gov-env.sh touchpoints-production-sidekiq-worker
-  cf_push_with_retry touchpoints-production-sidekiq-worker
-  echo "Push to Production Complete."
-else
-  echo "Not on the production branch."
+TARGET_ENV="${1:-}"
+
+if [ -z "$TARGET_ENV" ]; then
+  echo "Usage: ./.circleci/deploy-sidekiq.sh <production|demo|staging>"
+  exit 1
 fi
 
-if [ "${CIRCLE_BRANCH}" == "main" ]
-then
-  echo "Logging into cloud.gov"
-  # Log into CF and push
-  cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
-  echo "Pushing to Demo..."
-  cf_push_with_retry touchpoints-demo-sidekiq-worker
-  echo "Push to Demo Complete."
-else
-  echo "Not on the main branch."
-fi
-
-if [ "${CIRCLE_BRANCH}" == "develop" ]
-then
-  echo "Logging into cloud.gov"
-  # Log into CF and push
-  cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
-  echo "Pushing to Staging..."
-  cf_push_with_retry touchpoints-staging-sidekiq-worker
-  echo "Push to Staging Complete."
-else
-  echo "Not on the develop branch."
-fi
+case "$TARGET_ENV" in
+  production)
+    echo "Logging into cloud.gov"
+    # Log into CF and push
+    cf login -a $CF_API_ENDPOINT -u $CF_PRODUCTION_SPACE_DEPLOYER_USERNAME -p $CF_PRODUCTION_SPACE_DEPLOYER_PASSWORD -o $CF_ORG -s prod
+    echo "PUSHING to PRODUCTION..."
+    echo "Syncing Login.gov environment variables..."
+    ./.circleci/sync-login-gov-env.sh touchpoints-production-sidekiq-worker
+    cf_push_with_retry touchpoints-production-sidekiq-worker
+    echo "Push to Production Complete."
+    ;;
+  demo)
+    echo "Logging into cloud.gov"
+    # Log into CF and push
+    cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+    echo "Pushing to Demo..."
+    cf_push_with_retry touchpoints-demo-sidekiq-worker
+    echo "Push to Demo Complete."
+    ;;
+  staging)
+    echo "Logging into cloud.gov"
+    # Log into CF and push
+    cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+    echo "Pushing to Staging..."
+    cf_push_with_retry touchpoints-staging-sidekiq-worker
+    echo "Push to Staging Complete."
+    ;;
+  *)
+    echo "Unknown environment: $TARGET_ENV"
+    echo "Usage: ./.circleci/deploy-sidekiq.sh <production|demo|staging>"
+    exit 1
+    ;;
+esac

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -281,40 +281,43 @@ cf_push_with_retry() {
   return 1
 }
 
-if [ "${CIRCLE_BRANCH}" == "production" ]
-then
-  echo "Logging into cloud.gov"
-  # Log into CF and push
-  cf login -a $CF_API_ENDPOINT -u $CF_PRODUCTION_SPACE_DEPLOYER_USERNAME -p $CF_PRODUCTION_SPACE_DEPLOYER_PASSWORD -o $CF_ORG -s prod
-  echo "PUSHING web servers to Production..."
-  echo "Syncing Login.gov environment variables..."
-  ./.circleci/sync-login-gov-env.sh touchpoints
-  cf_push_with_retry touchpoints touchpoints.yml false
-  echo "Push to Production Complete."
-else
-  echo "Not on the production branch."
+TARGET_ENV="${1:-}"
+
+if [ -z "$TARGET_ENV" ]; then
+  echo "Usage: ./.circleci/deploy.sh <production|demo|staging>"
+  exit 1
 fi
 
-if [ "${CIRCLE_BRANCH}" == "main" ]
-then
-  echo "Logging into cloud.gov"
-  # Log into CF and push
-  cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
-  echo "Pushing web servers to Demo..."
-  cf_push_with_retry touchpoints-demo "" true
-  echo "Push to Demo Complete."
-else
-  echo "Not on the main branch."
-fi
-
-if [ "${CIRCLE_BRANCH}" == "develop" ]
-then
-  echo "Logging into cloud.gov"
-  # Log into CF and push
-  cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
-  echo "Pushing web servers to Staging..."
-  cf_push_with_retry touchpoints-staging "" true
-  echo "Push to Staging Complete."
-else
-  echo "Not on the develop branch."
-fi
+case "$TARGET_ENV" in
+  production)
+    echo "Logging into cloud.gov"
+    # Log into CF and push
+    cf login -a $CF_API_ENDPOINT -u $CF_PRODUCTION_SPACE_DEPLOYER_USERNAME -p $CF_PRODUCTION_SPACE_DEPLOYER_PASSWORD -o $CF_ORG -s prod
+    echo "PUSHING web servers to Production..."
+    echo "Syncing Login.gov environment variables..."
+    ./.circleci/sync-login-gov-env.sh touchpoints
+    cf_push_with_retry touchpoints touchpoints.yml false
+    echo "Push to Production Complete."
+    ;;
+  demo)
+    echo "Logging into cloud.gov"
+    # Log into CF and push
+    cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+    echo "Pushing web servers to Demo..."
+    cf_push_with_retry touchpoints-demo "" true
+    echo "Push to Demo Complete."
+    ;;
+  staging)
+    echo "Logging into cloud.gov"
+    # Log into CF and push
+    cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+    echo "Pushing web servers to Staging..."
+    cf_push_with_retry touchpoints-staging "" true
+    echo "Push to Staging Complete."
+    ;;
+  *)
+    echo "Unknown environment: $TARGET_ENV"
+    echo "Usage: ./.circleci/deploy.sh <production|demo|staging>"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
The Touchpoints development process as described [here](https://github.com/GSA/touchpoints/wiki/Operations#touchpoints-development-process) is too heavyweight for a project that:

- Never has more than one or two active developers
- Does not require multiple layers of sign-off before code can be pushed to production
- Does not need to support multiple versions of the software in production

The existing process has the following gates:

1. Automated tests and automated scans must pass
2. Code must be reviewed and approved
3. Behavior of new code is tested and approved in staging environment by product owner
4. Users use the product and share feedback in a demo environment
5. Finally, the owner of the system pushes the code to production

I don't think gate 4 is necessary. Day-to-day, the best place for users to test the product is in production, while using the product to accomplish the things they need to accomplish. We don't have the resources to recruit users to volunteer to test stuff in a demo environment. If, on rare occasions, we do want to beta test new features, we can do so with feature flags.

This PR eliminates the 4th gate and moves Touchpoints towards a higher-velocity trunk-based development model. It does not eliminate the demo environment, which still may have some use as a place for experimenting with Touchpoints, but it deploys the demo environment as a copy of production, rather than as a precursor to production.

Once this change is deployed to production, I intend to delete the 'main' branch.