### PR TITLE
Disable Bullet alerts in development.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.after_initialize do
     Bullet.enable        = true
-    Bullet.alert         = true
+    Bullet.alert         = false
     Bullet.bullet_logger = true
     Bullet.console       = true
     Bullet.rails_logger  = true


### PR DESCRIPTION
Bullet is a development-time Ruby Gem that warns you about inefficient database queries. Currently, it's configured to warn you by throwing up a JS alert modal that you are forced to acknowledge over and over as you are running in development. I appreciate that it is annoying for a good reason and we should probably listen to it and improve our queries instead of disabling the warning. But the development team does not have time to fix all of these warnings right now so I'm going to disable the most annoying version of the warning. The warnings will still be logged and written to the JS console.