### PR TITLE
Add route /admin/forms/all

### DIFF
--- a/app/controllers/admin/forms_controller.rb
+++ b/app/controllers/admin/forms_controller.rb
@@ -51,7 +51,13 @@ module Admin
         params[:aasm_state] = @status # set the filter and dropdown by default
       end
 
-      @forms = Form.filtered_forms(@current_user, @status)
+      @forms = Form.my_forms(@current_user, @status)
+      @tags = @forms.collect(&:tag_list).flatten.uniq.sort
+    end
+
+    def all
+      ensure_admin
+      @forms = Form.all.non_templates
       @tags = @forms.collect(&:tag_list).flatten.uniq.sort
     end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -40,10 +40,8 @@ class Form < ApplicationRecord
 
   mount_uploader :logo, LogoUploader
 
-  def self.filtered_forms(user, aasm_state)
-    if user.admin?
-      items = all
-    elsif user.organizational_form_approver?
+  def self.my_forms(user, aasm_state)
+    if user.organizational_form_approver?
       items = user.organization.forms
     else
       items = user.forms.order('organization_id ASC').order('name ASC')

--- a/app/views/admin/forms/all.html.erb
+++ b/app/views/admin/forms/all.html.erb
@@ -1,27 +1,15 @@
 <% content_for :navigation_title do %>
-  My Forms
-  <%= link_to new_admin_form_path, class: "usa-button usa-button-inverted float-right" do %>
-    <i class="fa fa-plus-circle"></i>
-    New Form
-  <% end %>
+  All Forms
 <% end %>
 
-<div class="margin-top-1 border-bottom border-base-lighter padding-bottom-1 form-filter-buttons">
-  <%= label_tag :aasm_state, "Filter by form status:", class: "font-sans-2xs" %>
-  <div class="usa-button-group margin-top-1">
-    <% form_states = Form.aasm.states.collect(&:name) + [:all] %>
-    <% form_states.each do |state| %>
-      <%= link_to state.name.capitalize, admin_forms_path(aasm_state: state.name), method: :get,
-        class: "usa-button #{params[:aasm_state] == state.name.to_s ? 'usa-button--active' : 'usa-button--outline'}" %>
-    <% end %>
-  </div>
-</div>
-
-<%- if @forms.present? %>
 <table class="usa-table usa-table--sticky-header width-full font-sans-2xs">
   <thead class="font-sans-3xs z-top">
     <tr>
       <th>#</th>
+      <th data-sortable scope="col"
+        data-type="organization-name">
+        Organization name
+      </th>
       <th data-sortable scope="col"
         data-type="name">
         Name
@@ -50,6 +38,9 @@
     <tr>
       <td class="text-center">
         <%= index + 1 %>
+      </td>
+      <td>
+        <%= render "admin/organizations/badge", organization: form.organization %>
       </td>
       <td>
         <%= link_to form.name, admin_form_path(form) %>
@@ -113,16 +104,3 @@
     <% end %>
   </tbody>
 </table>
-<% else %>
-<div class="grid-row grid-gap-md">
-  <div class="grid-col">
-    <p class="font-serif-xl">
-      Welcome to Touchpoints
-    </p>
-    <p class="font-sans-lg">
-      To get started with customer feedback,
-      <%= link_to "create a new form", new_admin_form_path, class: "usa-link" %>.
-    </p>
-  </div>
-</div>
-<% end %>

--- a/app/views/admin/site/index.html.erb
+++ b/app/views/admin/site/index.html.erb
@@ -39,6 +39,11 @@
                 </a>
               </li>
               <li>
+                <%= link_to all_admin_forms_path do %>
+                  All Forms
+                <% end %>
+              </li>
+              <li>
                 <a href="/admin/management">
                   <span>Client Management</span>
                 </a>
@@ -52,11 +57,6 @@
                 <a href="/admin/sidekiq">
                   <span>Manage Sidekiq</span>
                 </a>
-              </li>
-              <li>
-                <%= link_to admin_record_retention_path do %>
-                  Record Retention
-                <% end %>
               </li>
             </ul>
           </div>
@@ -125,6 +125,11 @@
               <li>
                 <%= link_to admin_integrations_path do %>
                   Integrations
+                <% end %>
+              </li>
+              <li>
+                <%= link_to admin_record_retention_path do %>
+                  Record Retention
                 <% end %>
               </li>
             </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,6 +305,7 @@ Rails.application.routes.draw do
         get 'events', to: 'forms#events', as: :events
       end
       collection do
+        get 'all', to: 'forms#all'
         post 'copy', to: 'forms#copy', as: :copy_id
       end
       resources :form_sections, except: %i[index show edit] do

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -7,40 +7,56 @@ feature 'Forms', js: true do
     3.days.from_now
   end
   let(:organization) { FactoryBot.create(:organization) }
+  let(:another_organization) { FactoryBot.create(:organization, :another) }
   let(:admin) { FactoryBot.create(:user, :admin, organization:) }
   let(:user) { FactoryBot.create(:user, organization:) }
 
   context 'as Admin' do
+    let!(:user_forms) do
+      FactoryBot.create_list(:form, 3, organization:) do |form, i|
+        FactoryBot.create(:user_role, :form_manager, user: admin, form:)
+        if i == 0
+          form.update(aasm_state: :archived)
+        end
+      end
+    end
+    let!(:form_in_my_org) { FactoryBot.create(:form, organization:) }
+    let!(:form_in_other_org) { FactoryBot.create(:form, organization: another_organization) }
+
     before do
       login_as(admin)
     end
 
     describe '/admin/forms' do
-      let!(:form) { FactoryBot.create(:form, organization:) }
-      let!(:form2) { FactoryBot.create(:form, organization:) }
-      let!(:form3) { FactoryBot.create(:form, organization:) }
-      let!(:form4) { FactoryBot.create(:form, organization:, aasm_state: :submitted) }
-      let!(:form5) { FactoryBot.create(:form, organization:, aasm_state: :archived) }
-
       before do
         visit admin_forms_path
       end
 
-      it 'displays 3 published forms' do
+      it 'displays 2 published form owned by the admin user' do
+        expect(find_all('.usa-table tbody tr').size).to eq(2)
         expect(page).to have_content('PUBLISHED')
         expect(page).to_not have_content('ARCHIVED')
-        expect(find_all('.usa-table tbody tr').size).to eq(3)
       end
 
       context 'use the visible buttons to filter for archived forms' do
-        it 'displays 1 archived form' do
+        it 'displays 1 archived form owned by the admin user' do
           within('.form-filter-buttons') do
             click_on('Archived')
           end
+          expect(find_all('.usa-table tbody tr').size).to eq(1)
           expect(page).to have_content('ARCHIVED')
           expect(page).to_not have_content('PUBLISHED')
-          expect(find_all('.usa-table tbody tr').size).to eq(1)
         end
+      end
+    end
+
+    describe '/admin/forms/all' do
+      before do
+        visit all_admin_forms_path
+      end
+
+      it 'displays all 5 forms' do
+        expect(find_all('.usa-table tbody tr').size).to eq(5)
       end
     end
   end
@@ -1429,6 +1445,18 @@ feature 'Forms', js: true do
           end
         end
       end
+    end
+  end
+
+  context 'as non-admin user' do
+    before do
+      login_as(user)
+    end
+
+    it 'cannot access All Forms page' do
+      visit all_admin_forms_path
+      expect(page.current_path).to eq(admin_root_path)
+      expect(page).to have_content('Authorization is Required')
     end
   end
 


### PR DESCRIPTION
This PR is purely for the benefit of Touchpoints admins. 

The landing page when you log into Touchpoints is the "My Forms" page at /admin/forms. If you are a non-admin user, this displays a list of forms for which you are a manager or response viewer. If you are an admin user, it displays all of the forms in the system. If you are an admin but you are also using Touchpoints as a normal user (managing a few forms), it's very hard to find the forms you manage in the list of all forms. Also, the list of all forms takes a long time to load.

This PR changes the MyForms to be a consistent experience for all users, only displaying a list of the logged in user's forms. Admin users can still view all forms under the /admin/forms/all path, which is linked to from the Admin page:

<img width="801" height="633" alt="Screenshot 2026-02-25 at 1 44 53 PM" src="https://github.com/user-attachments/assets/61668d14-e249-45bb-8f60-999d379131e3" />

One edge case: If you are an Organizational Form Approver, then your My Forms page will list all of the forms in your organization, not just the forms belonging to you.

