### PR TITLE
Potential fix for code scanning alert no. 43: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-widget.yml
+++ b/.github/workflows/build-widget.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   build-widget:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/touchpoints/security/code-scanning/43](https://github.com/GSA/touchpoints/security/code-scanning/43)

In general, this issue is fixed by explicitly specifying a `permissions` block that grants only the minimum required scopes to the `GITHUB_TOKEN`. For a build‑only workflow that checks out code and uploads artifacts but does not modify repository data, `contents: read` is usually sufficient, either at the workflow root (applies to all jobs) or directly under the specific job.

For this workflow, the least‑privilege fix without changing functionality is to add `permissions: contents: read` at the job level under `build-widget:` (around line 17). None of the listed steps need write access to repository contents, issues, or pull requests; the standard `actions/checkout`, `actions-rs/toolchain`, and `actions/upload-artifact` operations work with a read‑only `GITHUB_TOKEN` for repo contents. Concretely, in `.github/workflows/build-widget.yml`, insert a `permissions:` section under `build-widget:` and before `runs-on: ubuntu-22.04`, indented correctly. No imports or additional methods are required, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
