### PR TITLE
Speed up loading of recent_responses table in admin dashboard

### DIFF
--- a/app/controllers/admin/site_controller.rb
+++ b/app/controllers/admin/site_controller.rb
@@ -12,7 +12,6 @@ module Admin
       @response_groups = Submission.group('date(created_at)').count.sort.last(@days_since.days)
       @user_groups = User.group('date(created_at)').count.sort.last(@days_since.days)
       @inactive_user_groups = User.where(inactive: true).group('date(updated_at)').count.sort.last(@days_since.days)
-      todays_submissions = Submission.where('created_at > ?', Time.zone.now - @days_since.days)
 
       # Add in 0 count days to fetched analytics
       @dates.each do |date|
@@ -24,8 +23,11 @@ module Admin
       @inactive_user_groups = @inactive_user_groups.sort
       @response_groups = @response_groups.sort
 
-      form_ids = todays_submissions.collect(&:form_id).uniq
-      @recent_forms = Form.includes(:organization).find(form_ids)
+      @recent_forms = Form.includes(:organization)
+                          .joins(:submissions)
+                          .where("submissions.created_at > ?", Time.zone.now - @days_since.days)
+                          .select("forms.*", "count(distinct submissions.id) as recent_submissions_count")
+                          .group("forms.id")
     end
 
     def a11_v2_collections; end

--- a/app/views/components/admin/_recent_responses.html.erb
+++ b/app/views/components/admin/_recent_responses.html.erb
@@ -23,7 +23,7 @@
           <td>
             <%= link_to form.name, admin_form_path(form) %>
           </td>
-          <td data-sort-value="<%= c = form.submissions.where("created_at > ?", Time.now - days_since.days).count %>">
+          <td data-sort-value="<%= c = form.recent_submissions_count %>">
             <%= number_with_delimiter(c) %>
           </td>
         </tr>

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -142,6 +142,36 @@ feature 'Admin Dashboard', js: true do
         end
       end
     end
+
+    describe 'recent responses' do
+      let(:recent_form) { FactoryBot.create(:form, :open_ended_form, organization:) }
+      let(:older_form) { FactoryBot.create(:form, :recruiter, organization:) }
+      let!(:recent_form_responses) {
+        FactoryBot.create_list(:submission, 5, form: recent_form, created_at: 5.days.ago) do |submission, i|
+          submission.update(created_at: 1.days.ago) if i < 2
+        end
+      }
+      let!(:older_form_responses) {
+        FactoryBot.create_list(:submission, 3, form: older_form, created_at: 5.days.ago)
+      }
+
+      before do
+        visit admin_dashboard_path
+      end
+
+      it 'contains a "Data collected over past 3 days" table' do
+        expect(page).to have_content('Data collected over past 3 days')
+        table = page.find('#recent-responses table')
+        expect(table).to be_present
+
+        # 1 form with recent responses, 2 recent responses
+        rows = table.all('tbody tr')
+        expect(rows.count).to eq(1)
+        first_row_cells = rows.first.all('td')
+        expect(first_row_cells[1].text).to eq('Open-ended Test form')
+        expect(first_row_cells[2].text).to eq('2')
+      end
+    end
   end
 
   # Note:


### PR DESCRIPTION
`/admin/dashboard` takes 75 seconds to load. Nearly all of that time is taken up by more than 100 separate db queries to the `submissions` table. This PR aims to speed up the page load by replacing all of these queries with a single query.