### PR TITLE
Send new relic logs to stdout

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -20,6 +20,7 @@ common: &default_settings
 
   # Logging level for log/newrelic_agent.log
   log_level: info
+  log_file_path: STDOUT
 
 # Environment-specific settings are in this section.
 # RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.


### PR DESCRIPTION
NewRelic logs are written to file by default, not to stdout, which means they don't show up in the cloud.gov log streams. That makes it hard to debug NewRelic problems. This PR configures the logs to go to stdout.