### PR TITLE
Don't validate submissions during deletion.

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -186,23 +186,20 @@ module Admin
     def delete
       ensure_form_manager(form: @form)
 
-      if @submission.update(deleted: true, deleted_at: Time.now)
-        Event.log_event(Event.names[:response_deleted], 'Submission', @submission.id, "Submission #{@submission.id} deleted at #{DateTime.now}", current_user.id)
-      else
-        Rails.logger.warn("Failed to delete submission: #{@submission.errors.full_messages.join(', ')}")
-      end
+      Event.log_event(Event.names[:response_deleted], 'Submission', @submission.id, "Submission #{@submission.id} deleted at #{DateTime.now}", current_user.id)
+      @submission.assign_attributes(deleted: true, deleted_at: Time.now)
+      @submission.save(validate: false)
     end
 
     def destroy
       ensure_form_manager(form: @form)
 
-      if @submission.update(deleted: true, deleted_at: Time.now)
-        Event.log_event(Event.names[:response_deleted], 'Submission', @submission.id, "Submission #{@submission.id} deleted at #{DateTime.now}", current_user.id)
-        respond_to do |format|
-          format.js { render :destroy }
-        end
-      else
-        Rails.logger.warn("Failed to delete submission: #{@submission.errors.full_messages.join(', ')}")
+      Event.log_event(Event.names[:response_deleted], 'Submission', @submission.id, "Submission #{@submission.id} deleted at #{DateTime.now}", current_user.id)
+      @submission.assign_attributes(deleted: true, deleted_at: Time.now)
+      @submission.save(validate: false)
+
+      respond_to do |format|
+        format.js { render :destroy }
       end
     end
 
@@ -210,7 +207,8 @@ module Admin
       ensure_form_manager(form: @form)
 
       Event.log_event(Event.names[:response_undeleted], 'Submission', @submission.id, "Submission #{@submission.id} undeleted at #{DateTime.now}", current_user.id)
-      @submission.update(deleted: false, deleted_at: nil)
+      @submission.assign_attributes(deleted: false, deleted_at: nil)
+      @submission.save(validate: false)
     end
 
     def feed
@@ -302,7 +300,8 @@ module Admin
         when 'delete'
           submissions.each do |submission|
             Event.log_event(Event.names[:response_deleted], 'Submission', submission.id, "Submission #{submission.id} deleted at #{DateTime.now}", current_user.id)
-            submission.update(deleted: true, deleted_at: Time.now)
+            submission.assign_attributes(deleted: true, deleted_at: Time.now)
+            submission.save(validate: false)
           end
           flash[:notice] = "#{view_context.pluralize(submissions.count, 'Submission')} deleted."
         else

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -6,7 +6,7 @@ class Submission < ApplicationRecord
   belongs_to :form, counter_cache: :response_count
   attr_accessor :fba_directive # for SPAM capture
 
-  validate :validate_custom_form
+  validate :validate_answers, on: :create
   validates :uuid, uniqueness: true
 
   before_create :set_uuid
@@ -47,7 +47,7 @@ class Submission < ApplicationRecord
   end
 
   # Validate each submitted field against its question type
-  def validate_custom_form
+  def validate_answers
     # Isolate questions that were answered
     answered_questions = attributes.select { |_key, value| value.present? }
 

--- a/spec/controllers/admin/submissions_controller_spec.rb
+++ b/spec/controllers/admin/submissions_controller_spec.rb
@@ -99,6 +99,13 @@ RSpec.describe Admin::SubmissionsController, type: :controller do
       end.to change { Submission.active.count }.by(-1)
     end
 
+    it 'deletes the requested submission even if it has invalid answers' do
+      submission = Submission.create! invalid_attributes
+      expect do
+        delete :delete, params: { id: submission.to_param, form_id: form.short_uuid }, session: valid_session, format: :js
+      end.to change { Submission.active.count }.by(-1)
+    end
+
     it 'redirects to the submissions list' do
       submission = Submission.create! valid_attributes
       delete :destroy, params: { id: submission.to_param, form_id: form.short_uuid }, session: valid_session, format: :js

--- a/spec/controllers/admin/submissions_controller_spec.rb
+++ b/spec/controllers/admin/submissions_controller_spec.rb
@@ -9,28 +9,27 @@ RSpec.describe Admin::SubmissionsController, type: :controller do
   let!(:user_role) { FactoryBot.create(:user_role, user: admin, form:, role: UserRole::Role::FormManager) }
   let!(:questions) {
     FactoryBot.create(:question,
-      form:,
-      question_type: 'text_field',
-      form_section: form.form_sections.first,
-      answer_field: 'answer_02',
-      position: 2,
-      text: 'Two'
+                      form:,
+                      question_type: 'text_field',
+                      form_section: form.form_sections.first,
+                      answer_field: 'answer_02',
+                      position: 2,
+                      text: 'Two',
     )
     FactoryBot.create(:question,
-      form:,
-      question_type: 'text_field',
-      form_section: form.form_sections.first,
-      answer_field: 'answer_03',
-      position: 3,
-      text: 'Three'
+                      form:,
+                      question_type: 'text_field',
+                      form_section: form.form_sections.first,
+                      answer_field: 'answer_03',
+                      position: 3,
+                      text: 'Three',
     )
     FactoryBot.create(:question,
-      form:,
-      question_type: 'text_field',
-      form_section: form.form_sections.first,
-      answer_field: 'answer_04',
-      position: 4,
-      text: 'Four'
+                      :email,
+                      form:,
+                      form_section: form.form_sections.first,
+                      answer_field: 'answer_04',
+                      position: 4,
     )
 
   }
@@ -47,10 +46,11 @@ RSpec.describe Admin::SubmissionsController, type: :controller do
 
   let(:invalid_attributes) do
     {
+      form_id: form.id,
       answer_01: nil,
       answer_02: 'James',
       answer_03: 'Madison',
-      answer_04: nil,
+      answer_04: 'not_an_email',
     }
   end
 
@@ -100,7 +100,12 @@ RSpec.describe Admin::SubmissionsController, type: :controller do
     end
 
     it 'deletes the requested submission even if it has invalid answers' do
-      submission = Submission.create! invalid_attributes
+      expect { Submission.create! invalid_attributes }.to raise_error(ActiveRecord::RecordInvalid)
+
+      submission = Submission.create! valid_attributes
+      submission.assign_attributes(invalid_attributes)
+      submission.save(validate: false)
+
       expect do
         delete :delete, params: { id: submission.to_param, form_id: form.short_uuid }, session: valid_session, format: :js
       end.to change { Submission.active.count }.by(-1)

--- a/spec/features/admin/submissions_spec.rb
+++ b/spec/features/admin/submissions_spec.rb
@@ -103,9 +103,9 @@ feature 'Submissions', js: true do
                 visit admin_form_submission_path(form, submission)
               end
 
-              it 'try to update a submission that has had its question validations changed' do
+              it 'can update status of a submission that has had its question validations changed' do
                 click_on("Acknowledge")
-                expect(page).to have_content("Response could not be updated.")
+                expect(page).to have_content("Response was successfully updated.")
               end
             end
           end


### PR DESCRIPTION
When a survey response is submitted, Touchpoints runs model validations checking the submitted answers against the corresponding survey questions - an email question must have an email answer, a required question must have a non-nil answer, a dropdown question must have an answer that is one of the dropdown options, etc. This is sensible and useful for rejecting spam responses, among other uses.

Does this validation need to run again at any point after the response has been submitted? A submitted response is largely immutable but it does have a set of status flags can be changed by the survey owners as they process responses. For instance, responses can be flagged, tagged, archived, deleted, etc. Currently, Touchpoints runs the question-answer validations during these status updates too. This causes a problem because, although the answers cannot change after the response is created, the form and its questions can change, so a response that had valid answers when it was submitted might not be valid at a later date. In the case of delete and #1990 , Touchpoints was silently swallowing such validation errors, giving the impression that it was deleting responses when it was not.


I say there is no reason to re-run question/answer validation when it is only the status of a response that has changed. This PR updates the response model to only run such validations on submission.