### PR TITLE
Improve output from cron job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,8 +203,14 @@ jobs:
             sudo apt-get install -y cf8-cli
             cf -v
       - run:
-          name: Run CRON tasks
-          command: ./.circleci/cron.sh
+          name: Run CRON tasks for production
+          command: ./.circleci/cron.sh production
+      - run:
+          name: Run CRON tasks for demo
+          command: ./.circleci/cron.sh demo
+      - run:
+          name: Run CRON tasks for staging
+          command: ./.circleci/cron.sh staging
 
 workflows:
   daily_workflow:

--- a/.circleci/cron.sh
+++ b/.circleci/cron.sh
@@ -7,23 +7,28 @@ set -e
 # Set # of failures to 0
 F=0
 
+function run_scheduled_job() {
+  local app=$1
+  local job=$2
+  cf run-task $app --wait --name $job -c "rake scheduled_jobs:$job" || F=$((F+=1))
+}
+
 function run_production_tasks() {
 	# === PRODUCTION environment ===================================================
 	echo "Running tasks in Production..."
 
-	PROD_TASK="cf run-task touchpoints-production-sidekiq-worker --wait -c" 
 	# Users
-	$PROD_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning" || F=$((F+=1))
-	$PROD_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning" || F=$((F+=1))
-	$PROD_TASK "rake scheduled_jobs:deactivate_inactive_users" || F=$((F+=1))
+	run_scheduled_job "touchpoints-production-sidekiq-worker" "send_one_week_until_inactivation_warning"
+	run_scheduled_job "touchpoints-production-sidekiq-worker" "send_two_weeks_until_inactivation_warning"
+	run_scheduled_job "touchpoints-production-sidekiq-worker" "deactivate_inactive_users"
 
 	# Forms
-	# $PROD_TASK "rake scheduled_jobs:send_daily_notifications" || F=$((F+=1))
-	# $PROD_TASK "rake scheduled_jobs:send_weekly_notifications" || F=$((F+=1))
-	# $PROD_TASK "rake scheduled_jobs:check_expiring_forms" || F=$((F+=1))
-	# $PROD_TASK "rake scheduled_jobs:archive_forms" || F=$((F+=1))
-	$PROD_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms" || F=$((F+=1))
-	# $PROD_TASK "rake scheduled_jobs:delete_submissions_trash" || F=$((F+=1))
+	# run_task "touchpoints-production-sidekiq-worker" "rake scheduled_jobs:send_daily_notifications"
+	# run_task "touchpoints-production-sidekiq-worker" "rake scheduled_jobs:send_weekly_notifications"
+	# run_task "touchpoints-production-sidekiq-worker" "rake scheduled_jobs:check_expiring_forms"
+	# run_task "touchpoints-production-sidekiq-worker" "rake scheduled_jobs:archive_forms"
+	run_scheduled_job "touchpoints-production-sidekiq-worker" "notify_form_managers_of_inactive_forms"
+	# run_task "touchpoints-production-sidekiq-worker" "rake scheduled_jobs:delete_submissions_trash"
 	echo "Production tasks have completed."
 }
 
@@ -32,20 +37,18 @@ function run_staging_tasks() {
 	# === STAGING environment ======================================================
 	echo "Running tasks in Staging..."
 
-	STAGING_TASK="cf run-task touchpoints-staging-sidekiq-worker --wait -c"
-
 	# Users
-	$STAGING_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning" || F=$((F+=1))
-	$STAGING_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning" || F=$((F+=1))
-	$STAGING_TASK "rake scheduled_jobs:deactivate_inactive_users" || F=$((F+=1))
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "send_one_week_until_inactivation_warning"
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "send_two_weeks_until_inactivation_warning"
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "deactivate_inactive_users"
 
 	# Forms
-	$STAGING_TASK "rake scheduled_jobs:send_daily_notifications" || F=$((F+=1))
-	$STAGING_TASK "rake scheduled_jobs:send_weekly_notifications" || F=$((F+=1))
-	$STAGING_TASK "rake scheduled_jobs:check_expiring_forms" || F=$((F+=1))
-	$STAGING_TASK "rake scheduled_jobs:archive_forms" || F=$((F+=1))
-	$STAGING_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms" || F=$((F+=1))
-	# $STAGING_TASK "rake scheduled_jobs:delete_submissions_trash" || F=$((F+=1))
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "send_daily_notifications"
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "send_weekly_notifications"
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "check_expiring_forms"
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "archive_forms"
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "notify_form_managers_of_inactive_forms"
+	# run_task "touchpoints-staging-sidekiq-worker" "rake scheduled_jobs:delete_submissions_trash"
 
 	echo "Staging tasks have completed."
 }
@@ -53,34 +56,56 @@ function run_staging_tasks() {
 function run_demo_tasks() {
 	# === DEMO environment =========================================================
 	echo "Running tasks in Demo..."
-	DEMO_TASK="cf run-task touchpoints-demo-sidekiq-worker --wait -c"
 
 	# Users
-	$DEMO_TASK "rake scheduled_jobs:send_one_week_until_inactivation_warning" || F=$((F+=1))
-	$DEMO_TASK "rake scheduled_jobs:send_two_weeks_until_inactivation_warning" || F=$((F+=1))
-	$DEMO_TASK "rake scheduled_jobs:deactivate_inactive_users" || F=$((F+=1))
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "send_one_week_until_inactivation_warning"
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "send_two_weeks_until_inactivation_warning"
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "deactivate_inactive_users"
 
 	# Forms
-	$DEMO_TASK "rake scheduled_jobs:send_daily_notifications" || F=$((F+=1))
-	$DEMO_TASK "rake scheduled_jobs:send_weekly_notifications" || F=$((F+=1))
-	$DEMO_TASK "rake scheduled_jobs:check_expiring_forms" || F=$((F+=1))
-	$DEMO_TASK "rake scheduled_jobs:archive_forms" || F=$((F+=1))
-	$DEMO_TASK "rake scheduled_jobs:notify_form_managers_of_inactive_forms" || F=$((F+=1))
-	# $DEMO_TASK "rake scheduled_jobs:delete_submissions_trash" || F=$((F+=1))
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "send_daily_notifications"
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "send_weekly_notifications"
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "check_expiring_forms"
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "archive_forms"
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "notify_form_managers_of_inactive_forms"
+	# run_task "touchpoints-demo-sidekiq-worker" "rake scheduled_jobs:delete_submissions_trash"
 
 	echo "Demo tasks have completed."
 }
 
-echo "Logging into cloud.gov non-prod"
-cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
-run_staging_tasks
-run_demo_tasks
-cf logout
+TARGET_ENV="${1:-}"
 
-echo "Logging into cloud.gov production environment"
-cf login -a $CF_API_ENDPOINT -u $CF_PRODUCTION_SPACE_DEPLOYER_USERNAME -p $CF_PRODUCTION_SPACE_DEPLOYER_PASSWORD -o $CF_ORG -s prod
-run_production_tasks
-cf logout
+if [ -z "$TARGET_ENV" ]; then
+  echo "Usage: ./.circleci/cron.sh <production|demo|staging>"
+  exit 1
+fi
+
+
+case "$TARGET_ENV" in
+  production)
+    echo "Logging into cloud.gov production environment"
+    cf login -a $CF_API_ENDPOINT -u $CF_PRODUCTION_SPACE_DEPLOYER_USERNAME -p $CF_PRODUCTION_SPACE_DEPLOYER_PASSWORD -o $CF_ORG -s prod
+    run_production_tasks
+    cf logout
+    ;;
+  demo)
+    echo "Logging into cloud.gov non-prod"
+    cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+    run_demo_tasks
+    cf logout
+    ;;
+  staging)
+    echo "Logging into cloud.gov non-prod"
+    cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+    run_staging_tasks
+    cf logout
+    ;;
+  *)
+    echo "Unknown environment: $TARGET_ENV"
+    echo "Usage: ./.circleci/cron.sh <production|demo|staging>"
+    exit 1
+    ;;
+esac
 
 echo "$0 exiting with failure count: $F"
 exit $F


### PR DESCRIPTION
This PR improves logging output from the `daily_workflow` CI workflow so that it's possible to tell which Rake tasks failed when the workflow is unsuccessful. Right now, the output displays the number of tasks that failed but it is difficult to identify the failures.