### PR TITLE
Fix drag-and-drop redordering for question options

### DIFF
--- a/app/controllers/admin/question_options_controller.rb
+++ b/app/controllers/admin/question_options_controller.rb
@@ -21,11 +21,16 @@ module Admin
     end
 
     def sort
-      params[:question_option].each_with_index do |id, index|
-        QuestionOption.find(id).update(position: index + 1)
+      question = Question.find(params[:id])
+      current_option_ids = question.question_options.pluck(:id).map(&:to_s)
+      if current_option_ids.sort == params[:question_option].sort
+        params[:question_option].each_with_index do |id, index|
+          QuestionOption.find(id).update(position: index + 1)
+        end
+        head :ok
+      else
+        render json: { error: "All question options must be listed exactly once in reordering request" }, status: :unprocessable_content
       end
-
-      head :ok
     end
 
     def update_title

--- a/app/controllers/admin/question_options_controller.rb
+++ b/app/controllers/admin/question_options_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class QuestionOptionsController < AdminController
-    before_action :set_question, only: %i[new create create_other show edit update destroy]
+    before_action :set_question, only: %i[new create create_other show edit update destroy sort]
     before_action :set_question_option, only: %i[show edit update destroy]
 
     def index
@@ -21,8 +21,7 @@ module Admin
     end
 
     def sort
-      question = Question.find(params[:id])
-      current_option_ids = question.question_options.pluck(:id).map(&:to_s)
+      current_option_ids = @question.question_options.pluck(:id).map(&:to_s)
       if current_option_ids.sort == params[:question_option].sort
         params[:question_option].each_with_index do |id, index|
           QuestionOption.find(id).update(position: index + 1)

--- a/app/views/admin/questions/_form.html.erb
+++ b/app/views/admin/questions/_form.html.erb
@@ -124,6 +124,7 @@
 
             ele.html(resp);
             ele.find(".question-option-edit").hide();
+            initializeSortableQuestionOptions(ele.find(".question-options"));
           }
         });
       }
@@ -141,6 +142,7 @@
 
           ele.html(resp);
           ele.find(".question-option-edit").hide();
+          initializeSortableQuestionOptions(ele.find(".question-options"));
         }
       });
     });

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -429,7 +429,7 @@ function initializeSortableQuestionOptions($questionOptionContainer) {
     tolerance: 'pointer',
     update: function(e, ui) {
       try {
-        let url = $(this).parent().data("url");
+        let url = $(this).parent().data("url") + "/sort";
         let data = $(this).sortable('serialize');
         if (!url) {
           console.error("Missing URL for question options sort");

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -274,33 +274,9 @@ $(function() {
 
   // Initialize sortable for question options
   try {
-    $(".question-options").sortable({
-      items: '.question-option',
-      handle: '.drag-handle',
-      placeholder: 'sort-placeholder',
-      update: function(e, ui) {
-        try {
-          var url = $(this).parent().data("url");
-          if (!url) {
-            console.error("Missing URL for question options sort");
-            return;
-          }
-          $.ajax({
-            url: url,
-            type: "PATCH",
-            data: $(this).sortable('serialize'),
-            error: function(xhr, status, error) {
-              console.error("Option sort update failed:", error);
-              ui.item.animate({ left: 0 }, 300);
-            }
-          });
-        } catch (err) {
-          console.error("Error during option sort update:", err);
-        }
-      }
-    }).disableSelection();
+    initializeSortableQuestionOptions($(".question-options"));
   } catch (err) {
-    console.error("Failed to initialize option sortable:", err);
+    console.error("Failed to initialize question option sortable:", err);
   }
 
   // Initialize sortable for sections
@@ -444,6 +420,39 @@ function initializeSortableQuestions($questionContainer) {
         ui.placeholder.height(ui.item.height());
       }
     }).disableSelection();
+}
+
+function initializeSortableQuestionOptions($questionOptionContainer) {
+  $questionOptionContainer.sortable({
+    items: '.question-option',
+    placeholder: 'sort-placeholder',
+    tolerance: 'pointer',
+    update: function(e, ui) {
+      try {
+        let url = $(this).parent().data("url");
+        let data = $(this).sortable('serialize');
+        if (!url) {
+          console.error("Missing URL for question options sort");
+          return;
+        }
+        if (!data) {
+          console.error("Failed to serialize sortable data");
+          return;
+        }
+        $.ajax({
+          url: url,
+          type: "PATCH",
+          data: data,
+          error: () => {
+            alert("Failed to update question option order");
+            $(this).sortable("cancel");
+          }
+        });
+      } catch (err) {
+        console.error("Error during option sort update:", err);
+      }
+    }
+  }).disableSelection();
 }
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -313,17 +313,15 @@ Rails.application.routes.draw do
         patch 'update_title', to: 'form_sections#update_title', as: :inline_update
       end
       resources :questions, except: :new do
-        member do
-          patch 'question_options', to: 'question_options#sort', as: :sort_question_options
+        collection do
+          patch 'sort', to: 'questions#sort', as: :sort_questions
         end
         resources :question_options, except: %i[index show] do
           patch 'update_title', to: 'question_options#update_title', as: :inline_update
           collection do
             post 'create_other', to: 'question_options#create_other', as: :create_other
+            patch 'sort', to: 'question_options#sort', as: :sort_question_options
           end
-        end
-        collection do
-          patch 'sort', to: 'questions#sort', as: :sort_questions
         end
       end
       resources :submissions, only: %i[show update destroy] do

--- a/spec/controllers/admin/question_options_controller_spec.rb
+++ b/spec/controllers/admin/question_options_controller_spec.rb
@@ -156,4 +156,26 @@ RSpec.describe Admin::QuestionOptionsController, type: :controller do
       expect(response).to redirect_to(question_options_url)
     end
   end
+
+  describe 'PATCH #sort' do
+    context 'with multiple question options' do
+      let(:form) { FactoryBot.create(:form, organization:) }
+      let(:question) { FactoryBot.create(:question, form:, form_section: form.form_sections.first) }
+      let!(:option1) { FactoryBot.create(:question_option, question:, text: 'One', position: 1) }
+      let!(:option2) { FactoryBot.create(:question_option, question:, text: 'Two', position: 2) }
+      let!(:option3) { FactoryBot.create(:question_option, question:, text: 'Three', position: 3) }
+      let!(:option4) { FactoryBot.create(:question_option, question:, text: 'Four', position: 4) }
+
+      it 'reorders the question options' do
+        patch :sort, params: { id: question.id, form_id: form.id, question_option: [option2.id, option4.id, option3.id, option1.id] }, session: valid_session
+        question.reload
+        expect(question.question_options.order(:position).pluck(:text)).to eq(['Two', 'Four', 'Three', 'One'])
+      end
+
+      it 'validates that reorder is complete' do
+        patch :sort, params: { id: question.id, form_id: form.id, question_option: [option3.id, option4.id, option1.id] }, session: valid_session
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/question_options_controller_spec.rb
+++ b/spec/controllers/admin/question_options_controller_spec.rb
@@ -167,13 +167,13 @@ RSpec.describe Admin::QuestionOptionsController, type: :controller do
       let!(:option4) { FactoryBot.create(:question_option, question:, text: 'Four', position: 4) }
 
       it 'reorders the question options' do
-        patch :sort, params: { id: question.id, form_id: form.id, question_option: [option2.id, option4.id, option3.id, option1.id] }, session: valid_session
+        patch :sort, params: { question_id: question.id, form_id: form.id, question_option: [option2.id, option4.id, option3.id, option1.id] }, session: valid_session
         question.reload
         expect(question.question_options.order(:position).pluck(:text)).to eq(['Two', 'Four', 'Three', 'One'])
       end
 
       it 'validates that reorder is complete' do
-        patch :sort, params: { id: question.id, form_id: form.id, question_option: [option3.id, option4.id, option1.id] }, session: valid_session
+        patch :sort, params: { question_id: question.id, form_id: form.id, question_option: [option3.id, option4.id, option1.id] }, session: valid_session
         expect(response).to have_http_status(:unprocessable_content)
       end
     end

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -73,5 +73,16 @@ FactoryBot.define do
         FactoryBot.create(:question_option, question: dropdown_question, position: 4, text: 'Four')
       end
     end
+
+    trait :with_combobox_options do
+      text { 'Test Combo box Question' }
+      question_type { 'combobox' }
+      after(:create) do |combobox_question, _evaluator|
+        FactoryBot.create(:question_option, question: combobox_question, position: 1, text: 'One')
+        FactoryBot.create(:question_option, question: combobox_question, position: 2, text: 'Two')
+        FactoryBot.create(:question_option, question: combobox_question, position: 3, text: 'Three')
+        FactoryBot.create(:question_option, question: combobox_question, position: 4, text: 'Four')
+      end
+    end
   end
 end

--- a/spec/features/admin/forms_spec.rb
+++ b/spec/features/admin/forms_spec.rb
@@ -1444,6 +1444,31 @@ feature 'Forms', js: true do
             end
           end
         end
+
+        describe 'reordering Question Options' do
+          let!(:question) { FactoryBot.create(:question, :with_combobox_options, form:, form_section: form.form_sections.first) }
+
+          before do
+            visit questions_admin_form_path(form)
+            wait_for_builder
+            source = find('.question-option', text: 'One')
+            target = find('.question-option', text: 'Two')
+            source.drag_to(target)
+            wait_for_ajax
+          end
+
+          it 'moves the first question option down' do
+            expect(page.all('.question-option')[0]).to have_content('Two')
+            expect(page.all('.question-option')[1]).to have_content('One')
+          end
+
+          it 'persists after refresh' do
+            visit questions_admin_form_path(form)
+            wait_for_builder
+            expect(page.all('.question-option')[0]).to have_content('Two')
+            expect(page.all('.question-option')[1]).to have_content('One')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
See linked issue for description of the problem.

This PR:

- Adds backend validation to enforce that a reordering must be completely specified - it must assign a unique position to each of a question's options. This prevents ambiguous orderings where, for instance, multiple options have been assigned to position 1.
- Fixes the front-end code to actually perform drag-and-drop for question options.
- Initialize event listeners so that drag-and-drop still works after adding or editing a question, without requiring a page reload.
- Added controller and feature specs.

Manual tests performed:
- Load the Questions tab for the Kitchen Sink form and test that each of the following question types supports drag-and-drop reordering of question options: radio buttons, dropdown, checkbox, combo box.
- Drag-and-drop changes are persisted to the database.
- Within a question option, it is still possible to click on the delete button (to delete the option) and the option label (to update the option text and value).
- Question option is draggable immediately after being added to an existing question.
- Question option is draggable immediately after being added to a new question.
- "Other" option is draggable immediately after being added.
- Options are draggable after editing a question and then either Saving or Cancelling.
- Drag and drop reordering of _questions_ still works.