### PR TITLE
Enable delete-trashed-responses job in staging/demo

### DIFF
--- a/.circleci/cron.sh
+++ b/.circleci/cron.sh
@@ -48,7 +48,7 @@ function run_staging_tasks() {
 	run_scheduled_job "touchpoints-staging-sidekiq-worker" "check_expiring_forms"
 	run_scheduled_job "touchpoints-staging-sidekiq-worker" "archive_forms"
 	run_scheduled_job "touchpoints-staging-sidekiq-worker" "notify_form_managers_of_inactive_forms"
-	# run_task "touchpoints-staging-sidekiq-worker" "rake scheduled_jobs:delete_submissions_trash"
+	run_scheduled_job "touchpoints-staging-sidekiq-worker" "delete_submissions_trash"
 
 	echo "Staging tasks have completed."
 }
@@ -68,7 +68,7 @@ function run_demo_tasks() {
 	run_scheduled_job "touchpoints-demo-sidekiq-worker" "check_expiring_forms"
 	run_scheduled_job "touchpoints-demo-sidekiq-worker" "archive_forms"
 	run_scheduled_job "touchpoints-demo-sidekiq-worker" "notify_form_managers_of_inactive_forms"
-	# run_task "touchpoints-demo-sidekiq-worker" "rake scheduled_jobs:delete_submissions_trash"
+	run_scheduled_job "touchpoints-demo-sidekiq-worker" "delete_submissions_trash"
 
 	echo "Demo tasks have completed."
 }


### PR DESCRIPTION
Form responses can be deleted by a form manager. The delete is a soft-delete. I believe the intention was that there would be a hard delete after 30 days in the trash. The scheduled task to empty the trash was added in [this PR](https://github.com/GSA/touchpoints/pull/1794), but it was added commented out, not sure why. This PR enables the empty-trash task in demo and staging environments to try it out and see if it works.