### PR TITLE
Eliminate references to develop and production branches in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ workflows:
           filters:
             branches:
               only:
-                - production
+                - main
     jobs:
       - cron_tasks
   build-deploy:
@@ -249,7 +249,7 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - main
             tags:
               ignore: /.*/
       - deploy:


### PR DESCRIPTION
As part of #2053 , I'm renaming the default branch from 'develop' to 'main' and eliminating the need for the 'production' branch. This PR updates the CircleCI config to work with those changes.