### PR TITLE
Add form responses api endpoint

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -54,6 +54,15 @@ module Api
       end
 
       def responses
+        # Start temporary code for debugging in staging
+        Rails.logger.info "--- REQUEST HEADERS ---"
+        request.headers.each do |key, value|
+          # Filter for standard HTTP headers if preferred
+          Rails.logger.info "#{key}: #{value}"
+        end
+        Rails.logger.info "-----------------------"
+        # End temporary code
+
         valid_params = params.permit(:id, :start_date, :end_date, page: %i[number size])
 
         if current_user.organizational_admin?

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -53,6 +53,55 @@ module Api
         end
       end
 
+      def responses
+        valid_params = params.permit(:id, :start_date, :end_date, page: %i[number size])
+
+        if current_user.organizational_admin?
+          form = current_user.organization.forms.find_by_short_uuid(valid_params[:id])
+        else
+          form = current_user.forms.find_by_short_uuid(valid_params[:id])
+        end
+
+        render json: { error: { message: "no form with Short UUID of #{params[:id]}", status: 404 } }, status: :not_found and return if form.nil?
+
+        page_number = valid_params.dig(:page, :number).to_i.nonzero? || 1
+        page_size = valid_params.dig(:page, :size).to_i.nonzero? || 500
+        page_size = 500 if page_size <= 0
+        render json: { error: { message: "max page size is 5000", status: 400 } }, status: :bad_request and return if page_size > 5000
+
+        begin
+          start_date = Date.parse(valid_params[:start_date]) if valid_params[:start_date]
+          end_date = Date.parse(valid_params[:end_date]) if valid_params[:end_date]
+        rescue Date::Error
+          render json: { error: { message: "invalid date format, should be 'YYYY-MM-DD'", status: 400 } }, status: :bad_request and return
+        end
+
+        # base query
+        responses = form.submissions.non_deleted
+
+        # apply date filters only when provided
+        if start_date && end_date
+          responses = responses.where(created_at: start_date.beginning_of_day..end_date.end_of_day)
+        elsif start_date
+          responses = responses.where('created_at >= ?', start_date.beginning_of_day)
+        elsif end_date
+          responses = responses.where('created_at <= ?', end_date.end_of_day)
+        end
+
+        # ordering & pagination
+        responses = responses.order(:id).page(page_number).per(page_size)
+
+        render json: responses, each_serializer: SubmissionSerializer,
+               meta: {
+                 current_page: responses.current_page,
+                 page_size: responses.limit_value,
+                 total_pages: responses.total_pages,
+                 total_count: responses.total_count,
+               }
+      end
+
+      private
+
       def links(form, page, size)
         ret = {}
         if params[:page].present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,11 @@ Rails.application.routes.draw do
       resources :cx_responses, only: [:index]
       resources :cx_collections, only: [:index]
       resources :cx_collection_details, only: [:index]
-      resources :forms, only: %i[index show]
+      resources :forms, only: %i[index show] do
+        member do
+          get :responses, to: 'forms#responses'
+        end
+      end
       resources :websites, only: [:index]
       resources :service_providers, only: [:index]
       resources :services, only: %i[index show]

--- a/spec/controllers/api/v1/forms_controller_spec.rb
+++ b/spec/controllers/api/v1/forms_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'uri'
 
 describe Api::V1::FormsController, type: :controller do
   describe 'unauthenticated request' do
@@ -254,6 +255,158 @@ describe Api::V1::FormsController, type: :controller do
           parsed_response = JSON.parse(response.body)
           expect(response.status).to eq(400)
         end
+      end
+    end
+
+    describe 'responses#index' do
+      let!(:user) { FactoryBot.create(:user) }
+      let(:form) { FactoryBot.create(:form, :single_question, organization: user.organization) do |form|
+        i = 0
+        7.times { FactoryBot.create(:submission, form: form, created_at: 10.days.ago, answer_01: (i += 1)) }
+        8.times { FactoryBot.create(:submission, form: form, created_at: 1.day.ago, answer_01: (i += 1)) }
+      end }
+      let!(:user_role) { FactoryBot.create(:user_role, :form_manager, user:, form:) }
+
+      before do
+        user.update(api_key: TEST_API_KEY)
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(ENV.fetch('API_HTTP_USERNAME'), ENV.fetch('API_HTTP_PASSWORD'))
+      end
+
+      it 'only shows responses for forms user can see' do
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key }
+        expect(response.status).to eq(200)
+
+        user_role.destroy
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key }
+        expect(response.status).to eq(404)
+      end
+
+      it 'ignores invalid query params' do
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key,
+                                                 page: 3, style: 'fast' }
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['meta']['current_page']).to eq(1)
+      end
+
+      it 'sets defaults for page_number and page_size' do
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key }
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['meta']['current_page']).to eq(1)
+        expect(parsed_response['meta']['page_size']).to eq(500)
+      end
+
+      it 'limits page_size to 5000' do
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key, 'page[size]' => 10000 }
+        expect(response.status).to eq(400)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['error']).to eq({ 'message' => 'max page size is 5000', 'status' => 400 })
+      end
+
+      it 'errors on invalid date format' do
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key, start_date: 'not-a-date' }
+        expect(response.status).to eq(400)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['error']).to eq("message"=>"invalid date format, should be 'YYYY-MM-DD'", "status"=>400)
+      end
+
+      it 'returns items based on page_number, page_size and date filters' do
+        # Form has 15 responses but only 8 created within date range
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key,
+                                                 'page[number]' => 1, 'page[size]' => 5,
+                                                 'start_date' => 3.days.ago.strftime('%Y-%m-%d') }
+
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        data = parsed_response['data']
+        expect(data.size).to eq(5)
+        expect(data.map { |item| item['attributes']['answer_01'] }).to eq(["8", "9", "10", "11", "12"])
+
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key,
+                                                 'page[number]' => 2, 'page[size]' => 5,
+                                                 'start_date' => 3.days.ago.strftime('%Y-%m-%d') }
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        data = parsed_response['data']
+        expect(data.size).to eq(3)
+        expect(data.map { |item| item['attributes']['answer_01'] }).to eq(["13", "14", "15"])
+      end
+
+      it 'returns paging metadata based on page_number, page_size and date filters' do
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key,
+                                                 'page[number]' => 1, 'page[size]' => 5,
+                                                 'start_date' => 3.days.ago.strftime('%Y-%m-%d') }
+
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        meta = parsed_response['meta']
+        expect(meta).to eq({ "current_page"=>1, "page_size"=>5, "total_count"=>8, "total_pages"=>2 })
+
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key,
+                                                 'page[number]' => 2, 'page[size]' => 5,
+                                                 'start_date' => 3.days.ago.strftime('%Y-%m-%d') }
+
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        meta = parsed_response['meta']
+        expect(meta).to eq({ "current_page"=>2, "page_size"=>5, "total_count"=>8, "total_pages"=>2 })
+      end
+
+      it 'returns links based on page_number, page_size and date filters' do
+        start_date = 3.days.ago.strftime('%Y-%m-%d')
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key,
+                                                 'page[number]' => 1, 'page[size]' => 5,
+                                                 'start_date' => start_date }
+
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['links']).to eq(
+                                              {
+                                                "first" => "http://test.host/api/v1/forms/#{form.short_uuid}/responses.json?API_KEY=#{TEST_API_KEY}&page%5Bnumber%5D=1&page%5Bsize%5D=5&start_date=#{start_date}",
+                                                "last" => "http://test.host/api/v1/forms/#{form.short_uuid}/responses.json?API_KEY=#{TEST_API_KEY}&page%5Bnumber%5D=2&page%5Bsize%5D=5&start_date=#{start_date}",
+                                                "next" => "http://test.host/api/v1/forms/#{form.short_uuid}/responses.json?API_KEY=#{TEST_API_KEY}&page%5Bnumber%5D=2&page%5Bsize%5D=5&start_date=#{start_date}",
+                                                "prev" => nil,
+                                                "self" => "http://test.host/api/v1/forms/#{form.short_uuid}/responses.json?API_KEY=#{TEST_API_KEY}&page%5Bnumber%5D=1&page%5Bsize%5D=5&start_date=#{start_date}",
+                                              }
+                                            )
+
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key,
+                                                 'page[number]' => 2, 'page[size]' => 5,
+                                                 'start_date' => start_date }
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['links']).to eq(
+                                              {
+                                                "first" => "http://test.host/api/v1/forms/#{form.short_uuid}/responses.json?API_KEY=#{TEST_API_KEY}&page%5Bnumber%5D=1&page%5Bsize%5D=5&start_date=#{start_date}",
+                                                "last" => "http://test.host/api/v1/forms/#{form.short_uuid}/responses.json?API_KEY=#{TEST_API_KEY}&page%5Bnumber%5D=2&page%5Bsize%5D=5&start_date=#{start_date}",
+                                                "next" => nil,
+                                                "prev" => "http://test.host/api/v1/forms/#{form.short_uuid}/responses.json?API_KEY=#{TEST_API_KEY}&page%5Bnumber%5D=1&page%5Bsize%5D=5&start_date=#{start_date}",
+                                                "self" => "http://test.host/api/v1/forms/#{form.short_uuid}/responses.json?API_KEY=#{TEST_API_KEY}&page%5Bnumber%5D=2&page%5Bsize%5D=5&start_date=#{start_date}",
+                                              }
+                                            )
+      end
+
+      it 'returns links pointing to api gateway when appropriate', :skip => "not yet implemented" do
+        @request.headers['X-Api-Umbrella-Request-Id'] = 'aelqdj9lfoe7c2itheg0'
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key,
+                                                 'page[number]' => 1, 'page[size]' => 5 }
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        next_link = URI.parse(parsed_response['links']['next'])
+        expect(next_link.host).to eq('test.host')
+        expect(next_link.path).to eq('/api/v1/forms')
+      end
+
+      it 'does not return deleted responses' do
+        submission = form.submissions.first
+        submission.assign_attributes(deleted: true, deleted_at: Time.now)
+        submission.save(validate: false)
+
+        get :responses, format: :json, params: { id: form.short_uuid, 'API_KEY' => user.api_key }
+        expect(response.status).to eq(200)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['data'].size).to eq(14)
       end
     end
   end


### PR DESCRIPTION
Adding a new API endpoint `GET /api/v1/forms/{:id}/responses`. Currently, the way to get responses from a form is to call `GET /api/v1/forms/{:id}` and extract the responses from the returned form object. There are a few bugs with this method, however:

1. Deleted responses are included.
2. Pagination does not work correctly when the responses are filtered by date.
3. Pagination links returned by the endpoint refer to the raw API endpoints on the Touchpoints server (which are inaccessible to the public) instead of to the api.data.gov gateway.

The new endpoint introduced in this PR fixes the first and second bugs. The 3rd bug will be fixed in a subsequent PR.

This PR does not try to fix the existing endpoint. I plan to deprecate the `submissions` field that is returned by `GET /api/v1/forms/{:id}`.