### PR TITLE
Name release tags with v.date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ workflows:
             branches:
               only: /.*/
             tags:
-              only: /^release-.*/
+              only: /^v\d{4}\.\d{2}\.\d{2}\.\d+$/
       - test:
           requires:
             - build
@@ -240,7 +240,7 @@ workflows:
             branches:
               only: /.*/
             tags:
-              only: /^release-.*/
+              only: /^v\d{4}\.\d{2}\.\d{2}\.\d+$/
       - deploy:
           name: deploy-to-staging
           deploy_environment: staging
@@ -253,31 +253,12 @@ workflows:
             tags:
               ignore: /.*/
       - deploy:
-          name: deploy-to-demo
-          deploy_environment: demo
-          requires:
-            - test
-          filters:
-            tags:
-              only: /^release-.*/
-            branches:
-              ignore: /.*/
-      - approve-production:
-          type: approval
-          requires:
-            - test
-          filters:
-            tags:
-              only: /^release-.*/
-            branches:
-              ignore: /.*/
-      - deploy:
           name: deploy-to-production
           deploy_environment: production
           requires:
-            - approve-production
+            - test
           filters:
-            tags:
-              only: /^release-.*/
             branches:
               ignore: /.*/
+            tags:
+              only: /^v\d{4}\.\d{2}\.\d{2}\.\d+$/


### PR DESCRIPTION
Related to #2053 .

PR changes:

- Updates the naming schema for release tags. A release tag is now like `v2026.05.26.0` - the date on which the release was created plus a zero-indexed count, in case we need to create multiple releases in a single day.
- Stops deploying to the `demo` environment. Currently, demo is a copy of production for users to experiment with. I'm tentatively planning to eliminate it since it's a lot of overhead for an unclear amount of gain. But, for now, we're just going to stop updating it because Touchpoints deployments are quite slow.