### PR TITLE
Fix bugs in email domain matching to map users to organizations

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Organization < ApplicationRecord
+  MAX_DOMAIN_PARTS = 5
+
   acts_as_taggable_on :tags
 
   has_many :users
@@ -14,12 +16,26 @@ class Organization < ApplicationRecord
 
   validates :name, presence: true
   validates :name, uniqueness: true
-  validates :domain, presence: true
+  validates :domain, presence: true, uniqueness: true
+  validates :domain, format: {
+    with: /\A[a-z0-9]+([\-\.][a-z0-9]+)*\.[a-z]{2,}\z/i,
+    message: "must be a bare domain name (e.g., 'example.gov') without protocol, path, or trailing slash"
+  }, allow_blank: true
+  validate :domain_parts_limit
   validates :abbreviation,
     presence: true,
     uniqueness: true,
     length: { maximum: 10 },
     format: { with: /\A[a-zA-Z0-9]*\z/, message: "only allows letters and numbers" }
+
+  def domain_parts_limit
+    return if domain.blank?
+    
+    parts = domain.split('.')
+    if parts.size > MAX_DOMAIN_PARTS
+      errors.add(:domain, "cannot have more than 5 parts (e.g., 'sub1.sub2.sub3.example.gov')")
+    end
+  end
 
   def parent
     parent_id ? Organization.find(parent_id) : nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,35 +165,29 @@ class User < ApplicationRecord
     api_key.present? && will_save_change_to_api_key?
   end
 
-  def parse_host_from_domain(string)
-    fragments = string.split('.')
-    case fragments.size
-    when 2
-      string
-    when 3
-      fragments.shift
-      fragments.join('.')
-    when 4
-      fragments.shift
-      fragments.shift
-      fragments.join('.')
-    end
-  end
-
   def ensure_organization
     return if organization_id.present?
 
     email_address_domain = Mail::Address.new(email).domain
-    parsed_domain = parse_host_from_domain(email_address_domain)
-
-    if org = Organization.find_by_domain(email_address_domain)
-      self.organization_id = org.id
-    elsif org = Organization.find_by_domain(parsed_domain)
-      self.organization_id = org.id
-    else
-      UserMailer.no_org_notification(self).deliver_later if id
-      errors.add(:organization, "'#{email_address_domain}' has not yet been configured for Touchpoints - Please contact the Feedback Analytics Team for assistance.")
+    
+    # Try to match the full domain first, then progressively strip subdomains
+    # from left to right to find the most specific matching organization
+    fragments = email_address_domain.split('.').last(Organization::MAX_DOMAIN_PARTS)
+    
+    # Start from the full domain and work our way down
+    (0...fragments.size).each do |i|
+      domain_to_try = fragments[i..].join('.')
+      next if fragments.size - i < 2  # Skip if less than 2 fragments (need at least "example.gov")
+      
+      if org = Organization.find_by_domain(domain_to_try)
+        self.organization_id = org.id
+        return
+      end
     end
+    
+    # No matching organization found
+    UserMailer.no_org_notification(self).deliver_later if id
+    errors.add(:organization, "'#{email_address_domain}' has not yet been configured for Touchpoints - Please contact the Feedback Analytics Team for assistance.")
   end
 
   def send_new_user_notifications

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -54,6 +54,95 @@ RSpec.describe Organization, type: :model do
         expect(@org.save!).to be (true)
       end
     end
+
+    describe 'domain validation' do
+      it 'accepts a valid bare domain' do
+        @org = Organization.create({
+          name: "Example",
+          domain: "example.gov",
+          abbreviation: "EX"
+        })
+        expect(@org).to be_valid
+      end
+
+      it 'accepts a valid multi-level domain' do
+        @org = Organization.create({
+          name: "FEMA",
+          domain: "fema.dhs.gov",
+          abbreviation: "FEMA"
+        })
+        expect(@org).to be_valid
+      end
+
+      it 'rejects a domain with http:// protocol' do
+        @org = Organization.create({
+          name: "Example",
+          domain: "http://example.gov",
+          abbreviation: "EX"
+        })
+        expect(@org).not_to be_valid
+        expect(@org.errors.messages[:domain]).to include("must be a bare domain name (e.g., 'example.gov') without protocol, path, or trailing slash")
+      end
+
+      it 'rejects a domain with https:// protocol' do
+        @org = Organization.create({
+          name: "Example",
+          domain: "https://example.gov",
+          abbreviation: "EX"
+        })
+        expect(@org).not_to be_valid
+        expect(@org.errors.messages[:domain]).to include("must be a bare domain name (e.g., 'example.gov') without protocol, path, or trailing slash")
+      end
+
+      it 'rejects a domain with a path' do
+        @org = Organization.create({
+          name: "Example",
+          domain: "example.gov/path",
+          abbreviation: "EX"
+        })
+        expect(@org).not_to be_valid
+        expect(@org.errors.messages[:domain]).to include("must be a bare domain name (e.g., 'example.gov') without protocol, path, or trailing slash")
+      end
+
+      it 'rejects a domain with a trailing slash' do
+        @org = Organization.create({
+          name: "Example",
+          domain: "example.gov/",
+          abbreviation: "EX"
+        })
+        expect(@org).not_to be_valid
+        expect(@org.errors.messages[:domain]).to include("must be a bare domain name (e.g., 'example.gov') without protocol, path, or trailing slash")
+      end
+
+      it 'rejects a full URL' do
+        @org = Organization.create({
+          name: "Example",
+          domain: "https://www.example.gov/",
+          abbreviation: "EX"
+        })
+        expect(@org).not_to be_valid
+        expect(@org.errors.messages[:domain]).to include("must be a bare domain name (e.g., 'example.gov') without protocol, path, or trailing slash")
+      end
+
+      it 'accepts a domain with 5 parts' do
+        @org = Organization.create({
+          name: "Example",
+          domain: "a.b.c.example.gov",
+          abbreviation: "EX"
+        })
+        expect(@org).to be_valid
+      end
+
+      it 'rejects a domain with more than 5 parts' do
+        @org = Organization.create({
+          name: "Example",
+          domain: "a.b.c.d.e.example.gov",
+          abbreviation: "EX"
+        })
+        expect(@org).not_to be_valid
+        expect(@org.errors.messages[:domain]).to include("cannot have more than 5 parts (e.g., 'sub1.sub2.sub3.example.gov')")
+      end
+    end
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,46 +55,6 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'with a valid .gov email address (under 1 subdomain) for an Organization that has been created' do
-      before do
-        FactoryBot.create(:organization)
-        @user.email = 'user@associates.subdomain.example.gov'
-        @user.save
-      end
-
-      it 'is valid' do
-        expect(@user.valid?).to eq(true)
-        expect(@user.persisted?).to eq(true)
-      end
-    end
-
-    context 'with a valid .gov email address (under 2 subdomains) for an Organization that has been created' do
-      before do
-        FactoryBot.create(:organization)
-        @user.email = 'user@associates.subdomain.example.gov'
-        @user.save
-      end
-
-      it 'is valid' do
-        expect(@user.valid?).to eq(true)
-        expect(@user.persisted?).to eq(true)
-      end
-    end
-
-    context 'with a valid .gov email address (under 3 subdomains) for an Organization that has been created' do
-      before do
-        FactoryBot.create(:organization)
-        @user.email = 'user@toomany.associates.subdomain.example.gov'
-        @user.save
-      end
-
-      it 'fails tld_check' do
-        expect(@user.valid?).to eq(false)
-        expect(@user.persisted?).to eq(false)
-        expect(@user.errors.messages[:organization].first).to include("'toomany.associates.subdomain.example.gov' has not yet been configured for Touchpoints")
-      end
-    end
-
     context 'api key' do
       before do
         FactoryBot.create(:organization)
@@ -220,6 +180,13 @@ RSpec.describe User, type: :model do
       @user2.email = "user@sub.example.gov"
       @user2.save!
       expect(@user2.organization).to eq(@org2)
+    end
+
+    it 'respects sub-subdomains' do
+      @user_subsub = User.new
+      @user_subsub.email = "user@associates.sub.example.gov"
+      @user_subsub.save!
+      expect(@user_subsub.organization).to eq(@org2)
     end
 
     it 'matches by top-level domain if subdomain does not exist' do


### PR DESCRIPTION
Fixes the 2 linked bugs.

For organizations, the PR adds validation for the `domain` field:

- Domains must be unique. A user is assigned to a unique organization by finding the organization whose `domain` most closely matches the domain of the user's email address. If multiple organizations have the same domain, there's no way to guarantee which organization a user will be assigned to.
- Domains must be entered as actual domain strings, as enforced by a regex. Previously, the domain field was a free-form text field which sometimes was filled with URL's or other inappropriate string.
- Domains are limited to 5 parts (e.g., 'sub1.sub2.sub3.example.gov'), in order to put an upper bound on the number of look-ups we have to do when deciding which organization a new user belongs to. This limit covers all current organizations.

For users, the PR fixes the logic used to assign a new user to an existing organization. Conceptually, the logic is now:

1. Take the user's email address as passed in by Login.gov and extract the email's domain.
2. Find all organizations whose domain is a suffix of the user's email domain (e.g., organizations 'dhs.gov' and 'fema.dhs.gov' both match jill.smith@associates.fema.dhs.gov.)
3. Choose the organization with the longest domain (e.g. 'fema.dhs.gov' in this case).