### PR TITLE
Inject widget CSS as text node

### DIFF
--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -78,7 +78,7 @@ function FBAform(d, N) {
 		_loadCss: function() {
 			if (this.options.loadCSS) {
 				var style = d.createElement('style');
-				style.innerHTML = this.options.css;
+				style.textContent = this.options.css;
 				d.head.appendChild(style);
 				<%- if form.has_rich_text_questions? %>
 				var quillStyles = d.createElement('link');


### PR DESCRIPTION
This PR is a one-line change to the Touchpoints embedded widget. It constructs the widget's `<style>` tag by setting `textContent` instead of `innerHtml`. CSS doesn't need to be parsed as HTML so this won't break anything. It might be a tiny bit faster to load since it skips HTML parsing.

The hope is that this PR will fix https://github.com/GSA/touchpoints/issues/2087. The problem in that ticket relates to a specific website tech stack (Salesforce) which is hard for me to reproduce locally. So, I'm going to push the change out to production and test the fix there.