### PR TITLE
Fix scroll to top during page navigation in embedded forms

### DIFF
--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -635,12 +635,11 @@ function FBAform(d, N) {
 					});
 					d.dispatchEvent(previousPageEvent);
 
-					// if in a modal, scroll to the top of the modal on previous button click
-					if(this.formComponent().getElementsByClassName("fba-modal")[0]) {
-						this.formComponent().scrollTo(0,0);
-					} else {
-						N.scrollTo(0, 0);
-					}
+          <%- if form.delivery_method == "touchpoints-hosted-only" %>
+          N.scrollTo(0, 0);
+          <% else %>
+          this.formComponent().scrollIntoView();
+          <% end %>
 				}.bind(self));
 			}
 			for (var i = 0; i < nextButtons.length; i++) {
@@ -660,12 +659,11 @@ function FBAform(d, N) {
 					});
 					d.dispatchEvent(nextPageEvent);
 
-					// if in a modal, scroll to the top of the modal on next button click
-					if(this.formComponent().getElementsByClassName("fba-modal")[0]) {
-						this.formComponent().scrollTo(0,0);
-					} else {
-						N.scrollTo(0, 0);
-					}
+          <%- if form.delivery_method == "touchpoints-hosted-only" %>
+          N.scrollTo(0, 0);
+          <% else %>
+          this.formComponent().scrollIntoView();
+          <% end %>
 				}.bind(self))
 			}
 		},


### PR DESCRIPTION
See linked issue for problem description.

For hosted forms, we maintain the existing behavior, which is to scroll the window to the top of the page while navigating between pages of the form.

For modal forms, the new behavior is to scroll to the top of the modal while navigating between pages of the form. The scroll behavior is smooth, because that is the default scroll behavior for the USWDS modal.

For inline forms, the new behavior is to scroll to the top of the inline form while navigating between pages of the form.