### PR TITLE
Changes to Cloudflare Turnstile client-side implementation

### DIFF
--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -111,10 +111,7 @@
         <% end %>
         <%- if section == form.form_sections.last && !form.suppress_submit_button %>
           <%- if form.enable_turnstile? %>
-          <div class="margin-top-2">
-            <div id="turnstile-container"></div>
-            <%= hidden_field_tag "cf-turnstile-response", nil %>
-          </div>
+          <div id="fba-turnstile-container" class="fba-turnstile-container"></div>
           <% end %>
           <button type="submit" class="usa-button submit_form_button"><%= t 'form.submit' %></button>
         <% end %>

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -210,22 +210,22 @@ function FBAform(d, N) {
 			this.resetErrors();
 			var formElement = this.formElement();
 			var self = this;
-			if (self.validateForm(formElement)) {
-				<%- if form.enable_turnstile? %>
-				const elapsed = Date.now() - self.turnstileInitiatedAt;
-				if (elapsed > 5 * 60 * 1000) {
-					self.initTurnstile();
-					self.turnstileInitiatedAt = Date.now();
-					return false;
-				}
-				<% end %>
 
-				// disable submit button
-				var submitButton = formElement.querySelector("[type='submit']");
-				submitButton.disabled = true;
-				submitButton.classList.add("aria-disabled");
-				self.sendFeedback();
-			}
+      if (!self.validateForm(formElement)) {
+        return;
+      }
+
+      <%- if form.enable_turnstile? %>
+      if (!self.validateTurnstile()) {
+        return;
+      }
+      <% end %>
+
+      // disable submit button
+      var submitButton = formElement.querySelector("[type='submit']");
+      submitButton.disabled = true;
+      submitButton.classList.add("aria-disabled");
+      self.sendFeedback();
 		},
 		handleYesNoSubmitClick: function(e) {
 			e.preventDefault();
@@ -531,6 +531,11 @@ function FBAform(d, N) {
 						submitButton.disabled = false;
 					}
 
+          <%# Turnstile tokens are single-use so must be re-generated after submission failure %>
+          <%- if form.enable_turnstile? %>
+          this.regenerateTurnstileToken();
+          <% end %>
+
 					var jsonResponse = JSON.parse(e.target.response);
 					var errors = jsonResponse.messages;
 
@@ -583,6 +588,7 @@ function FBAform(d, N) {
 			xhr.onload = callback.bind(this);
 			xhr.send(JSON.stringify({
 				<%- if form.enable_turnstile? %>
+        <%# This hidden form field is automatically created and managed by Turnstile. %>
 				"cf-turnstile-response" : form.querySelector("input[name='cf-turnstile-response']") ? form.querySelector("input[name='cf-turnstile-response']").value : null,
 				<% end %>
 				"submission": params,
@@ -719,26 +725,80 @@ function FBAform(d, N) {
 		},
 		<% end %>
 		<%- if form.enable_turnstile? %>
+    turnstileContainer: function() {
+      return this.formComponent().querySelector("#fba-turnstile-container");
+    },
 		loadTurnstile: function() {
+      if (window.turnstile) {
+        <%# API already loaded (host page or another form loaded it) — render now. %>
+        this.initTurnstile();
+        return;
+      }
 			let script = document.createElement("script");
-			script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
-			script.async = true;
-			script.defer = true;
-			script.onload = this.initTurnstile;
-			this.turnstileInitiatedAt = Date.now();
-			if (!window.turnstile) {
-				document.head.appendChild(script);
-			}
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+			script.onload = this.initTurnstile.bind(this);
+      document.head.appendChild(script);
 		},
 		initTurnstile: function() {
-			turnstile.remove("#turnstile-container");
-			turnstile.render("#turnstile-container", {
+      let self = this;
+      this.challengeExecuted = false;
+
+      <%# Load the challenge at most once, on the first sign of engagement. %>
+      let trigger = function() {
+        if (self.challengeExecuted) {
+          return;
+        }
+        self.challengeExecuted = true;
+        self.turnstileContainer().classList.add('is-visible');
+        turnstile.execute(self.turnstileWidgetId);
+      };
+
+			this.turnstileWidgetId = turnstile.render(this.turnstileContainer(), {
 				sitekey: "<%= ENV['TURNSTILE_SITE_KEY'] %>",
-				callback: function (token) {
-					document.querySelector("input[name='cf-turnstile-response']").value = token;
-				}
+        appearance: "execute",
+        execution: "execute",
+        'timeout-callback': function() {
+          self.regenerateTurnstileToken();
+        },
+        'expired-callback': function() {
+          self.regenerateTurnstileToken();
+        }
 			});
+      
+      <%- if form.delivery_method == "touchpoints-hosted-only" %>
+      <%# Hosted mode: the form is the whole page, so run the challenge %>
+      <%# immediately rather than waiting for interaction. %>
+      trigger();
+      <% else %>
+      <%# Defer loading the Turnstile challenge until the user actually engages with %>
+      <%# the form, so we don't run a challenge for the many visitors who never interact. %>
+      let formElement = this.formElement();
+      if (formElement) {
+        formElement.addEventListener('input', trigger, { once: true });
+      }
+      <% end %>
 		},
+    regenerateTurnstileToken: function() {
+      turnstile.reset(this.turnstileWidgetId);
+      turnstile.execute(this.turnstileWidgetId);
+    },
+    validateTurnstile() {
+      let error = this.turnstileContainer().querySelector('#turnstile-error-message');
+      if (error) {
+        error.parentNode.removeChild(error);
+      }
+      const turnstileToken = turnstile.getResponse(self.turnstileWidgetId);
+      if (!turnstileToken) {
+        let span = d.createElement('span');
+        span.setAttribute('id', 'turnstile-error-message');
+        span.setAttribute('role','alert');
+        span.setAttribute('class','usa-error-message');
+        span.innerText = '<%= I18n.t 'form.turnstile_complete_captcha' %>';
+        this.turnstileContainer().prepend(span);
+        return false;
+      }
+      return true;
+    },
 		<% end %>
 		enableLocalStorage: function() {
 			const form = this.formElement();

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -1080,3 +1080,7 @@
 .ql-editor[contentEditable=true]:focus {
   outline: none;
 }
+
+.fba-turnstile-container.is-visible {
+  margin-top: 1rem;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,7 @@ en:
     field_is_invalid: "Please enter a valid value: "
     chars_remaining: "Chars remaining: "
     enter_other_text: "Enter other text"
+    turnstile_complete_captcha: "Please complete the CAPTCHA before submitting the form."
   header:
     official: "An official website of the United States government"
     heres_how_you_know: "Here’s how you know"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -42,6 +42,7 @@ es:
     field_is_invalid: "Por favor ingrese una cifra válida: "
     chars_remaining: "Caracteres restantes: "
     enter_other_text: "Ingresa otro texto"
+    turnstile_complete_captcha: "Por favor complete el CAPTCHA antes de enviar el formulario."
   header:
     official: "Un sitio web oficial del gobierno de los Estados Unidos"
     heres_how_you_know: "Así es como sabes"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -62,6 +62,7 @@ zh-CN:
     field_is_invalid: 请输入一个有效的值
     chars_remaining: "剩餘字符: "
     enter_other_text: "输入其他文字"
+    turnstile_complete_captcha: "请在提交表单前完成 CAPTCHA。"
   header:
     official: "美国政府的官方网站"
     heres_how_you_know: "这就是你所知道的"


### PR DESCRIPTION
This PR makes a few client-side improvements to our implementation of Cloudflare Turnstile. We are testing out Turnstile on a few forms currently, both our own internal forms and some customer forms.

Changes:

1. For embedded forms, don't issue a challenge until the user has interacted with the form. 
**Justification:** Most users who visit the page containing an embedded form will never actually interact with the form. There's no reason to incur the overhead of issuing challenges unless the user indicates that they plan to submit the form. Even if they do eventually fill out the form, tokens have a limited lifespan and there's no reason to refresh the token over and over while waiting for the user to open the form.
Also, our Turnstile analytics are currently overwhelmed by an enormous number of challenges solved without any resulting form submission. I'd like to see numbers that only reflect humans (or bots) who have interacted with the form.
2. When the user is required to complete an interactive challenge, display a validation error if they try to submit the form without doing the challenge.
3. Auto-refresh the token when it expires.
4. Auto-refresh the interactive challenge when it expires. 
