### PR TITLE
Add strict locals to views

### DIFF
--- a/app/views/admin/forms/example.html.erb
+++ b/app/views/admin/forms/example.html.erb
@@ -9,16 +9,98 @@
 
     <!-- Demo content styles -->
     <style>
+    :root {
+      --demo-bg: #f0f0f0;
+      --demo-surface: #ffffff;
+      --demo-border: #dfe1e2;
+      --demo-ink: #1b1b1b;
+      --demo-muted: #71767a;
+      --demo-accent: #005ea2;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      background-color: var(--demo-bg);
+      color: var(--demo-ink);
+      font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      line-height: 1.5;
+    }
+    .demo-shell {
+      max-width: 60rem;
+      margin: 0 auto;
+      padding: 2rem 1rem 4rem;
+    }
     .demo-content {
-      background-color: #efefef;
-      border: 1px solid #E5E5E5;
-      min-height: 100px;
+      background-color: var(--demo-surface);
+      border: 1px solid var(--demo-border);
+      border-radius: 0.5rem;
     }
-    .demo-grid {
-      margin-bottom: 4rem;
+    .demo-header {
+      text-align: center;
+      padding: 2.5rem 1.5rem;
+      margin-bottom: 2rem;
     }
-    .demo-grid div {
-      min-height: 300px;
+    .demo-header .demo-eyebrow {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--demo-muted);
+    }
+    .demo-header h1 {
+      margin: 0.5rem 0 0;
+      font-size: 2rem;
+      line-height: 1.2;
+    }
+    .demo-main {
+      padding: 2rem 1.5rem;
+      margin-bottom: 2rem;
+    }
+    .demo-placeholder {
+      min-height: 12rem;
+      margin-bottom: 2rem;
+    }
+
+    /* Inline delivery: the form renders directly inside the page body */
+    .demo-form-region {
+      padding: 2rem 1.5rem;
+    }
+    .demo-form-region .demo-form-label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--demo-muted);
+      margin-bottom: 1rem;
+    }
+    .demo-form-target {
+      background-color: var(--demo-bg);
+      border: 1px dashed var(--demo-border);
+      border-radius: 0.375rem;
+      padding: 1.5rem;
+      min-height: 6rem;
+    }
+
+    /* Custom button demo */
+    .demo-button-region {
+      padding: 3rem 1.5rem;
+      text-align: center;
+    }
+    .demo-custom-button {
+      display: inline-block;
+      cursor: pointer;
+      color: DeepPink;
+      font-family: sans-serif;
+      font-size: 2rem;
+      border: 7px solid DeepPink;
+      border-radius: 1rem;
+      padding: 1rem 1.5rem;
+      background-color: LightPink;
+      text-decoration: none;
     }
     </style>
     <!-- End demo content styles -->
@@ -28,65 +110,45 @@
   <body>
     <!-- Demo content -->
     <% if @form.delivery_method == "inline" %>
-    <br>
-    <div class="grid-container">
-      <div class="grid-col-12">
-        <main>
+    <div class="demo-shell">
+      <header class="demo-content demo-header">
+        <span class="demo-eyebrow">Example page</span>
+        <h1>Header</h1>
+      </header>
+      <main class="demo-content demo-form-region">
+        <span class="demo-form-label">Inline form</span>
+        <div class="demo-form-target">
           <div id="<%= @form.element_selector %>">
             Touchpoint will be rendered here.
           </div>
-        </main>
-      </div>
+        </div>
+      </main>
     </div>
-    <br>
     <% elsif @form.delivery_method == "custom-button-modal" %>
-    <br>
-    <div class="grid-container">
-      <div class="grid-col-12">
-        <div style="padding-left: 5rem; padding-top: 5rem;">
-          <a id="<%= @form.element_selector %>" style="color: DeepPink; font-family: sans-serif; font-size: 2rem; border: 7px solid DeepPink; border-radius: 1rem; padding: 1rem; background-color: LightPink;">
-            This is a custom button
-          </a>
-        </div>
-      </div>
-    </div>
-    <br>
-    <% else %>
-    <div class="grid-container demo-grid">
-      <header style="text-align: center;">
-        <div class="grid-row grid-gap-md">
-          <div class="grid-col-12 demo-content">
-            <br>
-            <span class="font-normal text-sans-sm">
-              Example page
-            </span>
-            <h1>
-              <br>header
-            </h1>
-          </div>
-        </div>
+    <div class="demo-shell">
+      <header class="demo-content demo-header">
+        <span class="demo-eyebrow">Example page</span>
+        <h1>Header</h1>
       </header>
+      <div class="demo-content demo-button-region">
+        <a id="<%= @form.element_selector %>" class="demo-custom-button">
+          This is a custom button
+        </a>
+      </div>
     </div>
-    <div class="grid-container demo-grid">
-      <div class="grid-row grid-gap-md">
-        <div class="grid-col-12 demo-content">
-          <main>
-            <div style="text-align: center; padding: 1rem;">
-              main content
-            </div>
-          </main>
+    <% else %>
+    <div class="demo-shell">
+      <header class="demo-content demo-header">
+        <span class="demo-eyebrow">Example page</span>
+        <h1>Header</h1>
+      </header>
+      <main class="demo-content demo-main">
+        <div style="text-align: center;">
+          main content
         </div>
-      </div>
-    </div>
-    <div class="grid-container demo-grid">
-      <div class="grid-row grid-gap-md">
-        <div class="grid-col-12 demo-content"></div>
-      </div>
-    </div>
-    <div class="grid-container demo-grid">
-      <div class="grid-row grid-gap-md">
-        <div class="grid-col-12 demo-content"></div>
-      </div>
+      </main>
+      <div class="demo-content demo-placeholder"></div>
+      <div class="demo-content demo-placeholder"></div>
     </div>
     <% end %>
     <!--- End demo content -->

--- a/app/views/admin/questions/_question.html.erb
+++ b/app/views/admin/questions/_question.html.erb
@@ -44,4 +44,4 @@
 <% elsif question.question_type == "date_select" %>
 <% @form_component_path = 'components/forms/question_types/date_select' %>
 <% end %>
-<%= render @form_component_path, form: form, question: question, question_number: question.position %>
+<%= render @form_component_path, question: question %>

--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:) %>
+
 <% multi_section_question_number = 0 %>
 
 <form
@@ -50,41 +52,41 @@
           <div class="question white-bg"
             id="<%= dom_id(question) %>">
             <%- if question.question_type == "text_field" %>
-              <%= render 'components/forms/question_types/text_field', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/text_field', question: question %>
             <% elsif question.question_type == "text_email_field" %>
-              <%= render 'components/forms/question_types/text_email_field', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/text_email_field', question: question %>
             <% elsif question.question_type == "text_phone_field" %>
-              <%= render 'components/forms/question_types/text_phone_field', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/text_phone_field', question: question %>
             <% elsif question.question_type == "star_radio_buttons" %>
-              <%= render 'components/forms/question_types/star_radio_buttons', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/star_radio_buttons', question: question %>
             <% elsif question.question_type == "big_thumbs_up_down_buttons" %>
-              <%= render 'components/forms/question_types/big_thumbs_up_down_buttons', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/big_thumbs_up_down_buttons', question: question %>
             <% elsif question.question_type == "yes_no_buttons" %>
-              <%= render 'components/forms/question_types/yes_no_buttons', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/yes_no_buttons', question: question %>
             <% elsif question.question_type == "radio_buttons" %>
-              <%= render 'components/forms/question_types/radio_buttons', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/radio_buttons', question: question %>
             <% elsif question.question_type == "dropdown" %>
-              <%= render 'components/forms/question_types/dropdown', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/dropdown', question: question %>
             <% elsif question.question_type == "states_dropdown" %>
-              <%= render 'components/forms/question_types/states_dropdown', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/states_dropdown', question: question %>
             <% elsif question.question_type == "checkbox" %>
-              <%= render 'components/forms/question_types/checkbox', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/checkbox', question: question %>
             <% elsif question.question_type == "combobox" %>
-              <%= render 'components/forms/question_types/combobox', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/combobox', question: question %>
             <% elsif question.question_type == "textarea" %>
-              <%= render 'components/forms/question_types/text_area', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/text_area', question: question %>
             <% elsif question.question_type == "rich_textarea" %>
-              <%= render 'components/forms/question_types/rich_textarea', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/rich_textarea', question: question %>
             <% elsif question.question_type == "text_display" %>
-              <%= render 'components/forms/question_types/text_display', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/text_display', question: question %>
             <% elsif question.question_type == "date_select" %>
-              <%= render 'components/forms/question_types/date_select', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/date_select', question: question %>
             <% elsif question.question_type == "custom_text_display" %>
-              <%= render 'components/forms/question_types/custom_text_display', form: form, question: question, question_number: multi_section_question_number %>
+              <%= render 'components/forms/question_types/custom_text_display', question: question %>
             <% end %>
           </div>
           <% else %>
-            <%= render 'components/forms/question_types/hidden_field', form: form, question: question, question_number: multi_section_question_number %>
+            <%= render 'components/forms/question_types/hidden_field', question: question %>
           <% end %>
         <% end %>
         </div>

--- a/app/views/components/forms/_custom_layout.html.erb
+++ b/app/views/components/forms/_custom_layout.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:) %>
+
 <div class="inner-wrapper">
   <div class="grid-row">
     <div class="grid-col-12">
@@ -15,7 +17,7 @@
         </p>
       <% end %>
       <%= render 'components/forms/flash', form: form %>
-      <%= render partial: "components/forms/custom", locals: { form: form, questions: form.questions } %>
+      <%= render partial: "components/forms/custom", locals: { form: form } %>
     </div>
   </div>
 </div>

--- a/app/views/components/forms/_flash.html.erb
+++ b/app/views/components/forms/_flash.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:) %>
+
 <div class="fba-alert usa-alert usa-alert--success" role="status" hidden>
   <div class="usa-alert__body">
     <h2 class="usa-alert__heading">

--- a/app/views/components/forms/_logo_and_title.html.erb
+++ b/app/views/components/forms/_logo_and_title.html.erb
@@ -1,20 +1,22 @@
-<header>
-  <h1
-    class="word-break fba-modal-title"
-    id="<%= "fba-form-title-#{form.short_uuid}" %>">
-    <%- if form.logo.present? %>
-    <div class="margin-bottom-2 text-center">
+<%# locals: (form:) %>
+
+<header class="fba-form-header">
+  <%- if form.logo.present? %>
+    <div class="text-center">
       <%- if form.header_logo_display_banner? %>
         <%= image_tag(form.logo.tag.url,
-          alt: form.logo_alt_text_or_default,
-          class: "form-header-logo") %>
+                      alt: form.logo_alt_text_or_default,
+                      class: "form-header-logo") %>
       <% elsif form.header_logo_display_square? %>
         <%= image_tag(form.logo.logo_square.url,
-          alt: form.logo_alt_text_or_default,
-          class: "form-header-logo-square") %>
+                      alt: form.logo_alt_text_or_default,
+                      class: "form-header-logo-square") %>
       <% end %>
     </div>
-    <% end %>
+  <% end %>
+  <h1
+    class="fba-modal-title"
+    id="<%= "fba-form-title-#{form.short_uuid}" %>">
     <%- if form.title.present? %>
     <%= form.title %>
     <% else %>

--- a/app/views/components/forms/edit/question_types/_checkbox.html.erb
+++ b/app/views/components/forms/edit/question_types/_checkbox.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (question:) %>
 <fieldset
   class="usa-fieldset"
   aria-labelledby="<%= question.answer_field %>"

--- a/app/views/components/forms/edit/question_types/_combobox.html.erb
+++ b/app/views/components/forms/edit/question_types/_combobox.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <fieldset
   class="usa-fieldset"
   aria-labelledby="<%= question.answer_field %>"

--- a/app/views/components/forms/edit/question_types/_dropdown.html.erb
+++ b/app/views/components/forms/edit/question_types/_dropdown.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div class="radios" role="group" aria-labelledby="<%= question.answer_field %>" data-url="<%= admin_form_question_question_options_path(question.form, question) %>">
   <%= render 'components/question_title', question: question, form_builder: true %>
   <%= select_tag(question.ui_selector, options_for_select(question.question_options.each_with_index.map { |option, index| [option.text, option.value] }), { prompt: (t 'form.select_one'), class: "usa-select", required: question.is_required  }) %>

--- a/app/views/components/forms/edit/question_types/_hidden_field.html.erb
+++ b/app/views/components/forms/edit/question_types/_hidden_field.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div class="radios" role="group" aria-labelledby="<%= question.answer_field %>">
   <%= render 'components/question_title', question: question, form_builder: true %>
   <%= text_field_tag question.ui_selector, nil, class: "usa-input", value: question.placeholder_text %>

--- a/app/views/components/forms/edit/question_types/_radio_buttons.html.erb
+++ b/app/views/components/forms/edit/question_types/_radio_buttons.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <fieldset class="usa-fieldset radios"
   role="group"
   aria-labelledby="<%= question.answer_field %>"

--- a/app/views/components/forms/edit/question_types/_rich_textarea.html.erb
+++ b/app/views/components/forms/edit/question_types/_rich_textarea.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <%
   form_options = {
     class: "usa-textarea",

--- a/app/views/components/forms/edit/question_types/_states_dropdown.html.erb
+++ b/app/views/components/forms/edit/question_types/_states_dropdown.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div
   aria-labelledby="<%= question.answer_field %>"
   data-url="<%= admin_form_question_question_options_path(question.form, question) %>">

--- a/app/views/components/forms/edit/question_types/_text_area.html.erb
+++ b/app/views/components/forms/edit/question_types/_text_area.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div
   aria-labelledby="<%= question.answer_field %>">
   <%= render 'components/question_title', question: question, form_builder: true %>

--- a/app/views/components/forms/edit/question_types/_text_email_field.html.erb
+++ b/app/views/components/forms/edit/question_types/_text_email_field.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div
   aria-labelledby="<%= question.answer_field %>">
   <%= render 'components/question_title', question: question, form_builder: true %>

--- a/app/views/components/forms/edit/question_types/_text_field.html.erb
+++ b/app/views/components/forms/edit/question_types/_text_field.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div
   aria-labelledby="<%= question.answer_field %>">
   <%= render 'components/question_title', question: question, form_builder: true %>

--- a/app/views/components/forms/edit/question_types/_text_phone_field.html.erb
+++ b/app/views/components/forms/edit/question_types/_text_phone_field.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div
   aria-labelledby="<%= question.answer_field %>">
   <%= render 'components/question_title', question: question, form_builder: true %>

--- a/app/views/components/forms/question_types/_big_thumbs_up_down_buttons.html.erb
+++ b/app/views/components/forms/question_types/_big_thumbs_up_down_buttons.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <fieldset class="usa-fieldset radios">
   <legend class="usa-sr-only">
     <%= question.text %>

--- a/app/views/components/forms/question_types/_checkbox.html.erb
+++ b/app/views/components/forms/question_types/_checkbox.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <fieldset class="usa-fieldset margin-top-3">
   <%= render 'components/question_title_legend', question: question %>
   <div class="question-options"

--- a/app/views/components/forms/question_types/_combobox.html.erb
+++ b/app/views/components/forms/question_types/_combobox.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <%
 form_options = {
   prompt: t('form.select_one'),

--- a/app/views/components/forms/question_types/_custom_text_display.html.erb
+++ b/app/views/components/forms/question_types/_custom_text_display.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <section
   id="<%= question.ui_selector %>"
   class="usa-site-alert usa-site-alert--info"

--- a/app/views/components/forms/question_types/_date_select.html.erb
+++ b/app/views/components/forms/question_types/_date_select.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div role="group">
   <div class="usa-form-group">
     <%= render 'components/question_title', question: question %>

--- a/app/views/components/forms/question_types/_dropdown.html.erb
+++ b/app/views/components/forms/question_types/_dropdown.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <%
 form_options = {
   prompt: t('form.select_one'),

--- a/app/views/components/forms/question_types/_hidden_field.html.erb
+++ b/app/views/components/forms/question_types/_hidden_field.html.erb
@@ -1,1 +1,3 @@
+<%# locals: (question:) %>
+
 <%= hidden_field_tag question.ui_selector, question.placeholder_text %>

--- a/app/views/components/forms/question_types/_radio_buttons.html.erb
+++ b/app/views/components/forms/question_types/_radio_buttons.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <fieldset class="usa-fieldset radios margin-top-2">
   <%= render 'components/question_title_legend', question: question %>
   <div class="question-options">

--- a/app/views/components/forms/question_types/_rich_textarea.html.erb
+++ b/app/views/components/forms/question_types/_rich_textarea.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <%
   form_options = {
     class: "usa-textarea",

--- a/app/views/components/forms/question_types/_star_radio_buttons.html.erb
+++ b/app/views/components/forms/question_types/_star_radio_buttons.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <fieldset class="usa-fieldset">
   <legend class="usa-sr-only"><%= question.ui_selector %></legend>
   <%= render 'components/question_title', question: question %>

--- a/app/views/components/forms/question_types/_states_dropdown.html.erb
+++ b/app/views/components/forms/question_types/_states_dropdown.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div role="group">
   <%= render 'components/question_title', question: question %>
   <br>

--- a/app/views/components/forms/question_types/_text_area.html.erb
+++ b/app/views/components/forms/question_types/_text_area.html.erb
@@ -1,3 +1,6 @@
+<%# locals: (question:) %>
+
+
 <%
   form_options = {
     class: "usa-textarea",

--- a/app/views/components/forms/question_types/_text_display.html.erb
+++ b/app/views/components/forms/question_types/_text_display.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <p
   class="touchpoints-form-text-display margin-top-5"
   id="<%= question.ui_selector %>">

--- a/app/views/components/forms/question_types/_text_email_field.html.erb
+++ b/app/views/components/forms/question_types/_text_email_field.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <%
 form_options = {
   type: :email,

--- a/app/views/components/forms/question_types/_text_field.html.erb
+++ b/app/views/components/forms/question_types/_text_field.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <%
 form_options = {
   class: "usa-input",

--- a/app/views/components/forms/question_types/_text_phone_field.html.erb
+++ b/app/views/components/forms/question_types/_text_phone_field.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div role="group">
   <%= render 'components/question_title_label', question: question %>
   <%= telephone_field_tag question.ui_selector, nil, class: "usa-input", required: question.is_required, maxlength: 10 %>

--- a/app/views/components/forms/question_types/_yes_no_buttons.html.erb
+++ b/app/views/components/forms/question_types/_yes_no_buttons.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (question:) %>
+
 <div class="touchpoints-yes-no-buttons">
   <label
     class="usa-label"

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:, suppress_ui: false) %>
+
 // Form components are namespaced under 'fba' = 'Feedback Analytics'
 // Updated: July 2024
 'use strict';

--- a/app/views/components/widget/_modal.html.erb
+++ b/app/views/components/widget/_modal.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:) %>
+
 <div
   class="<%= form.prefix "usa-modal__content" %> fba-modal-dialog">
   <div>

--- a/app/views/components/widget/_no_modal.html.erb
+++ b/app/views/components/widget/_no_modal.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:) %>
+
 <div
   class="touchpoints-form-wrapper <%= form.kind %>"
   id="touchpoints-form-<%= form.short_uuid %>"
@@ -19,7 +21,7 @@
     </p>
     <% end %>
     <%= render 'components/forms/flash', form: form %>
-    <%= render partial: "components/forms/custom", locals: { form: form, questions: form.questions } %>
+    <%= render partial: "components/forms/custom", locals: { form: form } %>
     <% else %>
     <%= render partial: "submissions/archived_form", locals: { form: form } %>
     <% end %>

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -3,10 +3,24 @@
   font-size: 100%;
 }
 
-.fba-modal-dialog h1 {
+.fba-modal-dialog .fba-form-header {
   margin-right: 20px;
   margin-top: -1rem;
-  word-wrap: break-word;
+}
+
+.fba-form-header {
+    margin: 1rem 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.fba-modal-title {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1.2;
+    overflow-wrap: break-word;
+    margin: 0;
 }
 
 .fba-inline-container {

--- a/app/views/submissions/_archived_form.html.erb
+++ b/app/views/submissions/_archived_form.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:) %>
+
 <br>
 <div class="usa-alert usa-alert--info">
   <div class="usa-alert__body">

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render "components/forms/custom_layout", form: form, questions: form.ordered_questions %>
+<%= render "components/forms/custom_layout", form: form %>
 <script>
   <%= render(partial: "components/widget/fba", formats: :js, locals: { form: form, suppress_ui: true }) %>
 </script>


### PR DESCRIPTION
This PR does some preliminary work to prepare for a subsequent PR that will address https://github.com/GSA/touchpoints/issues/1954. The PR adds [strict locals](https://guides.rubyonrails.org/v7.1.5/7_1_release_notes.html#allow-templates-to-set-strict-locals) declarations to many of the templates involved in displaying forms. The work for https://github.com/GSA/touchpoints/issues/1954 will involve adding a new local to a number of templates and I wanted to make the locals contract explicit before doing so. After adding the strict local declarations, I discovered several places where the caller was passing unused locals, which I cleaned up.

A couple of other miscellaneous changes:

- The preview page (app/views/admin/forms/example.html.erb) has been prettified slightly.
- Fixed a template that was generating invalid HTML (`div` inside heading tag is invalid, see changes to app/views/components/forms/_logo_and_title.html.erb).