### PR TITLE
Use render-context-specific heading tags in forms

### DIFF
--- a/app/controllers/touchpoints_controller.rb
+++ b/app/controllers/touchpoints_controller.rb
@@ -13,7 +13,7 @@ class TouchpointsController < ApplicationController
         js
       end
       format.css do
-        render(partial: 'components/widget/widget', formats: :css, locals: { form: @form })
+        render(partial: 'components/widget/widget', formats: :css)
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -248,5 +248,23 @@ module ApplicationHelper
     value ? 'Yes' : 'No'
   end
 
+  # Heading levels per render context and semantic role. An embedded widget is
+  # injected into host pages that already own the top-level <h1>, so its title
+  # is demoted to <h2> (and alerts to <h3>) to preserve valid heading order.
+  # Hosted forms own the page, so the title is the <h1>.
+  HEADING_LEVELS = {
+    hosted: { title: 'h1', alert: 'h2' },
+    modal: { title: 'h2', alert: 'h3' },
+    inline: { title: 'h2', alert: 'h3' },
+  }.freeze
+
+  def title_heading_level(render_context)
+    HEADING_LEVELS.fetch(render_context).fetch(:title)
+  end
+
+  def alert_heading_level(render_context)
+    HEADING_LEVELS.fetch(render_context).fetch(:alert)
+  end
+
   delegate :fiscal_year_and_quarter, to: :FiscalYear
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -374,12 +374,6 @@ class Form < ApplicationRecord
 
   # Renders the widget CSS partial for use with the Rust widget renderer
   def render_widget_css
-    controller_with_request = build_controller_with_mock_request
-    controller_with_request.render_to_string(partial: 'components/widget/widget', formats: :css, locals: { form: self })
-  end
-
-  # Renders the widget CSS partial for use with the Rust widget renderer
-  def render_widget_css
     controller = ApplicationController.new
 
     # Set up a mock request with default URL options
@@ -398,7 +392,7 @@ class Form < ApplicationRecord
     )
 
     controller.request = mock_request
-    controller.render_to_string(partial: 'components/widget/widget', formats: :css, locals: { form: self })
+    controller.render_to_string(partial: 'components/widget/widget', formats: :css)
   end
 
   def reportable_submissions(start_date: nil, end_date: nil)

--- a/app/views/admin/questions/_question.html.erb
+++ b/app/views/admin/questions/_question.html.erb
@@ -9,39 +9,39 @@
   <% end %>
 </div>
 
-<%- if question.question_type == "text_field" %>
-<% @form_component_path = 'components/forms/edit/question_types/text_field' %>
-<% elsif question.question_type == "text_email_field" %>
-<% @form_component_path = 'components/forms/edit/question_types/text_email_field' %>
-<% elsif question.question_type == "text_phone_field" %>
-<% @form_component_path = 'components/forms/edit/question_types/text_phone_field' %>
-<% elsif question.question_type == "radio_buttons" %>
-<% @form_component_path = 'components/forms/edit/question_types/radio_buttons' %>
-<% elsif question.question_type == "big_thumbs_up_down_buttons" %>
-<% @form_component_path = 'components/forms/question_types/big_thumbs_up_down_buttons' %>
-<% elsif question.question_type == "dropdown" %>
-<% @form_component_path = 'components/forms/edit/question_types/dropdown' %>
-<% elsif question.question_type == "states_dropdown" %>
-<% @form_component_path = 'components/forms/edit/question_types/states_dropdown' %>
-<% elsif question.question_type == "checkbox" %>
-<% @form_component_path = 'components/forms/edit/question_types/checkbox' %>
-<% elsif question.question_type == "combobox" %>
-<% @form_component_path = 'components/forms/edit/question_types/combobox' %>
-<% elsif question.question_type == "textarea" %>
-<% @form_component_path = 'components/forms/edit/question_types/text_area' %>
-<% elsif question.question_type == "rich_textarea" %>
-<% @form_component_path = 'components/forms/edit/question_types/rich_textarea' %>
-<% elsif question.question_type == "hidden_field" %>
-<% @form_component_path = 'components/forms/edit/question_types/hidden_field' %>
-<% elsif question.question_type == "custom_text_display" %>
-<% @form_component_path = 'components/forms/question_types/custom_text_display' %>
-<% elsif question.question_type == "star_radio_buttons" %>
-<% @form_component_path = 'components/forms/question_types/star_radio_buttons' %>
-<% elsif question.question_type == "yes_no_buttons" %>
-<% @form_component_path = 'components/forms/question_types/yes_no_buttons' %>
-<% elsif question.question_type == "text_display" %>
-<% @form_component_path = 'components/forms/question_types/text_display' %>
-<% elsif question.question_type == "date_select" %>
-<% @form_component_path = 'components/forms/question_types/date_select' %>
-<% end %>
-<%= render @form_component_path, question: question %>
+<%- case question.question_type %>
+<%- when "text_field" %>
+  <%= render 'components/forms/edit/question_types/text_field', question: question %>
+<%- when "text_email_field" %>
+  <%= render 'components/forms/edit/question_types/text_email_field', question: question %>
+<%- when "text_phone_field" %>
+  <%= render 'components/forms/edit/question_types/text_phone_field', question: question %>
+<%- when "radio_buttons" %>
+  <%= render 'components/forms/edit/question_types/radio_buttons', question: question %>
+<%- when "big_thumbs_up_down_buttons" %>
+  <%= render 'components/forms/question_types/big_thumbs_up_down_buttons', question: question %>
+<%- when "dropdown" %>
+  <%= render 'components/forms/edit/question_types/dropdown', question: question %>
+<%- when "states_dropdown" %>
+  <%= render 'components/forms/edit/question_types/states_dropdown', question: question %>
+<%- when "checkbox" %>
+  <%= render 'components/forms/edit/question_types/checkbox', question: question %>
+<%- when "combobox" %>
+  <%= render 'components/forms/edit/question_types/combobox', question: question %>
+<%- when "textarea" %>
+  <%= render 'components/forms/edit/question_types/text_area', question: question %>
+<%- when "rich_textarea" %>
+  <%= render 'components/forms/edit/question_types/rich_textarea', question: question %>
+<%- when "hidden_field" %>
+  <%= render 'components/forms/edit/question_types/hidden_field', question: question %>
+<%- when "custom_text_display" %>
+  <%= render 'components/forms/question_types/custom_text_display', question: question, heading_level: 'h2' %>
+<%- when "star_radio_buttons" %>
+  <%= render 'components/forms/question_types/star_radio_buttons', question: question %>
+<%- when "yes_no_buttons" %>
+  <%= render 'components/forms/question_types/yes_no_buttons', question: question %>
+<%- when "text_display" %>
+  <%= render 'components/forms/question_types/text_display', question: question %>
+<%- when "date_select" %>
+  <%= render 'components/forms/question_types/date_select', question: question %>
+<%- end %>

--- a/app/views/components/forms/_archived_form.html.erb
+++ b/app/views/components/forms/_archived_form.html.erb
@@ -1,11 +1,11 @@
-<%# locals: (form:) %>
+<%# locals: (form:, heading_level:) %>
 
 <br>
 <div class="usa-alert usa-alert--info">
   <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">
+    <%= content_tag heading_level, class: "usa-alert__heading" do %>
       This form is not currently accepting feedback
-    </h3>
+    <% end %>
     <p class="usa-alert__text">
       The form,
       <strong><%= form.title %></strong>,

--- a/app/views/components/forms/_custom.html.erb
+++ b/app/views/components/forms/_custom.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (form:) %>
+<%# locals: (form:, render_context:) %>
 
 <% multi_section_question_number = 0 %>
 
@@ -82,7 +82,7 @@
             <% elsif question.question_type == "date_select" %>
               <%= render 'components/forms/question_types/date_select', question: question %>
             <% elsif question.question_type == "custom_text_display" %>
-              <%= render 'components/forms/question_types/custom_text_display', question: question %>
+              <%= render 'components/forms/question_types/custom_text_display', question: question, heading_level: alert_heading_level(render_context) %>
             <% end %>
           </div>
           <% else %>

--- a/app/views/components/forms/_custom_layout.html.erb
+++ b/app/views/components/forms/_custom_layout.html.erb
@@ -1,9 +1,9 @@
-<%# locals: (form:) %>
+<%# locals: (form:, render_context:) %>
 
 <div class="inner-wrapper">
   <div class="grid-row">
     <div class="grid-col-12">
-      <%= render "components/forms/logo_and_title", form: form %>
+      <%= render "components/forms/logo_and_title", form: form, heading_level: title_heading_level(render_context) %>
       <%- if form.instructions.present? %>
         <div class="fba-instructions margin-bottom-2">
           <%= sanitize(form.instructions) %>
@@ -16,8 +16,8 @@
           </small>
         </p>
       <% end %>
-      <%= render 'components/forms/flash', form: form %>
-      <%= render partial: "components/forms/custom", locals: { form: form } %>
+      <%= render 'components/forms/flash', form: form, heading_level: alert_heading_level(render_context) %>
+      <%= render partial: "components/forms/custom", locals: { form: form, render_context: render_context } %>
     </div>
   </div>
 </div>

--- a/app/views/components/forms/_flash.html.erb
+++ b/app/views/components/forms/_flash.html.erb
@@ -1,10 +1,10 @@
-<%# locals: (form:) %>
+<%# locals: (form:, heading_level:) %>
 
 <div class="fba-alert usa-alert usa-alert--success" role="status" hidden>
   <div class="usa-alert__body">
-    <h2 class="usa-alert__heading">
+    <%= content_tag heading_level, class: "usa-alert__heading" do %>
       <%= form.success_text_heading %>
-    </h2>
+    <% end %>
     <div class="usa-alert__text">
       <%= sanitize(form.success_text) %>
     </div>
@@ -12,9 +12,9 @@
 </div>
 <div class="fba-alert-error usa-alert usa-alert--error" role="alert" hidden>
   <div class="usa-alert__body">
-    <h2 class="usa-alert__heading">
+    <%= content_tag heading_level, class: "usa-alert__heading" do %>
       <%= t 'error' %>
-    </h2>
+    <% end %>
     <p class="usa-alert__text">
       alert message
     </p>

--- a/app/views/components/forms/_logo_and_title.html.erb
+++ b/app/views/components/forms/_logo_and_title.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (form:) %>
+<%# locals: (form:, heading_level:) %>
 
 <header class="fba-form-header">
   <%- if form.logo.present? %>
@@ -14,9 +14,9 @@
       <% end %>
     </div>
   <% end %>
-  <h1
-    class="fba-modal-title"
-    id="<%= "fba-form-title-#{form.short_uuid}" %>">
+  <%= content_tag heading_level,
+                  class: "fba-modal-title",
+                  id: "fba-form-title-#{form.short_uuid}" do %>
     <%- if form.title.present? %>
     <%= form.title %>
     <% else %>
@@ -24,5 +24,5 @@
       Feedback form
     </span>
     <% end %>
-  </h1>
+  <% end %>
 </header>

--- a/app/views/components/forms/edit/_builder.html.erb
+++ b/app/views/components/forms/edit/_builder.html.erb
@@ -114,7 +114,7 @@
   <div class="grid-col-7">
     <br>
     <br>
-    <%= render "components/forms/flash", form: form %>
+    <%= render "components/forms/flash", form: form, heading_level: 'h2' %>
   </div>
 </div>
 

--- a/app/views/components/forms/question_types/_custom_text_display.html.erb
+++ b/app/views/components/forms/question_types/_custom_text_display.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (question:) %>
+<%# locals: (question:, heading_level:) %>
 
 <section
   id="<%= question.ui_selector %>"
@@ -6,9 +6,9 @@
   aria-label="Site alert">
   <div class="usa-alert">
     <div class="usa-alert__body">
-      <h3 class="usa-alert__heading">
+      <%= content_tag heading_level, class: "usa-alert__heading" do %>
         <%= question.text.html_safe %>
-      </h3>
+      <% end %>
       <%- if question.help_text.present? %>
       <p class="usa-alert__text">
         <%= question.help_text.html_safe %>

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -127,23 +127,23 @@ function FBAform(d, N) {
 			}
 		},
 		_loadHtml: function() {
-      <%# inject the form interface for the `inline` delivery option, without a wrapper %>
-      if ((this.options.deliveryMethod && this.options.deliveryMethod === 'inline') && this.options.suppressSubmitButton) {
+    <%# inject the form interface for the `inline` delivery option, without a wrapper %>
+    if ((this.options.deliveryMethod && this.options.deliveryMethod === 'inline') && this.options.suppressSubmitButton) {
         if (this.options.elementSelector) {
-          if (d.getElementById(this.options.elementSelector) != null) {
-            d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBodyNoModal();
-          }
+            if (d.getElementById(this.options.elementSelector) != null) {
+                 d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBodyNoModal();
+            }
         }
-      } else if (this.options.deliveryMethod && this.options.deliveryMethod === 'inline') { <%# inject the form interface for inline with the modal wrapper %>
+    } else if (this.options.deliveryMethod && this.options.deliveryMethod === 'inline') { <%# inject the form interface for inline with the modal wrapper %>
         if (this.options.elementSelector) {
-          if (d.getElementById(this.options.elementSelector) != null) {
-            d.getElementById(this.options.elementSelector).classList.add('fba-inline-container');
-            d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBody();
-          }
+            if (d.getElementById(this.options.elementSelector) != null) {
+                 d.getElementById(this.options.elementSelector).classList.add('fba-inline-container');
+                 d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBody();
+            }
         }
-      }
-      <%# inject the form interface for modal and custom-button-modal %>
-      if (this.options.deliveryMethod && (this.options.deliveryMethod === 'modal' || this.options.deliveryMethod === 'custom-button-modal')) {
+    }
+    <%# inject the form interface for modal and custom-button-modal %>
+    if (this.options.deliveryMethod && (this.options.deliveryMethod === 'modal' || this.options.deliveryMethod === 'custom-button-modal')) {
         this.dialogEl = d.createElement('div');
         this.dialogEl.setAttribute('class', "<%= form.prefix "usa-modal" %> fba-modal");
         this.dialogEl.setAttribute('id', this.modalId());
@@ -153,19 +153,19 @@ function FBAform(d, N) {
 
         this.dialogEl.innerHTML = this.options.htmlFormBody();
         d.body.appendChild(this.dialogEl);
-      }
-      <%# add button behaviors for custom-button-modal %>
-      if (this.options.deliveryMethod && this.options.deliveryMethod === 'custom-button-modal') {
+    }
+    <%# add button behaviors for custom-button-modal %>
+    if (this.options.deliveryMethod && this.options.deliveryMethod === 'custom-button-modal') {
         if (this.options.elementSelector) {
-          const customButtonEl = d.getElementById(this.options.elementSelector);
-          if (customButtonEl != null) {
-            customButtonEl.setAttribute('data-open-modal', '');
-            customButtonEl.setAttribute('aria-controls', this.modalId());
-            customButtonEl.addEventListener('click', () => d.dispatchEvent(new CustomEvent('onTouchpointsModalOpen', {detail: {form: this}}
-            )));
-          }
+            const customButtonEl = d.getElementById(this.options.elementSelector);
+            if (customButtonEl != null) {
+                customButtonEl.setAttribute('data-open-modal', '');
+                customButtonEl.setAttribute('aria-controls', this.modalId());
+                customButtonEl.addEventListener('click', () => d.dispatchEvent(new CustomEvent('onTouchpointsModalOpen', {detail: {form: this}}
+                )));
+            }
         }
-      }
+    }
     },
 		resetErrors: function() {
 			var formComponent = this.formComponent();

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -1,4 +1,4 @@
-<%# locals: (form:, suppress_ui: false) %>
+<%# locals: (form:, render_context: nil, suppress_ui: false) %>
 
 // Form components are namespaced under 'fba' = 'Feedback Analytics'
 // Updated: July 2024
@@ -34,7 +34,9 @@ function FBAform(d, N) {
 			if (this.options.loadCSS) {
 				this._loadCss();
 			}
-			this._loadHtml();
+      <%- unless render_context == :hosted %>
+        this._loadHtml();
+      <% end %>
 			if (!this.options.suppressUI && (this.options.deliveryMethod && this.options.deliveryMethod === 'modal')) {
 				this.loadButton();
 			}
@@ -61,7 +63,34 @@ function FBAform(d, N) {
 		_bindEventListeners: function() {
 			var self = this;
 
-			const textareas = this.formComponent().querySelectorAll(".usa-textarea, .ql-editor");
+      const otherElements = self.formElement().querySelectorAll(".usa-input.other-option");
+      for (var i = 0; i < otherElements.length; i++) {
+        otherElements[i].addEventListener('keyup', self.handleOtherOption.bind(self), false);
+      }
+
+      var phoneElements = self.formElement().querySelectorAll("input[type='tel']");
+      for (var i = 0; i < phoneElements.length; i++) {
+        phoneElements[i].addEventListener('keyup', self.handlePhoneInput.bind(self), false);
+      }
+
+      var formElement = self.formElement();
+      // returns 1 or more submit buttons within the Touchpoints form
+      var submitButtons = formElement.querySelectorAll("[type='submit']");
+
+      var yesNoForm = formElement.querySelector('.touchpoints-yes-no-buttons');
+      if (yesNoForm) { // only for yes/no questions
+        Array.prototype.forEach.call(submitButtons, function(submitButton) {
+          submitButton.addEventListener('click', self.handleYesNoSubmitClick.bind(self), false);
+        })
+      } else { // for all other types of forms/questions
+        if (submitButtons) {
+          Array.prototype.forEach.call(submitButtons, function(submitButton) {
+            submitButton.addEventListener('click', self.handleSubmitClick.bind(self), false);
+          })
+        }
+      }
+
+			const textareas = self.formComponent().querySelectorAll(".usa-textarea, .ql-editor");
 			textareas.forEach(function(textarea) {
 				if (textarea.getAttribute("maxlength") != '0' && textarea.getAttribute("maxlength") != '10000')  {
 					textarea.addEventListener("keyup", self.textCounter);
@@ -69,7 +98,7 @@ function FBAform(d, N) {
 			});
 
 			<%# only text fields; not email or telephone %>
-			const textFields = this.formComponent().querySelectorAll(".usa-input[type='text']");
+			const textFields = self.formComponent().querySelectorAll(".usa-input[type='text']");
 			textFields.forEach(function(textField) {
 				if (textField.getAttribute("maxlength") != '0' && textField.getAttribute("maxlength") != '10000')  {
 					textField.addEventListener("keyup", self.textCounter);
@@ -91,73 +120,46 @@ function FBAform(d, N) {
 			}
 		},
 		_loadHtml: function() {
-		<%# inject the form interface for the `inline` delivery option, without a wrapper %>
-		if ((this.options.deliveryMethod && this.options.deliveryMethod === 'inline') && this.options.suppressSubmitButton) {
-			if (this.options.elementSelector) {
-				if(d.getElementById(this.options.elementSelector) != null) {
-					d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBodyNoModal();
-				}
-			}
-		} else if (this.options.deliveryMethod && this.options.deliveryMethod === 'inline') { <%# inject the form interface for inline with the modal wrapper %>
-			if (this.options.elementSelector) {
-				if(d.getElementById(this.options.elementSelector) != null) {
-					d.getElementById(this.options.elementSelector).classList.add('fba-inline-container');
-					d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBody();
-				}
-			}
-		}
-		<%# inject the form interface for modal and custom-button-modal %>
-		if (this.options.deliveryMethod && (this.options.deliveryMethod === 'modal' || this.options.deliveryMethod === 'custom-button-modal')) {
-			this.dialogEl = d.createElement('div');
-			this.dialogEl.setAttribute('class', "<%= form.prefix "usa-modal" %> fba-modal");
-			this.dialogEl.setAttribute('id', this.modalId());
-			this.dialogEl.setAttribute('aria-labelledby', `fba-form-title-${this.options.formId}`);
-			this.dialogEl.setAttribute('aria-describedby', `fba-form-instructions-${this.options.formId}`);
-			this.dialogEl.setAttribute('data-touchpoints-form-id', this.options.formId);
+      <%# inject the form interface for the `inline` delivery option, without a wrapper %>
+      if ((this.options.deliveryMethod && this.options.deliveryMethod === 'inline') && this.options.suppressSubmitButton) {
+        if (this.options.elementSelector) {
+          if (d.getElementById(this.options.elementSelector) != null) {
+            d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBodyNoModal();
+          }
+        }
+      } else if (this.options.deliveryMethod && this.options.deliveryMethod === 'inline') { <%# inject the form interface for inline with the modal wrapper %>
+        if (this.options.elementSelector) {
+          if (d.getElementById(this.options.elementSelector) != null) {
+            d.getElementById(this.options.elementSelector).classList.add('fba-inline-container');
+            d.getElementById(this.options.elementSelector).innerHTML = this.options.htmlFormBody();
+          }
+        }
+      }
+      <%# inject the form interface for modal and custom-button-modal %>
+      if (this.options.deliveryMethod && (this.options.deliveryMethod === 'modal' || this.options.deliveryMethod === 'custom-button-modal')) {
+        this.dialogEl = d.createElement('div');
+        this.dialogEl.setAttribute('class', "<%= form.prefix "usa-modal" %> fba-modal");
+        this.dialogEl.setAttribute('id', this.modalId());
+        this.dialogEl.setAttribute('aria-labelledby', `fba-form-title-${this.options.formId}`);
+        this.dialogEl.setAttribute('aria-describedby', `fba-form-instructions-${this.options.formId}`);
+        this.dialogEl.setAttribute('data-touchpoints-form-id', this.options.formId);
 
-			this.dialogEl.innerHTML = this.options.htmlFormBody();
-			d.body.appendChild(this.dialogEl);
-		}
-		var otherElements = this.formElement().querySelectorAll(".usa-input.other-option");
-		for (var i = 0; i < otherElements.length; i++) {
-		    otherElements[i].addEventListener('keyup', this.handleOtherOption.bind(this), false);
-		}
-		var phoneElements = this.formElement().querySelectorAll("input[type='tel']");
-		for (var i = 0; i < phoneElements.length; i++) {
-		    phoneElements[i].addEventListener('keyup', this.handlePhoneInput.bind(this), false);
-		}
-		<%# add button behaviors for custom-button-modal %>
-		if (this.options.deliveryMethod && this.options.deliveryMethod === 'custom-button-modal') {
-			if (this.options.elementSelector) {
-				const customButtonEl = d.getElementById(this.options.elementSelector);
-				if (customButtonEl != null) {
-					customButtonEl.setAttribute('data-open-modal', '');
-					customButtonEl.setAttribute('aria-controls', this.modalId());
-					customButtonEl.addEventListener('click', () => d.dispatchEvent(new CustomEvent('onTouchpointsModalOpen', { detail: { form: this } }
-					)));
-				}
-			}
-		}
-
-			var formElement = this.formElement();
-			// returns 1 or more submit buttons within the Touchpoints form
-			var submitButtons = formElement.querySelectorAll("[type='submit']");
-			var that = this;
-
-			var yesNoForm = formElement.querySelector('.touchpoints-yes-no-buttons');
-
-			if (yesNoForm) { // only for yes/no questions
-				Array.prototype.forEach.call(submitButtons, function(submitButton) {
-					submitButton.addEventListener('click', that.handleYesNoSubmitClick.bind(that), false);
-				})
-			} else { // for all other types of forms/questions
-				if (submitButtons) {
-					Array.prototype.forEach.call(submitButtons, function(submitButton) {
-						submitButton.addEventListener('click', that.handleSubmitClick.bind(that), false);
-					})
-				}
-			}
-		},
+        this.dialogEl.innerHTML = this.options.htmlFormBody();
+        d.body.appendChild(this.dialogEl);
+      }
+      <%# add button behaviors for custom-button-modal %>
+      if (this.options.deliveryMethod && this.options.deliveryMethod === 'custom-button-modal') {
+        if (this.options.elementSelector) {
+          const customButtonEl = d.getElementById(this.options.elementSelector);
+          if (customButtonEl != null) {
+            customButtonEl.setAttribute('data-open-modal', '');
+            customButtonEl.setAttribute('aria-controls', this.modalId());
+            customButtonEl.addEventListener('click', () => d.dispatchEvent(new CustomEvent('onTouchpointsModalOpen', {detail: {form: this}}
+            )));
+          }
+        }
+      }
+    },
 		resetErrors: function() {
 			var formComponent = this.formComponent();
 			var alertElement = formComponent.querySelector(".fba-alert");
@@ -643,7 +645,7 @@ function FBAform(d, N) {
 					});
 					d.dispatchEvent(previousPageEvent);
 
-          <%- if form.delivery_method == "touchpoints-hosted-only" %>
+          <%- if render_context == :hosted %>
           N.scrollTo(0, 0);
           <% else %>
           this.formComponent().scrollIntoView();
@@ -667,7 +669,7 @@ function FBAform(d, N) {
 					});
 					d.dispatchEvent(nextPageEvent);
 
-          <%- if form.delivery_method == "touchpoints-hosted-only" %>
+          <%- if render_context == :hosted %>
           N.scrollTo(0, 0);
           <% else %>
           this.formComponent().scrollIntoView();
@@ -774,7 +776,7 @@ function FBAform(d, N) {
         }
 			});
       
-      <%- if form.delivery_method == "touchpoints-hosted-only" %>
+      <%- if render_context == :hosted %>
       <%# Hosted mode: the form is the whole page, so run the challenge %>
       <%# immediately rather than waiting for interaction. %>
       trigger();
@@ -861,7 +863,7 @@ var touchpointFormOptions<%= form.short_uuid %> = {
 	'formId': "<%= form.short_uuid %>",
 	'modalButtonText': "<%= form.modal_button_text %>",
 	'elementSelector': "<%= form.element_selector %>",
-	'css' : "<%= escape_javascript(render partial: 'components/widget/widget', formats: :css, locals: { form: form }) %>",
+	'css' : "<%= escape_javascript(render partial: 'components/widget/widget', formats: :css, locals: { render_context: render_context }) %>",
 	'loadCSS' : <%= form.load_css %>,
 	'formSpecificScript' : function() {
 		<%- if ["a11_v2", "a11_v2_radio", "a11_yes_no"].include?(form.kind) %>
@@ -883,15 +885,17 @@ var touchpointFormOptions<%= form.short_uuid %> = {
 	'suppressUI' : <%= (local_assigns.has_key?(:suppress_ui) && suppress_ui) %>,
 	'suppressSubmitButton' : <%= form.suppress_submit_button %>,
 	'htmlFormBody' : function() {
-		<%- if (form.delivery_method == "inline" && !form.suppress_submit_button && form.element_selector?) || form.delivery_method == "modal" || form.delivery_method == "custom-button-modal" %>
-		return "<%= escape_javascript render(partial: 'components/widget/modal', locals: { form: form }) %>";
-		<% else %>
+		<%- if form.delivery_method == "inline" && !form.suppress_submit_button && form.element_selector? %>
+		return "<%= escape_javascript render(partial: 'components/widget/modal', locals: { form: form, render_context: :inline }) %>";
+		<% elsif form.delivery_method == "modal" || form.delivery_method == "custom-button-modal" %>
+    return "<%= escape_javascript render(partial: 'components/widget/modal', locals: { form: form, render_context: :modal }) %>";
+    <% else %>
 		return null;
 		<% end %>
 	},
 	'htmlFormBodyNoModal' : function() {
 		<%- if form.delivery_method == "inline" && form.suppress_submit_button && form.element_selector? %>
-		return "<%= escape_javascript render(partial: 'components/widget/no_modal', locals: { form: form }) %>";
+		return "<%= escape_javascript render(partial: 'components/widget/no_modal', locals: { form: form, render_context: :inline }) %>";
 		<% else %>
 		return null;
 		<% end %>
@@ -902,7 +906,7 @@ var touchpointFormOptions<%= form.short_uuid %> = {
 window.touchpointForm<%= form.short_uuid %> = new FBAform(document, window);
 window.touchpointForm<%= form.short_uuid %>.init(touchpointFormOptions<%= form.short_uuid %>);
 
-<%- if form.load_css && form.delivery_method != "touchpoints-hosted-only" %>
+<%- if form.load_css && render_context != :hosted %>
 // Load the USWDS JS, loads as module 'fbaUswds' in global scope
 <%= render partial: 'components/widget/widget-uswds', formats: :js %>
 

--- a/app/views/components/widget/_fba.js.erb
+++ b/app/views/components/widget/_fba.js.erb
@@ -1,4 +1,11 @@
-<%# locals: (form:, render_context: nil, suppress_ui: false) %>
+<%# locals: (form:, hosted_mode: false) %>
+<%#
+  hosted_mode: true when the form is rendered as its own full page on
+  Touchpoints rather than embedded in a host site. It skips injecting the form
+  HTML (the page already renders it), scrolls the window on page changes instead
+  of the widget container, and omits the bundled USWDS JS/CSS the page provides.
+  Defaults to false for embedded/modal/inline delivery.
+%>
 
 // Form components are namespaced under 'fba' = 'Feedback Analytics'
 // Updated: July 2024
@@ -34,12 +41,12 @@ function FBAform(d, N) {
 			if (this.options.loadCSS) {
 				this._loadCss();
 			}
-      <%- unless render_context == :hosted %>
+      if (!this.options.hostedMode) {
         this._loadHtml();
-      <% end %>
-			if (!this.options.suppressUI && (this.options.deliveryMethod && this.options.deliveryMethod === 'modal')) {
-				this.loadButton();
-			}
+        if (this.options.deliveryMethod && this.options.deliveryMethod === 'modal') {
+          this.loadButton();
+        }
+      }
 			this.enableLocalStorage();
 			this._bindEventListeners();
 			this.successState = false; // initially false
@@ -645,7 +652,7 @@ function FBAform(d, N) {
 					});
 					d.dispatchEvent(previousPageEvent);
 
-          <%- if render_context == :hosted %>
+          <%- if hosted_mode %>
           N.scrollTo(0, 0);
           <% else %>
           this.formComponent().scrollIntoView();
@@ -669,7 +676,7 @@ function FBAform(d, N) {
 					});
 					d.dispatchEvent(nextPageEvent);
 
-          <%- if render_context == :hosted %>
+          <%- if hosted_mode %>
           N.scrollTo(0, 0);
           <% else %>
           this.formComponent().scrollIntoView();
@@ -776,7 +783,7 @@ function FBAform(d, N) {
         }
 			});
       
-      <%- if render_context == :hosted %>
+      <%- if hosted_mode %>
       <%# Hosted mode: the form is the whole page, so run the challenge %>
       <%# immediately rather than waiting for interaction. %>
       trigger();
@@ -863,7 +870,7 @@ var touchpointFormOptions<%= form.short_uuid %> = {
 	'formId': "<%= form.short_uuid %>",
 	'modalButtonText': "<%= form.modal_button_text %>",
 	'elementSelector': "<%= form.element_selector %>",
-	'css' : "<%= escape_javascript(render partial: 'components/widget/widget', formats: :css, locals: { render_context: render_context }) %>",
+	'css' : "<%= escape_javascript(render partial: 'components/widget/widget', formats: :css, locals: { hosted_mode: }) %>",
 	'loadCSS' : <%= form.load_css %>,
 	'formSpecificScript' : function() {
 		<%- if ["a11_v2", "a11_v2_radio", "a11_yes_no"].include?(form.kind) %>
@@ -882,7 +889,7 @@ var touchpointFormOptions<%= form.short_uuid %> = {
 		<% end %>
 		}
 	},
-	'suppressUI' : <%= (local_assigns.has_key?(:suppress_ui) && suppress_ui) %>,
+	'hostedMode' : <%= hosted_mode %>,
 	'suppressSubmitButton' : <%= form.suppress_submit_button %>,
 	'htmlFormBody' : function() {
 		<%- if form.delivery_method == "inline" && !form.suppress_submit_button && form.element_selector? %>
@@ -906,7 +913,7 @@ var touchpointFormOptions<%= form.short_uuid %> = {
 window.touchpointForm<%= form.short_uuid %> = new FBAform(document, window);
 window.touchpointForm<%= form.short_uuid %>.init(touchpointFormOptions<%= form.short_uuid %>);
 
-<%- if form.load_css && render_context != :hosted %>
+<%- if form.load_css && !hosted_mode %>
 // Load the USWDS JS, loads as module 'fbaUswds' in global scope
 <%= render partial: 'components/widget/widget-uswds', formats: :js %>
 

--- a/app/views/components/widget/_modal.html.erb
+++ b/app/views/components/widget/_modal.html.erb
@@ -1,10 +1,10 @@
-<%# locals: (form:) %>
+<%# locals: (form:, render_context:) %>
 
 <div
   class="<%= form.prefix "usa-modal__content" %> fba-modal-dialog">
   <div>
     <div class="<%= form.prefix "usa-modal__main" %> padding-bottom-0 padding-top-0">
-      <%= render "components/widget/no_modal", form: form %>
+      <%= render "components/widget/no_modal", form: form, render_context: render_context %>
     </div>
     <%= render partial: 'components/forms/footer', locals: { form: form } %>
   </div>

--- a/app/views/components/widget/_no_modal.html.erb
+++ b/app/views/components/widget/_no_modal.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (form:) %>
+<%# locals: (form:, render_context:) %>
 
 <div
   class="touchpoints-form-wrapper <%= form.kind %>"
@@ -7,7 +7,7 @@
 >
   <div class="touchpoints-inner-form-wrapper">
     <%- unless form.archived? %>
-    <%= render "components/forms/logo_and_title", form: form %>
+    <%= render "components/forms/logo_and_title", form: form, heading_level: title_heading_level(render_context) %>
     <%- if form.instructions? %>
     <div class="fba-instructions" id="<%= "fba-form-instructions-#{form.short_uuid}" %>">
       <%= sanitize(form.instructions) %>
@@ -20,10 +20,10 @@
       </small>
     </p>
     <% end %>
-    <%= render 'components/forms/flash', form: form %>
-    <%= render partial: "components/forms/custom", locals: { form: form } %>
+    <%= render 'components/forms/flash', form: form, heading_level: alert_heading_level(render_context) %>
+    <%= render partial: "components/forms/custom", locals: { form: form, render_context: render_context } %>
     <% else %>
-    <%= render partial: "submissions/archived_form", locals: { form: form } %>
+    <%= render partial: "components/forms/archived_form", locals: { form: form, heading_level: alert_heading_level(render_context) } %>
     <% end %>
   </div>
   <%= yield %>

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -1,4 +1,11 @@
-<%# locals: (render_context:) %>
+<%# locals: (hosted_mode: false) %>
+<%#
+  hosted_mode: true when the form is rendered as its own full page on
+  Touchpoints (rather than embedded in a host site). In hosted mode the page
+  already loads USWDS, so the bundled USWDS styles below are skipped to avoid
+  duplicating them. Defaults to false for embedded/modal/inline delivery, which
+  must ship its own USWDS styles.
+%>
 
 .fba-modal-dialog {
   font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
@@ -65,7 +72,7 @@
   display: none;
 }
 
-<%- if render_context != :hosted %>
+<%- unless hosted_mode %>
 <%= render partial: 'components/widget/widget-uswds-styles', formats: :css %>
 
 .fba-modal-dialog .usa-sr-only{

--- a/app/views/components/widget/_widget.css.erb
+++ b/app/views/components/widget/_widget.css.erb
@@ -1,3 +1,5 @@
+<%# locals: (render_context:) %>
+
 .fba-modal-dialog {
   font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
   font-size: 100%;
@@ -63,7 +65,7 @@
   display: none;
 }
 
-<%- if form.delivery_method != "touchpoints-hosted-only" %>
+<%- if render_context != :hosted %>
 <%= render partial: 'components/widget/widget-uswds-styles', formats: :css %>
 
 .fba-modal-dialog .usa-sr-only{

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -1,4 +1,0 @@
-<%= render "components/forms/custom_layout", form: form %>
-<script>
-  <%= render(partial: "components/widget/fba", formats: :js, locals: { form: form, suppress_ui: true }) %>
-</script>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -12,7 +12,7 @@
   <div class="touchpoint-form hide">
     <%= render "components/forms/custom_layout", form: @form, render_context: :hosted %>
     <script>
-      <%= render(partial: "components/widget/fba", formats: :js, locals: { form: @form, render_context: :hosted, suppress_ui: true }) %>
+      <%= render(partial: "components/widget/fba", formats: :js, locals: { form: @form, hosted_mode: true }) %>
     </script>
   </div>
 <% end %>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,13 +1,8 @@
 <div
   class="touchpoints-form-wrapper <%= @form.kind %>"
   data-touchpoints-form-id="<%= @form.short_uuid %>">
-<%
-# override the delivery method for this `touchpoints-hosted-only` view
-# otherwise, fba.js.erb will render the form the 2nd time
-@form.delivery_method = "touchpoints-hosted-only"
-%>
 <%- if @form.archived? %>
-  <%= render 'archived_form', form: @form %>
+  <%= render 'components/forms/archived_form', form: @form, heading_level: alert_heading_level(:hosted) %>
 <% else %>
   <div class="javascript-disabled-message text-center padding-3">
     Javascript is required for this form to function properly.
@@ -15,7 +10,10 @@
     Javascript does not appear to be enabled.
   </div>
   <div class="touchpoint-form hide">
-    <%= render 'form', form: @form %>
+    <%= render "components/forms/custom_layout", form: @form, render_context: :hosted %>
+    <script>
+      <%= render(partial: "components/widget/fba", formats: :js, locals: { form: @form, render_context: :hosted, suppress_ui: true }) %>
+    </script>
   </div>
 <% end %>
 </div>

--- a/spec/features/inline_touchpoints_spec.rb
+++ b/spec/features/inline_touchpoints_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Inline Touchpoints', js: true do
+  let(:organization) { FactoryBot.create(:organization) }
+  let!(:user) { FactoryBot.create(:user, :admin, organization:) }
+
+  context 'as Admin' do
+    let!(:form) { FactoryBot.create(:form, :kitchen_sink, :inline, organization:) }
+
+    describe '/forms/:id/example' do
+      before do
+        login_as(user)
+        visit example_admin_form_path(form)
+      end
+
+      it 'is accessible' do
+        expect_page_axe_clean
+      end
+
+      context 'submitting the inline kitchen-sink form' do
+        # Walks the full multi-page inline flow and submits the form.
+        # Unlike the modal variant, an inline form renders directly on the
+        # page (no #fba-button to open), so the flow starts on Page 1.
+        # Assertions about page-to-page behavior live here because they
+        # describe the interaction being performed, not the outcome.
+        def complete_and_submit_form
+          expect(page).to have_selector('h2', text: 'Do you have a few minutes to help us test this site?')
+
+          # --- Page 1 ---
+          expect(page).to have_content('Page 1')
+          expect(page).to have_no_content('Option elements')
+          expect(page).to have_no_content('Custom elements')
+          expect(page).to have_field(form.ordered_questions.first.ui_selector, wait: 10)
+          fill_in form.ordered_questions.first.ui_selector, with: 'input field'
+          fill_in form.ordered_questions.second.ui_selector, with: 'email'
+          fill_in form.ordered_questions.third.ui_selector, with: 'textarea'
+          expect(page).to have_link('html')
+
+          find('.pagination-buttons.text-right', visible: true).click_link('Next')
+
+          # validation surfaces on invalid email
+          expect(page).to have_content('Please enter a valid value')
+          expect(page).to have_content('This is help text')
+          fill_in form.ordered_questions.second.ui_selector, with: 'email@example.gov'
+
+          find('.pagination-buttons.text-right', visible: true).click_link('Next')
+
+          # --- Page 2: Option elements ---
+          expect(page).to have_content('Option elements')
+          expect(page).to have_no_content('Page 1')
+          expect(page).to have_no_content('Custom elements')
+          expect(all("#question_#{form.ordered_questions[4].id} .usa-radio__label").size).to eq(4)
+          all("#question_#{form.ordered_questions[4].id} .usa-radio__label").last.click
+          fill_in("#{form.ordered_questions[4].ui_selector}_other", with: 'otro 2')
+
+          expect(page).to have_content('Custom Question Checkboxes')
+          expect(page).to have_content('This is help text for checkboxes')
+          all('.usa-checkbox__label').each(&:click)
+          expect(page).to have_content('Enter other text')
+
+          ele = find("##{form.ordered_questions[5].ui_selector}_other", visible: false)
+          scroll_to(ele)
+          expect(page).to have_content('Custom Question Dropdown')
+          expect(page).to have_content('An official form of')
+
+          fill_in("#{form.ordered_questions[5].ui_selector}_other", with: 'other 3')
+          find("##{form.ordered_questions[5].ui_selector}_other", visible: true).native.send_key :tab
+
+          ele = find("##{form.ordered_questions[6].ui_selector}", visible: false)
+          scroll_to(ele)
+          expect(page).to have_content('This is help text for a dropdown.')
+          select('Option 2', from: form.ordered_questions[6].ui_selector)
+
+          find('.pagination-buttons.text-right', visible: true).click_link('Next')
+
+          # --- Page 3: Custom elements ---
+          expect(page).to have_content('Custom elements')
+          expect(page).to have_no_content('Page 1')
+          expect(page).to have_no_content('Option elements')
+          find('.submit_form_button').click
+        end
+
+        it 'submits the form, shows success, and persists all answers' do
+          complete_and_submit_form
+
+          # shows success flash message
+          expect(page).to have_selector('h3', text: 'Success')
+          expect(page).to have_content('Thank you. Your feedback has been received.')
+
+          submission = Submission.last
+          aggregate_failures do
+            expect(submission.answer_01).to eq('input field')
+            expect(submission.answer_02).to eq('email@example.gov')
+            expect(submission.answer_03).to eq('textarea')
+            expect(submission.answer_04).to eq('otro 2')
+            expect(submission.answer_05).to eq('1,2,other 3')
+            expect(submission.answer_06).to eq('2')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/modal_touchpoints_spec.rb
+++ b/spec/features/modal_touchpoints_spec.rb
@@ -19,16 +19,20 @@ feature 'Touchpoints', js: true do
         expect_page_axe_clean
       end
 
-      context 'default success text' do
-        before do
+      context 'submitting the modal kitchen-sink form' do
+        # Walks the full multi-page modal flow and submits the form.
+        # Assertions about page-to-page behavior live here because they
+        # describe the interaction being performed, not the outcome.
+        def open_and_submit_form
           expect(page).to have_content('main content')
           expect(page).to have_selector('#fba-button', visible: true, wait: 10)
           find('#fba-button').click # opens modal
 
           expect(page).to have_content('Help improve this site')
-          expect(page).to have_content('Do you have a few minutes to help us test this site?')
+          expect(page).to have_selector('h2', text: 'Do you have a few minutes to help us test this site?')
 
           within('.fba-modal') do
+            # --- Page 1 ---
             expect(page).to have_content('Page 1')
             expect(page).to have_no_content('Option elements')
             expect(page).to have_no_content('Custom elements')
@@ -39,12 +43,15 @@ feature 'Touchpoints', js: true do
             expect(page).to have_link('html')
 
             find('.pagination-buttons.text-right', visible: true).click_link('Next')
+
+            # validation surfaces on invalid email
             expect(page).to have_content('Please enter a valid value')
             expect(page).to have_content('This is help text')
             fill_in form.ordered_questions.second.ui_selector, with: 'email@example.gov'
 
             find('.pagination-buttons.text-right', visible: true).click_link('Next')
 
+            # --- Page 2: Option elements ---
             expect(page).to have_content('Option elements')
             expect(page).to have_no_content('Page 1')
             expect(page).to have_no_content('Custom elements')
@@ -69,31 +76,38 @@ feature 'Touchpoints', js: true do
             scroll_to(ele)
             expect(page).to have_content('This is help text for a dropdown.')
             select('Option 2', from: form.ordered_questions[6].ui_selector)
+
             find('.pagination-buttons.text-right', visible: true).click_link('Next')
+
+            # --- Page 3: Custom elements ---
             expect(page).to have_content('Custom elements')
             expect(page).to have_no_content('Page 1')
             expect(page).to have_no_content('Option elements')
             find('.submit_form_button').click
-
-            # shows success flash message
-            expect(page).to have_content('Success')
-            expect(page).to have_content('Thank you. Your feedback has been received.')
           end
+        end
 
-          # doesn't reset form; leave the flash message
+        it 'submits the form, shows success, and persists all answers' do
+          open_and_submit_form
+
+          # shows success flash message
+          expect(page).to have_selector('h3', text: 'Success')
+          expect(page).to have_content('Thank you. Your feedback has been received.')
+
+          # doesn't reset form; leave the flash message on reopen
           find('.fba-modal-close').click
           find('#fba-button').click
           expect(page).to have_content('Thank you. Your feedback has been received.')
-        end
 
-        it 'renders success flash message' do
-          @submission = Submission.last
-          expect(@submission.answer_01).to eq('input field')
-          expect(@submission.answer_02).to eq('email@example.gov')
-          expect(@submission.answer_03).to eq('textarea')
-          expect(@submission.answer_04).to eq('otro 2')
-          expect(@submission.answer_05).to eq('1,2,other 3')
-          expect(@submission.answer_06).to eq('2')
+          submission = Submission.last
+          aggregate_failures do
+            expect(submission.answer_01).to eq('input field')
+            expect(submission.answer_02).to eq('email@example.gov')
+            expect(submission.answer_03).to eq('textarea')
+            expect(submission.answer_04).to eq('otro 2')
+            expect(submission.answer_05).to eq('1,2,other 3')
+            expect(submission.answer_06).to eq('2')
+          end
         end
       end
     end

--- a/spec/features/touchpoints_spec.rb
+++ b/spec/features/touchpoints_spec.rb
@@ -704,7 +704,7 @@ feature 'Touchpoints', js: true do
         end
 
         it 'render archived/inactive message' do
-          expect(page).to have_content('This form is not currently accepting feedback')
+          expect(page).to have_selector('h2', text: 'This form is not currently accepting feedback')
           expect(page).to have_content(form.title)
           expect(page.current_path).to eq(submit_touchpoint_path(form))
         end
@@ -721,7 +721,7 @@ feature 'Touchpoints', js: true do
 
         it 'render the form' do
           expect(page).to have_css('.touchpoint-form')
-          expect(page).to have_content(form.title)
+          expect(page).to have_selector('h1', text: form.title)
         end
       end
     end

--- a/spec/views/components/forms/_custom_layout.html.erb_spec.rb
+++ b/spec/views/components/forms/_custom_layout.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'components/forms/_custom_layout.html.erb' do
   let(:form) { create(:form) }
 
   subject(:rendered) do
-    render partial: 'components/forms/custom_layout', locals: { form: }
+    render partial: 'components/forms/custom_layout', locals: { form:, render_context: :hosted }
   end
 
   context 'with required fields' do


### PR DESCRIPTION
Fixes https://github.com/GSA/touchpoints/issues/1954.

Touchpoints forms use heading tags for two purposes:

1. The title of the form is a heading.
2. Various instances of the USWDS Alert component are used in forms and they may contain heading tags.

This PR adjusts the levels of these two types of heading tag based on how the form is being displayed:

- **Hosted on Touchpoints:** The title is `<h1>` and alert headings are `<h2>`.
- **Embedded as a modal:** The title is `<h2>` and alert headings are `<h3>`. (Note that there is [some disagreement](https://github.com/w3c/wcag/discussions/2722) about whether it is wrong to use `<h1>` for the title of a modal but `<h2>` seems to be the less controversial choice.)
- **Embedded as an inline form:** The title is `<h2>` and alert headings are `<h3>`. This fixes the bug in question (enforce only one `<h1>` on a page) but does nothing to guarantee that the form fits into the heading hierarchy of the overall page. I'm going to wait until someone complains before I try to fix the trickier 'overall hierarchy' problem.